### PR TITLE
CIRCSTORE-66: Added publicDescription field to cancellation-reasons

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 ## 5.4.0 Unreleased
 * Add 'metadata' field to loans-policy records (CIRCSTORE-63)
+* Add `publicDescription` to cancellation reason record (CIRCSTORE-66).
 
 ## 5.3.0 2018-07-10
 

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -183,7 +183,7 @@
     },
     {
       "id" : "cancellation-reason-storage",
-      "version": "1.0",
+      "version": "1.1",
       "handlers": [
         {
           "methods": ["GET"],
@@ -402,7 +402,7 @@
       "permissionName": "circulation-storage.cancellation-reasons.collection.get",
       "displayName": "Circulation storage - get cancellation reasons collection",
       "description": "Get cancellation reasons from storage"
-    },    
+    },
     {
       "permissionName": "circulation-storage.cancellation-reasons.item.get",
       "displayName": "Circulation storage - get individual cancellation reason",

--- a/ramls/cancellation-reason.json
+++ b/ramls/cancellation-reason.json
@@ -11,6 +11,9 @@
     "description" : {
       "type": "string"
     },
+    "publicDescription": {
+      "type": "string"
+    },
     "requiresAdditionalInformation": {
       "type": "boolean"
     },
@@ -21,8 +24,7 @@
    },
    "additionalProperties": false,
     "required": [
-      "name",
-      "description"
+      "name"
     ]
 }
 

--- a/ramls/examples/cancellation-reason.json
+++ b/ramls/examples/cancellation-reason.json
@@ -1,7 +1,8 @@
 {
   "id": "5aace7aa-a741-4d69-9741-46737da78f7f",
-  "name": "notavailable",
+  "name": "Not available",
   "description": "The item is no longer available",
+  "publicDescription": "The item status is unknown",
   "requiresAdditionalInformation": false
 }
 

--- a/ramls/examples/cancellation-reasons.json
+++ b/ramls/examples/cancellation-reasons.json
@@ -2,10 +2,11 @@
   "cancellationReasons" : [
     {
       "id": "5aace7aa-a741-4d69-9741-46737da78f7f",
-      "name": "notavailable",
+      "name": "Not available",
       "description": "The item is no longer available",
+      "publicDescription": "The item status is unknown",
       "requiresAdditionalInformation": false
-    }
+        }
   ],
   "totalRecords": 1
 }

--- a/reference-data/cancellation-reason-storage/cancellation-reasons/needed-for-course-reserves.json
+++ b/reference-data/cancellation-reason-storage/cancellation-reasons/needed-for-course-reserves.json
@@ -2,5 +2,6 @@
   "id": "1c0e9ba1-6a97-4bbc-94fc-83eecc32f5fd",
   "name": "Needed For Course Reserves",
   "description": "Item is needed for course reserves",
+  "publicDescription": "Item is no longer available for request",
   "requiresAdditionalInformation": false
 }

