### PR TITLE
Add "errors" schema loan-rules-storage.raml folio-601

### DIFF
--- a/ramls/loan-rules-storage.raml
+++ b/ramls/loan-rules-storage.raml
@@ -10,6 +10,7 @@ documentation:
 
 schemas:
   - loan-rules: !include schema/loan-rules.json
+  - errors: !include ../raml-util/schemas/errors.schema
 
 traits:
   - secured: !include ../raml-util/traits/auth.raml


### PR DESCRIPTION
It is used by traits/validation.raml
Fixes warning from raml-cop