### PR TITLE
Update reference loan rule to use UUID for format.

### DIFF
--- a/reference-data/loan-rules-storage/use-example-for-everything.json
+++ b/reference-data/loan-rules-storage/use-example-for-everything.json
@@ -1,3 +1,3 @@
 {
-  "loanRulesAsTextFile": "priority: t, s, c, b, a, m, g\nfallback-policy: 43198de5-f56a-4a53-a0bd-5a324418967a\nm book: d9cd0bed-1b49-4b5e-a7bd-064b8d177231"
+  "loanRulesAsTextFile": "priority: t, s, c, b, a, m, g\nfallback-policy: 43198de5-f56a-4a53-a0bd-5a324418967a\nm 1a54b431-2e4f-452d-9cae-9cee66c9a892: d9cd0bed-1b49-4b5e-a7bd-064b8d177231"
 }


### PR DESCRIPTION
Towards FOLIO-1334. Original loan rule referenced the format as `book`.