### PR TITLE
Upgrade RAML Module Builder to 19.1.5 CIRCSTORE-62

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+## 5.3.0 Unreleased
+
+* Upgrades RAML module builder to version 19.1.5, to allow for database connection expiry (CIRCSTORE-62, RMB-154)
+
 ## 5.2.0 2018-06-27
 
 * Adds `Closed - Cancelled` request status enum (CIRCSTORE-59)

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <artifactId>mod-circulation-storage</artifactId>
   <groupId>org.folio</groupId>
-  <version>5.2.1-SNAPSHOT</version>
+  <version>5.3.0-SNAPSHOT</version>
   <licenses>
     <license>
       <name>Apache License 2.0</name>
@@ -27,7 +27,7 @@
     <dependency>
       <groupId>org.folio</groupId>
       <artifactId>domain-models-runtime</artifactId>
-      <version>19.0.0</version>
+      <version>19.1.5</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>

--- a/src/main/java/org/folio/rest/impl/FixedDueDateSchedulesAPI.java
+++ b/src/main/java/org/folio/rest/impl/FixedDueDateSchedulesAPI.java
@@ -136,9 +136,26 @@ public class FixedDueDateSchedulesAPI implements FixedDueDateScheduleStorageReso
                         .withJsonOK(pagedSchedules)));
               } else {
                 log.error(reply.cause());
-                asyncResultHandler.handle(io.vertx.core.Future.succeededFuture(
-                    FixedDueDateScheduleStorageResource.GetFixedDueDateScheduleStorageFixedDueDateSchedulesResponse
-                        .withPlainInternalServerError(reply.cause().getMessage())));
+
+                if(reply.cause() instanceof CQLQueryValidationException) {
+                  CQLQueryValidationException exception = (CQLQueryValidationException)reply.cause();
+
+                  String field = exception.getMessage();
+                  int start = field.indexOf('\'');
+                  int end = field.lastIndexOf('\'');
+                  if(start != -1 && end != -1){
+                    field = field.substring(start+1, end);
+                  }
+                  Errors e = ValidationHelper.createValidationErrorMessage(field, "", exception.getMessage());
+                  asyncResultHandler.handle(io.vertx.core.Future.succeededFuture(
+                    GetFixedDueDateScheduleStorageFixedDueDateSchedulesResponse
+                      .withJsonUnprocessableEntity(e)));
+                }
+                else {
+                  asyncResultHandler.handle(io.vertx.core.Future.succeededFuture(
+                      FixedDueDateScheduleStorageResource.GetFixedDueDateScheduleStorageFixedDueDateSchedulesResponse
+                          .withPlainInternalServerError(reply.cause().getMessage())));
+                }
               }
             } catch (Exception e) {
               log.error(e);
@@ -147,19 +164,6 @@ public class FixedDueDateSchedulesAPI implements FixedDueDateScheduleStorageReso
                       .withPlainInternalServerError(e.getMessage())));
             }
           });
-        }
-        catch(CQLQueryValidationException e1){
-          String field = e1.getMessage();
-          int start = field.indexOf('\'');
-          int end = field.lastIndexOf('\'');
-          if(start != -1 && end != -1){
-            field = field.substring(start+1, end);
-          }
-          log.error(e1.getMessage());
-          Errors e = ValidationHelper.createValidationErrorMessage(field, "", e1.getMessage());
-          asyncResultHandler.handle(io.vertx.core.Future.succeededFuture(
-            GetFixedDueDateScheduleStorageFixedDueDateSchedulesResponse
-            .withJsonUnprocessableEntity(e)));
         }
         catch (Exception e) {
           log.error(e);


### PR DESCRIPTION
Includes changes to CQLQueryValidationException handling
as this is now included as the cause of a failure
rather than thrown as an exception