--- a/src/test/java/org/folio/rest/api/CancellationReasonsApiTest.java
+++ b/src/test/java/org/folio/rest/api/CancellationReasonsApiTest.java
@@ -35,7 +35,7 @@ import static org.junit.Assert.assertTrue;
  * @author kurt
  */
 public class CancellationReasonsApiTest extends ApiTests {
-  
+
   private static URL cancelReasonURL() throws MalformedURLException {
     return cancelReasonURL("");
   }
@@ -46,7 +46,7 @@ public class CancellationReasonsApiTest extends ApiTests {
     return StorageTestSuite.storageUrl(
       "/cancellation-reason-storage/cancellation-reasons" + subPath);
   }
-  
+
   private void assertCreateCancellationReason(JsonObject request)
       throws MalformedURLException,
       InterruptedException,
@@ -54,15 +54,15 @@ public class CancellationReasonsApiTest extends ApiTests {
       TimeoutException {
 
     JsonResponse response = createCancellationReason(request);
-    
+
     MatcherAssert.assertThat(String.format("Failed to create cancellation reason: %s",
         response.getBody()),
       response.getStatusCode(), is(HttpURLConnection.HTTP_CREATED));
 
     new IndividualResource(response);
   }
-  
-  private JsonResponse createCancellationReason(JsonObject request) 
+
+  private JsonResponse createCancellationReason(JsonObject request)
       throws MalformedURLException,
       InterruptedException,
       ExecutionException,
@@ -74,37 +74,37 @@ public class CancellationReasonsApiTest extends ApiTests {
 
     return createCompleted.get(5, TimeUnit.SECONDS);
   }
-  
-  private IndividualResource assertGetCancellationReason(String id) 
+
+  private IndividualResource assertGetCancellationReason(String id)
       throws MalformedURLException,
-      InterruptedException, 
+      InterruptedException,
       ExecutionException,
-      TimeoutException {    
+      TimeoutException {
     JsonResponse response = getCancellationReason(id);
-    
+
     MatcherAssert.assertThat(String.format("Failed to retrieve cancellation reason: %s (%s)",
         response.getBody(), response.getStatusCode()),
         response.getStatusCode(), is(HttpURLConnection.HTTP_OK));
-    
+
     return new IndividualResource(response);
   }
-  
-  private JsonResponse getCancellationReason(String id) 
+
+  private JsonResponse getCancellationReason(String id)
       throws MalformedURLException,
       InterruptedException,
-      ExecutionException, 
+      ExecutionException,
       TimeoutException {
-    CompletableFuture<JsonResponse> getReasonFuture = new CompletableFuture<>();    
+    CompletableFuture<JsonResponse> getReasonFuture = new CompletableFuture<>();
     client.get(cancelReasonURL("/"+id), StorageTestSuite.TENANT_ID,
         ResponseHandler.json(getReasonFuture));
 
     return getReasonFuture.get(5, TimeUnit.SECONDS);
   }
-  
+
   private JsonResponse getCancellationReasonCollection(String query)
       throws MalformedURLException,
       InterruptedException,
-      ExecutionException, 
+      ExecutionException,
       TimeoutException {
     CompletableFuture<JsonResponse> getReasonsFuture = new CompletableFuture<>();
     String queryParam;
@@ -118,11 +118,11 @@ public class CancellationReasonsApiTest extends ApiTests {
 
     return getReasonsFuture.get(5, TimeUnit.SECONDS);
   }
-  
-  private TextResponse updateCancellationReason(String id, JsonObject request) 
+
+  private TextResponse updateCancellationReason(String id, JsonObject request)
       throws MalformedURLException,
       InterruptedException,
-      ExecutionException, 
+      ExecutionException,
       TimeoutException {
     CompletableFuture<TextResponse> updateReasonFuture = new CompletableFuture<>();
     client.put(cancelReasonURL("/"+id), request, StorageTestSuite.TENANT_ID,
@@ -130,23 +130,23 @@ public class CancellationReasonsApiTest extends ApiTests {
 
     return updateReasonFuture.get(5, TimeUnit.SECONDS);
   }
-  
+
   private void assertUpdateCancellationReason(String id, JsonObject request)
       throws MalformedURLException,
       InterruptedException,
-      ExecutionException, 
+      ExecutionException,
       TimeoutException {
     TextResponse response = updateCancellationReason(id, request);
-    
+
     MatcherAssert.assertThat(String.format("Failed to update cancellation reason: %s (%s)",
         response.getBody(), response.getStatusCode()),
         response.getStatusCode(), is(HttpURLConnection.HTTP_NO_CONTENT));
   }
-  
+
   private TextResponse deleteCancellationReason(String id)
       throws MalformedURLException,
       InterruptedException,
-      ExecutionException, 
+      ExecutionException,
       TimeoutException {
     CompletableFuture<TextResponse> deleteReasonFuture = new CompletableFuture<>();
 
@@ -155,14 +155,14 @@ public class CancellationReasonsApiTest extends ApiTests {
 
     return deleteReasonFuture.get(5, TimeUnit.SECONDS);
   }
-  
+
   private void assertDeleteCancellationReason(String id)
       throws MalformedURLException,
       InterruptedException,
-      ExecutionException, 
+      ExecutionException,
       TimeoutException {
     TextResponse response = deleteCancellationReason(id);
-    
+
     MatcherAssert.assertThat(String.format("Failed to delete cancellation reason: %s (%s)",
         response.getBody(), response.getStatusCode()),
         response.getStatusCode(), is(HttpURLConnection.HTTP_NO_CONTENT));
@@ -176,20 +176,21 @@ public class CancellationReasonsApiTest extends ApiTests {
   }
   //Tests
   @Test
-  public void canCreateCancellationReason() 
-      throws MalformedURLException, 
-      InterruptedException, 
-      ExecutionException, 
+  public void canCreateCancellationReason()
+      throws MalformedURLException,
+      InterruptedException,
+      ExecutionException,
       TimeoutException {
     JsonObject request = new JsonObject()
         .put("name", "cosmicrays")
-        .put("description", "Excess solar radiation has destroyed the item");
+        .put("description", "Excess solar radiation has destroyed the item")
+        .put("publicDescription", "The item has been destroyed");
     assertCreateCancellationReason(request);
   }
-  
+
   @Test
-  public void canCreateAndRetrieveCancellationRequest() 
-      throws MalformedURLException, 
+  public void canCreateAndRetrieveCancellationRequest()
+      throws MalformedURLException,
       InterruptedException,
       ExecutionException,
       TimeoutException {
@@ -203,10 +204,10 @@ public class CancellationReasonsApiTest extends ApiTests {
     IndividualResource reason = assertGetCancellationReason(id);
     assertEquals("slime", reason.getJson().getString("name"));
   }
-  
+
   @Test
   public void canUpdateCancellationRequest()
-      throws MalformedURLException, 
+      throws MalformedURLException,
       InterruptedException,
       ExecutionException,
       TimeoutException {
@@ -225,10 +226,10 @@ public class CancellationReasonsApiTest extends ApiTests {
     IndividualResource reason = assertGetCancellationReason(id);
     assertEquals("oobleck", reason.getJson().getString("name"));
   }
-  
+
   @Test
   public void canRetrieveByCQL()
-      throws MalformedURLException, 
+      throws MalformedURLException,
       InterruptedException,
       ExecutionException,
       TimeoutException {
@@ -246,10 +247,10 @@ public class CancellationReasonsApiTest extends ApiTests {
     assertEquals("fire", response.getJson().getJsonArray("cancellationReasons")
         .getJsonObject(0).getString("name"));
   }
-  
+
   @Test
   public void canDeleteCancellationRequest()
-      throws MalformedURLException, 
+      throws MalformedURLException,
       InterruptedException,
       ExecutionException,
       TimeoutException {
@@ -263,10 +264,10 @@ public class CancellationReasonsApiTest extends ApiTests {
     JsonResponse getResponse = getCancellationReason(id);
     assertTrue(getResponse.getStatusCode() == 404);
   }
-  
+
   @Test
   public void cannotCreateDuplicateCancellationRequestNames()
-      throws MalformedURLException, 
+      throws MalformedURLException,
       InterruptedException,
       ExecutionException,
       TimeoutException {
@@ -278,14 +279,14 @@ public class CancellationReasonsApiTest extends ApiTests {
         .put("description", "Chicken grease stains on item");
     assertCreateCancellationReason(request);
     JsonResponse response = createCancellationReason(request2);
-    assertEquals(400, response.getStatusCode());    
+    assertEquals(400, response.getStatusCode());
   }
-  
+
   @Test
-  public void cannotDeleteCancellationReasonInUse() 
-      throws MalformedURLException, 
-      InterruptedException, 
-      ExecutionException, 
+  public void cannotDeleteCancellationReasonInUse()
+      throws MalformedURLException,
+      InterruptedException,
+      ExecutionException,
       TimeoutException {
     UUID requestId = UUID.randomUUID();
     UUID cancellationReasonId = UUID.randomUUID();
@@ -293,7 +294,7 @@ public class CancellationReasonsApiTest extends ApiTests {
     UUID requesterId = UUID.randomUUID();
     UUID proxyId = UUID.randomUUID();
     DateTime requestDate = new DateTime(2017, 7, 22, 10, 22, 54, DateTimeZone.UTC);
-    
+
     JsonObject reasonRequest = new JsonObject()
         .put("name", "worms").put("description", "Item Eaten by space worms.")
         .put("id", cancellationReasonId.toString());
@@ -314,7 +315,7 @@ public class CancellationReasonsApiTest extends ApiTests {
       .withStatus(OPEN_NOT_YET_FILLED)
       .withCancellationReasonId(cancellationReasonId)
       .create();
-    
+
     assertCreateCancellationReason(reasonRequest);
     CompletableFuture<JsonResponse> createRequestFuture = new CompletableFuture<>();
     client.post(requestStorageUrl(), requestRequest, StorageTestSuite.TENANT_ID,
@@ -323,13 +324,13 @@ public class CancellationReasonsApiTest extends ApiTests {
     assertEquals(201, createRequestResponse.getStatusCode());
     TextResponse deleteReasonResponse = deleteCancellationReason(cancellationReasonId.toString());
     assertEquals(400, deleteReasonResponse.getStatusCode());
-    
+
   }
   @Test
   //My canary in the coalmine :)
   public void dummyTest() {
     assertTrue(true);
   }
-  
-  
+
+
 }


### PR DESCRIPTION
Handles [CIRCSTORE-66](https://issues.folio.org/browse/CIRCSTORE-66) which was necessitated by [UIREQ-99](https://issues.folio.org/browse/UIREQ-99).