### PR TITLE
Change output to log CIRCSTORE-26

### DIFF
--- a/src/main/java/org/folio/rest/impl/FixedDueDateSchedulesAPI.java
+++ b/src/main/java/org/folio/rest/impl/FixedDueDateSchedulesAPI.java
@@ -5,6 +5,7 @@ import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
 import org.apache.commons.io.IOUtils;
 import org.folio.rest.annotations.Validate;
+import org.folio.rest.impl.support.LogWriter;
 import org.folio.rest.jaxrs.model.Errors;
 import org.folio.rest.jaxrs.model.FixedDueDateSchedule;
 import org.folio.rest.jaxrs.model.FixedDueDateSchedules;
@@ -38,6 +39,7 @@ import static org.folio.rest.impl.Headers.TENANT_HEADER;
 public class FixedDueDateSchedulesAPI implements FixedDueDateScheduleStorageResource {
 
   private static final Logger       log               = LoggerFactory.getLogger(FixedDueDateSchedulesAPI.class);
+  private static final LogWriter    logWriter         = new LogWriter(log);
   private static final String       SCHEMA_NAME       = "apidocs/raml/fixed-due-date-schedule.json";
   private static final String       FIXED_SCHEDULE_TABLE  = "fixed_due_date_schedule";
   private static final String       INVALID_DATE_MSG  = "Unable to save fixed loan date. Date range not valid";
@@ -56,7 +58,7 @@ public class FixedDueDateSchedulesAPI implements FixedDueDateScheduleStorageReso
     try {
       schema = IOUtils.toString(FixedDueDateSchedulesAPI.class.getClassLoader().getResourceAsStream(SCHEMA_NAME), "UTF-8");
     } catch (Exception e) {
-      log.error("unable to load schema - " +SCHEMA_NAME+ ", validation of query fields will not be active");
+      log.error("unable to load schema - " +SCHEMA_NAME+ ", validation of query fields will not be active", e);
     }
   }
 
@@ -85,15 +87,15 @@ public class FixedDueDateSchedulesAPI implements FixedDueDateScheduleStorageReso
                       .DeleteFixedDueDateScheduleStorageFixedDueDateSchedulesResponse
                         .noContent().build()));
                 }
-                else{
-                  log.error(reply.cause());
+                else {
+                  logWriter.error(reply.cause());
                   asyncResultHandler.handle(io.vertx.core.Future.succeededFuture(
                       FixedDueDateScheduleStorageResource.DeleteFixedDueDateScheduleStorageFixedDueDateSchedulesResponse
                           .withPlainInternalServerError(reply.cause().getMessage())));
                 }
             });
       } catch (Exception e) {
-        log.error(e);
+        logWriter.error(e);
         asyncResultHandler.handle(io.vertx.core.Future.succeededFuture(
             FixedDueDateScheduleStorageResource.DeleteFixedDueDateScheduleStorageFixedDueDateSchedulesResponse
                 .withPlainInternalServerError(e.getMessage())));
@@ -136,7 +138,7 @@ public class FixedDueDateSchedulesAPI implements FixedDueDateScheduleStorageReso
                     FixedDueDateScheduleStorageResource.GetFixedDueDateScheduleStorageFixedDueDateSchedulesResponse
                         .withJsonOK(pagedSchedules)));
               } else {
-                log.error(reply.cause());
+                logWriter.error(reply.cause());
 
                 if(reply.cause() instanceof CQLQueryValidationException) {
                   CQLQueryValidationException exception = (CQLQueryValidationException)reply.cause();
@@ -159,7 +161,7 @@ public class FixedDueDateSchedulesAPI implements FixedDueDateScheduleStorageReso
                 }
               }
             } catch (Exception e) {
-              log.error(e);
+              logWriter.error(e);
               asyncResultHandler.handle(io.vertx.core.Future.succeededFuture(
                   FixedDueDateScheduleStorageResource.GetFixedDueDateScheduleStorageFixedDueDateSchedulesResponse
                       .withPlainInternalServerError(e.getMessage())));
@@ -167,14 +169,14 @@ public class FixedDueDateSchedulesAPI implements FixedDueDateScheduleStorageReso
           });
         }
         catch (Exception e) {
-          log.error(e);
+          logWriter.error(e);
           asyncResultHandler.handle(io.vertx.core.Future.succeededFuture(
               FixedDueDateScheduleStorageResource.GetFixedDueDateScheduleStorageFixedDueDateSchedulesResponse
                   .withPlainInternalServerError(e.getMessage())));
         }
       });
     } catch (Exception e) {
-      log.error(e);
+      logWriter.error(e);
       asyncResultHandler.handle(io.vertx.core.Future.succeededFuture(
           FixedDueDateScheduleStorageResource.GetFixedDueDateScheduleStorageFixedDueDateSchedulesResponse
               .withPlainInternalServerError(e.getMessage())));
@@ -221,7 +223,7 @@ public class FixedDueDateSchedulesAPI implements FixedDueDateScheduleStorageReso
                     FixedDueDateScheduleStorageResource.PostFixedDueDateScheduleStorageFixedDueDateSchedulesResponse
                         .withJsonCreated(reply.result(), stream)));
               } else {
-                log.error(reply.cause());
+                logWriter.error(reply.cause());
                 if(isUniqueViolation(reply.cause())){
                   asyncResultHandler.handle(io.vertx.core.Future.succeededFuture(
                     FixedDueDateScheduleStorageResource.PostFixedDueDateScheduleStorageFixedDueDateSchedulesResponse
@@ -234,21 +236,21 @@ public class FixedDueDateSchedulesAPI implements FixedDueDateScheduleStorageReso
                 }
               }
             } catch (Exception e) {
-              log.error(e);
+              logWriter.error(e);
               asyncResultHandler.handle(io.vertx.core.Future.succeededFuture(
                 FixedDueDateScheduleStorageResource.PostFixedDueDateScheduleStorageFixedDueDateSchedulesResponse
                     .withPlainInternalServerError(e.getMessage())));
             }
           });
         } catch (Exception e) {
-          log.error(e);
+          logWriter.error(e);
           asyncResultHandler.handle(io.vertx.core.Future.succeededFuture(
               FixedDueDateScheduleStorageResource.PostFixedDueDateScheduleStorageFixedDueDateSchedulesResponse
                   .withPlainInternalServerError(e.getMessage())));
         }
       });
     } catch (Exception e) {
-      log.error(e);
+      logWriter.error(e);
       asyncResultHandler.handle(io.vertx.core.Future.succeededFuture(
           FixedDueDateScheduleStorageResource.PostFixedDueDateScheduleStorageFixedDueDateSchedulesResponse
               .withPlainInternalServerError(e.getMessage())));
@@ -298,28 +300,28 @@ public class FixedDueDateSchedulesAPI implements FixedDueDateScheduleStorageReso
                           .withPlainNotFound(PgExceptionUtil.badRequestMessage(reply.cause()))));
                 }
               } else {
-                log.error(reply.cause());
+                logWriter.error(reply.cause());
                 asyncResultHandler.handle(Future.succeededFuture(
                     FixedDueDateScheduleStorageResource.GetFixedDueDateScheduleStorageFixedDueDateSchedulesByFixedDueDateScheduleIdResponse
                         .withPlainInternalServerError(reply.cause().getMessage())));
 
               }
             } catch (Exception e) {
-              log.error(e);
+              logWriter.error(e);
               asyncResultHandler.handle(io.vertx.core.Future.succeededFuture(
                   FixedDueDateScheduleStorageResource.GetFixedDueDateScheduleStorageFixedDueDateSchedulesByFixedDueDateScheduleIdResponse
                       .withPlainInternalServerError(e.getMessage())));
             }
           });
         } catch (Exception e) {
-          log.error(e);
+          logWriter.error(e);
           asyncResultHandler.handle(io.vertx.core.Future.succeededFuture(
               FixedDueDateScheduleStorageResource.GetFixedDueDateScheduleStorageFixedDueDateSchedulesByFixedDueDateScheduleIdResponse
                   .withPlainInternalServerError(e.getMessage())));
         }
       });
     } catch (Exception e) {
-      log.error(e);
+      logWriter.error(e);
       asyncResultHandler.handle(io.vertx.core.Future.succeededFuture(
           FixedDueDateScheduleStorageResource.GetFixedDueDateScheduleStorageFixedDueDateSchedulesByFixedDueDateScheduleIdResponse
               .withPlainInternalServerError(e.getMessage())));
@@ -359,7 +361,7 @@ public class FixedDueDateSchedulesAPI implements FixedDueDateScheduleStorageReso
                   DeleteFixedDueDateScheduleStorageFixedDueDateSchedulesByFixedDueDateScheduleIdResponse
                       .withNoContent()));
             } else {
-              log.error(reply.cause());
+              logWriter.error(reply.cause());
               if(isBadId(reply.cause())){
                 asyncResultHandler.handle(Future.succeededFuture(
                   DeleteFixedDueDateScheduleStorageFixedDueDateSchedulesByFixedDueDateScheduleIdResponse
@@ -378,14 +380,14 @@ public class FixedDueDateSchedulesAPI implements FixedDueDateScheduleStorageReso
             }
           });
         } catch (Exception e) {
-          log.error(e);
+          logWriter.error(e);
           asyncResultHandler.handle(Future
               .succeededFuture(DeleteFixedDueDateScheduleStorageFixedDueDateSchedulesByFixedDueDateScheduleIdResponse
                   .withPlainInternalServerError(e.getMessage())));
         }
       });
     } catch (Exception e) {
-      log.error(e);
+      logWriter.error(e);
       asyncResultHandler.handle(
           Future.succeededFuture(DeleteFixedDueDateScheduleStorageFixedDueDateSchedulesByFixedDueDateScheduleIdResponse
               .withPlainInternalServerError(e.getMessage())));
@@ -445,7 +447,7 @@ public class FixedDueDateSchedulesAPI implements FixedDueDateScheduleStorageReso
                             PutFixedDueDateScheduleStorageFixedDueDateSchedulesByFixedDueDateScheduleIdResponse
                                 .withNoContent()));
                       } else {
-                        log.error(update.cause());
+                        logWriter.error(update.cause());
                         if(isUniqueViolation(update.cause())){
                           asyncResultHandler.handle(io.vertx.core.Future.succeededFuture(
                             FixedDueDateScheduleStorageResource.
@@ -453,21 +455,21 @@ public class FixedDueDateSchedulesAPI implements FixedDueDateScheduleStorageReso
                                 .withPlainBadRequest(PgExceptionUtil.badRequestMessage(update.cause()))));
                         }
                         else{
-                          log.error(update.cause());
+                          logWriter.error(update.cause());
                           asyncResultHandler.handle(Future.succeededFuture(
                             PutFixedDueDateScheduleStorageFixedDueDateSchedulesByFixedDueDateScheduleIdResponse
                                 .withPlainInternalServerError(update.cause().getMessage())));
                         }
                       }
                     } catch (Exception e) {
-                      log.error(e);
+                      logWriter.error(e);
                       asyncResultHandler.handle(Future.succeededFuture(
                           PutFixedDueDateScheduleStorageFixedDueDateSchedulesByFixedDueDateScheduleIdResponse
                               .withPlainInternalServerError(e.getMessage())));
                     }
                   });
                 } catch (Exception e) {
-                  log.error(e);
+                  logWriter.error(e);
                   asyncResultHandler.handle(Future.succeededFuture(
                       PutFixedDueDateScheduleStorageFixedDueDateSchedulesByFixedDueDateScheduleIdResponse
                           .withPlainInternalServerError(e.getMessage())));
@@ -484,27 +486,27 @@ public class FixedDueDateSchedulesAPI implements FixedDueDateScheduleStorageReso
                             PutFixedDueDateScheduleStorageFixedDueDateSchedulesByFixedDueDateScheduleIdResponse
                                 .withNoContent()));
                       } else {
-                          log.error(save.cause());
+                          logWriter.error(save.cause());
                           asyncResultHandler.handle(Future.succeededFuture(
                               PutFixedDueDateScheduleStorageFixedDueDateSchedulesByFixedDueDateScheduleIdResponse
                                   .withPlainInternalServerError(save.cause().getMessage())));
                       }
                     } catch (Exception e) {
-                      log.error(e);
+                      logWriter.error(e);
                       asyncResultHandler.handle(Future.succeededFuture(
                           PutFixedDueDateScheduleStorageFixedDueDateSchedulesByFixedDueDateScheduleIdResponse
                               .withPlainInternalServerError(e.getMessage())));
                     }
                   });
                 } catch (Exception e) {
-                    log.error(e);
+                    logWriter.error(e);
                     asyncResultHandler.handle(Future.succeededFuture(
                       PutFixedDueDateScheduleStorageFixedDueDateSchedulesByFixedDueDateScheduleIdResponse
                           .withPlainInternalServerError(e.getMessage())));
                 }
               }
             } else {
-              log.error(reply.cause());
+              logWriter.error(reply.cause());
               if(isBadId(reply.cause())){
                 asyncResultHandler.handle(Future
                   .succeededFuture(PutFixedDueDateScheduleStorageFixedDueDateSchedulesByFixedDueDateScheduleIdResponse
@@ -518,14 +520,14 @@ public class FixedDueDateSchedulesAPI implements FixedDueDateScheduleStorageReso
             }
           });
         } catch (Exception e) {
-          log.error(e);
+          logWriter.error(e);
           asyncResultHandler.handle(
               Future.succeededFuture(PutFixedDueDateScheduleStorageFixedDueDateSchedulesByFixedDueDateScheduleIdResponse
                   .withPlainInternalServerError(e.getMessage())));
         }
       });
     } catch (Exception e) {
-      log.error(e);
+      logWriter.error(e);
       asyncResultHandler.handle(
           Future.succeededFuture(PutFixedDueDateScheduleStorageFixedDueDateSchedulesByFixedDueDateScheduleIdResponse
               .withPlainInternalServerError(e.getMessage())));
@@ -577,7 +579,7 @@ public class FixedDueDateSchedulesAPI implements FixedDueDateScheduleStorageReso
         }
       }
     } catch (Exception e) {
-      log.error(e.getMessage(), e);
+      logWriter.error(e);
     }
     return errors;
   }

--- a/src/main/java/org/folio/rest/impl/FixedDueDateSchedulesAPI.java
+++ b/src/main/java/org/folio/rest/impl/FixedDueDateSchedulesAPI.java
@@ -23,8 +23,11 @@ import org.folio.rest.tools.utils.OutStream;
 import org.folio.rest.tools.utils.TenantTool;
 import org.folio.rest.tools.utils.ValidationHelper;
 import org.z3950.zing.cql.cql2pgjson.CQL2PgJSON;
+import org.z3950.zing.cql.cql2pgjson.FieldException;
+import org.z3950.zing.cql.cql2pgjson.SchemaException;
 
 import javax.ws.rs.core.Response;
+import java.io.IOException;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
@@ -40,7 +43,7 @@ public class FixedDueDateSchedulesAPI implements FixedDueDateScheduleStorageReso
   private static final String       INVALID_DATE_MSG  = "Unable to save fixed loan date. Date range not valid";
 
   private static String             schema      =  null;
-  private final Class<FixedDueDateSchedule> DUE_DATE_SCHEDULE_CLASS = FixedDueDateSchedule.class;
+  private static final Class<FixedDueDateSchedule> DUE_DATE_SCHEDULE_CLASS = FixedDueDateSchedule.class;
 
 
   public FixedDueDateSchedulesAPI(Vertx vertx, String tenantId) {
@@ -64,8 +67,7 @@ public class FixedDueDateSchedulesAPI implements FixedDueDateScheduleStorageReso
       Map<String,
       String> okapiHeaders,
       Handler<AsyncResult<Response>> asyncResultHandler,
-      Context vertxContext
-      ) throws Exception {
+      Context vertxContext) {
 
     String tenantId = okapiHeaders.get(TENANT_HEADER);
 
@@ -107,8 +109,7 @@ public class FixedDueDateSchedulesAPI implements FixedDueDateScheduleStorageReso
       String lang,
       Map<String, String> okapiHeaders,
       Handler<AsyncResult<Response>> asyncResultHandler,
-      Context vertxContext
-      ) throws Exception {
+      Context vertxContext) {
 
     String tenantId = okapiHeaders.get(TENANT_HEADER);
 
@@ -187,8 +188,7 @@ public class FixedDueDateSchedulesAPI implements FixedDueDateScheduleStorageReso
       FixedDueDateSchedule entity,
       Map<String, String> okapiHeaders,
       Handler<AsyncResult<Response>> asyncResultHandler,
-      Context vertxContext
-      ) throws Exception {
+      Context vertxContext) {
 
     String tenantId = okapiHeaders.get(TENANT_HEADER);
 
@@ -262,8 +262,7 @@ public class FixedDueDateSchedulesAPI implements FixedDueDateScheduleStorageReso
       String lang,
       Map<String, String> okapiHeaders,
       Handler<AsyncResult<Response>> asyncResultHandler,
-      Context vertxContext
-      ) throws Exception {
+      Context vertxContext) {
 
     String tenantId = okapiHeaders.get(TENANT_HEADER);
 
@@ -533,7 +532,9 @@ public class FixedDueDateSchedulesAPI implements FixedDueDateScheduleStorageReso
     }
   }
 
-  private CQLWrapper getCQL(String query, int limit, int offset, String schema) throws Exception {
+  private CQLWrapper getCQL(String query, int limit, int offset, String schema)
+    throws FieldException, IOException, SchemaException {
+
     CQL2PgJSON cql2pgJson = null;
     if(schema != null){
       cql2pgJson = new CQL2PgJSON("fixed_due_date_schedule.jsonb", schema);
@@ -582,23 +583,17 @@ public class FixedDueDateSchedulesAPI implements FixedDueDateScheduleStorageReso
   }
 
   private boolean isUniqueViolation(Throwable e){
-    if(e != null && e.getMessage().contains("duplicate key value violates unique constraint")){
-      return true;
-    }
-    return false;
+    return e != null
+      && e.getMessage().contains("duplicate key value violates unique constraint");
   }
 
   private boolean isBadId(Throwable e){
-    if(e != null && e.getMessage().contains("invalid input syntax for type numeric")){
-      return true;
-    }
-    return false;
+    return e != null
+      && e.getMessage().contains("invalid input syntax for type numeric");
   }
 
   private boolean iStillReferenced(Throwable e){
-    if(e != null && e.getMessage().contains("violates foreign key constraint")){
-      return true;
-    }
-    return false;
+    return e != null
+      && e.getMessage().contains("violates foreign key constraint");
   }
 }

--- a/src/main/java/org/folio/rest/impl/Headers.java
+++ b/src/main/java/org/folio/rest/impl/Headers.java
@@ -1,5 +1,7 @@
 package org.folio.rest.impl;
 
-public class Headers {
+class Headers {
+  private Headers() {}
+
   static final String TENANT_HEADER = "x-okapi-tenant";
 }

--- a/src/main/java/org/folio/rest/impl/LoanPoliciesAPI.java
+++ b/src/main/java/org/folio/rest/impl/LoanPoliciesAPI.java
@@ -4,6 +4,8 @@ import io.vertx.core.AsyncResult;
 import io.vertx.core.Context;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
+import io.vertx.core.logging.Logger;
+import io.vertx.core.logging.LoggerFactory;
 import org.folio.rest.annotations.Validate;
 import org.folio.rest.jaxrs.model.LoanPolicies;
 import org.folio.rest.jaxrs.model.LoanPolicy;
@@ -19,6 +21,7 @@ import org.folio.rest.tools.utils.TenantTool;
 import org.z3950.zing.cql.cql2pgjson.CQL2PgJSON;
 
 import javax.ws.rs.core.Response;
+import java.lang.invoke.MethodHandles;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -26,6 +29,7 @@ import java.util.UUID;
 import static org.folio.rest.impl.Headers.TENANT_HEADER;
 
 public class LoanPoliciesAPI implements LoanPolicyStorageResource {
+  private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
   private final String LOAN_POLICY_TABLE = "loan_policy";
   private final Class<LoanPolicy> LOAN_POLICY_CLASS = LoanPolicy.class;
@@ -106,21 +110,21 @@ public class LoanPoliciesAPI implements LoanPolicyStorageResource {
                         withPlainInternalServerError(reply.cause().getMessage())));
                   }
                 } catch (Exception e) {
-                  e.printStackTrace();
+                  log.error(e);
                   asyncResultHandler.handle(io.vertx.core.Future.succeededFuture(
                     LoanPolicyStorageResource.GetLoanPolicyStorageLoanPoliciesResponse.
                       withPlainInternalServerError(e.getMessage())));
                 }
               });
           } catch (Exception e) {
-            e.printStackTrace();
+            log.error(e);
             asyncResultHandler.handle(io.vertx.core.Future.succeededFuture(
               LoanPolicyStorageResource.GetLoanPolicyStorageLoanPoliciesResponse.
                 withPlainInternalServerError(e.getMessage())));
           }
         });
       } catch (Exception e) {
-        e.printStackTrace();
+        log.error(e);
         asyncResultHandler.handle(io.vertx.core.Future.succeededFuture(
           LoanPolicyStorageResource.GetLoanPolicyStorageLoanPoliciesResponse.
             withPlainInternalServerError(e.getMessage())));
@@ -167,7 +171,7 @@ public class LoanPoliciesAPI implements LoanPolicyStorageResource {
                         .withPlainInternalServerError(reply.cause().toString())));
                 }
               } catch (Exception e) {
-                e.printStackTrace();
+                log.error(e);
                 asyncResultHandler.handle(
                   io.vertx.core.Future.succeededFuture(
                     LoanPolicyStorageResource.PostLoanPolicyStorageLoanPoliciesResponse
@@ -175,14 +179,14 @@ public class LoanPoliciesAPI implements LoanPolicyStorageResource {
               }
             });
         } catch (Exception e) {
-          e.printStackTrace();
+          log.error(e);
           asyncResultHandler.handle(io.vertx.core.Future.succeededFuture(
             LoanPolicyStorageResource.PostLoanPolicyStorageLoanPoliciesResponse
               .withPlainInternalServerError(e.getMessage())));
         }
       });
     } catch (Exception e) {
-      e.printStackTrace();
+      log.error(e);
       asyncResultHandler.handle(io.vertx.core.Future.succeededFuture(
         LoanPolicyStorageResource.PostLoanPolicyStorageLoanPoliciesResponse
           .withPlainInternalServerError(e.getMessage())));
@@ -246,7 +250,7 @@ public class LoanPoliciesAPI implements LoanPolicyStorageResource {
 
                 }
               } catch (Exception e) {
-                e.printStackTrace();
+                log.error(e);
                 asyncResultHandler.handle(io.vertx.core.Future.succeededFuture(
                   LoanPolicyStorageResource.
                     GetLoanPolicyStorageLoanPoliciesByLoanPolicyIdResponse.
@@ -254,7 +258,7 @@ public class LoanPoliciesAPI implements LoanPolicyStorageResource {
               }
             });
         } catch (Exception e) {
-          e.printStackTrace();
+          log.error(e);
           asyncResultHandler.handle(io.vertx.core.Future.succeededFuture(
             LoanPolicyStorageResource.
               GetLoanPolicyStorageLoanPoliciesByLoanPolicyIdResponse.
@@ -262,7 +266,7 @@ public class LoanPoliciesAPI implements LoanPolicyStorageResource {
         }
       });
     } catch (Exception e) {
-      e.printStackTrace();
+      log.error(e);
       asyncResultHandler.handle(io.vertx.core.Future.succeededFuture(
         LoanPolicyStorageResource.
           GetLoanPolicyStorageLoanPoliciesByLoanPolicyIdResponse.

--- a/src/main/java/org/folio/rest/impl/LoanPoliciesAPI.java
+++ b/src/main/java/org/folio/rest/impl/LoanPoliciesAPI.java
@@ -31,15 +31,15 @@ import static org.folio.rest.impl.Headers.TENANT_HEADER;
 public class LoanPoliciesAPI implements LoanPolicyStorageResource {
   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
-  private final String LOAN_POLICY_TABLE = "loan_policy";
-  private final Class<LoanPolicy> LOAN_POLICY_CLASS = LoanPolicy.class;
+  private static final String LOAN_POLICY_TABLE = "loan_policy";
+  private static final Class<LoanPolicy> LOAN_POLICY_CLASS = LoanPolicy.class;
 
   @Override
   @Validate
   public void deleteLoanPolicyStorageLoanPolicies(
     String lang, Map<String, String> okapiHeaders,
     Handler<AsyncResult<Response>> asyncResultHandler,
-    Context vertxContext) throws Exception {
+    Context vertxContext) {
 
     String tenantId = okapiHeaders.get(TENANT_HEADER);
 
@@ -50,11 +50,8 @@ public class LoanPoliciesAPI implements LoanPolicyStorageResource {
 
         postgresClient.mutate(String.format("TRUNCATE TABLE %s_%s.%s",
           tenantId, "mod_circulation_storage", LOAN_POLICY_TABLE),
-          reply -> {
-            asyncResultHandler.handle(io.vertx.core.Future.succeededFuture(
-              LoanPolicyStorageResource.DeleteLoanPolicyStorageLoanPoliciesResponse
-                .noContent().build()));
-          });
+          reply -> asyncResultHandler.handle(Future.succeededFuture(
+            DeleteLoanPolicyStorageLoanPoliciesResponse.withNoContent())));
       }
       catch(Exception e) {
         asyncResultHandler.handle(io.vertx.core.Future.succeededFuture(
@@ -72,7 +69,7 @@ public class LoanPoliciesAPI implements LoanPolicyStorageResource {
     String lang,
     Map<String, String> okapiHeaders,
     Handler<AsyncResult<Response>> asyncResultHandler,
-    Context vertxContext) throws Exception {
+    Context vertxContext) {
 
       String tenantId = okapiHeaders.get(TENANT_HEADER);
 
@@ -98,7 +95,7 @@ public class LoanPoliciesAPI implements LoanPolicyStorageResource {
 
                     LoanPolicies pagedLoans = new LoanPolicies();
                     pagedLoans.setLoanPolicies(loanPolicies);
-                    pagedLoans.setTotalRecords((Integer)reply.result().getResultInfo().getTotalRecords());
+                    pagedLoans.setTotalRecords(reply.result().getResultInfo().getTotalRecords());
 
                     asyncResultHandler.handle(io.vertx.core.Future.succeededFuture(
                       LoanPolicyStorageResource.GetLoanPolicyStorageLoanPoliciesResponse.
@@ -137,7 +134,7 @@ public class LoanPoliciesAPI implements LoanPolicyStorageResource {
     String lang, LoanPolicy entity,
     Map<String, String> okapiHeaders,
     Handler<AsyncResult<Response>> asyncResultHandler,
-    Context vertxContext) throws Exception {
+    Context vertxContext) {
 
     String tenantId = okapiHeaders.get(TENANT_HEADER);
 
@@ -152,7 +149,7 @@ public class LoanPoliciesAPI implements LoanPolicyStorageResource {
             entity.setId(UUID.randomUUID().toString());
           }
 
-          postgresClient.save("loan_policy", entity.getId(), entity,
+          postgresClient.save(LOAN_POLICY_TABLE, entity.getId(), entity,
             reply -> {
               try {
                 if(reply.succeeded()) {
@@ -200,7 +197,7 @@ public class LoanPoliciesAPI implements LoanPolicyStorageResource {
     String lang,
     Map<String, String> okapiHeaders,
     Handler<AsyncResult<Response>> asyncResultHandler,
-    Context vertxContext) throws Exception {
+    Context vertxContext) {
 
     String tenantId = okapiHeaders.get(TENANT_HEADER);
 
@@ -280,7 +277,7 @@ public class LoanPoliciesAPI implements LoanPolicyStorageResource {
     String loanPolicyId,
     String lang, Map<String, String> okapiHeaders,
     Handler<AsyncResult<Response>> asyncResultHandler,
-    Context vertxContext) throws Exception {
+    Context vertxContext) {
 
     String tenantId = okapiHeaders.get(TENANT_HEADER);
 
@@ -334,7 +331,7 @@ public class LoanPoliciesAPI implements LoanPolicyStorageResource {
     LoanPolicy entity,
     Map<String, String> okapiHeaders,
     Handler<AsyncResult<Response>> asyncResultHandler,
-    Context vertxContext) throws Exception {
+    Context vertxContext) {
 
     String tenantId = okapiHeaders.get(TENANT_HEADER);
 

--- a/src/main/java/org/folio/rest/impl/LoanPoliciesAPI.java
+++ b/src/main/java/org/folio/rest/impl/LoanPoliciesAPI.java
@@ -7,6 +7,7 @@ import io.vertx.core.Handler;
 import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
 import org.folio.rest.annotations.Validate;
+import org.folio.rest.impl.support.LogWriter;
 import org.folio.rest.jaxrs.model.LoanPolicies;
 import org.folio.rest.jaxrs.model.LoanPolicy;
 import org.folio.rest.jaxrs.resource.LoanPolicyStorageResource;
@@ -30,6 +31,7 @@ import static org.folio.rest.impl.Headers.TENANT_HEADER;
 
 public class LoanPoliciesAPI implements LoanPolicyStorageResource {
   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+  private static final LogWriter logWriter = new LogWriter(log);
 
   private static final String LOAN_POLICY_TABLE = "loan_policy";
   private static final Class<LoanPolicy> LOAN_POLICY_CLASS = LoanPolicy.class;
@@ -54,6 +56,8 @@ public class LoanPoliciesAPI implements LoanPolicyStorageResource {
             DeleteLoanPolicyStorageLoanPoliciesResponse.withNoContent())));
       }
       catch(Exception e) {
+        logWriter.error(e);
+
         asyncResultHandler.handle(io.vertx.core.Future.succeededFuture(
           LoanPolicyStorageResource.DeleteLoanPolicyStorageLoanPoliciesResponse
             .withPlainInternalServerError(e.getMessage())));
@@ -107,21 +111,24 @@ public class LoanPoliciesAPI implements LoanPolicyStorageResource {
                         withPlainInternalServerError(reply.cause().getMessage())));
                   }
                 } catch (Exception e) {
-                  log.error(e);
+                  logWriter.error(e);
+
                   asyncResultHandler.handle(io.vertx.core.Future.succeededFuture(
                     LoanPolicyStorageResource.GetLoanPolicyStorageLoanPoliciesResponse.
                       withPlainInternalServerError(e.getMessage())));
                 }
               });
           } catch (Exception e) {
-            log.error(e);
+            logWriter.error(e);
+
             asyncResultHandler.handle(io.vertx.core.Future.succeededFuture(
               LoanPolicyStorageResource.GetLoanPolicyStorageLoanPoliciesResponse.
                 withPlainInternalServerError(e.getMessage())));
           }
         });
       } catch (Exception e) {
-        log.error(e);
+        logWriter.error(e);
+
         asyncResultHandler.handle(io.vertx.core.Future.succeededFuture(
           LoanPolicyStorageResource.GetLoanPolicyStorageLoanPoliciesResponse.
             withPlainInternalServerError(e.getMessage())));
@@ -168,7 +175,8 @@ public class LoanPoliciesAPI implements LoanPolicyStorageResource {
                         .withPlainInternalServerError(reply.cause().toString())));
                 }
               } catch (Exception e) {
-                log.error(e);
+                logWriter.error(e);
+
                 asyncResultHandler.handle(
                   io.vertx.core.Future.succeededFuture(
                     LoanPolicyStorageResource.PostLoanPolicyStorageLoanPoliciesResponse
@@ -176,14 +184,16 @@ public class LoanPoliciesAPI implements LoanPolicyStorageResource {
               }
             });
         } catch (Exception e) {
-          log.error(e);
+          logWriter.error(e);
+
           asyncResultHandler.handle(io.vertx.core.Future.succeededFuture(
             LoanPolicyStorageResource.PostLoanPolicyStorageLoanPoliciesResponse
               .withPlainInternalServerError(e.getMessage())));
         }
       });
     } catch (Exception e) {
-      log.error(e);
+      logWriter.error(e);
+
       asyncResultHandler.handle(io.vertx.core.Future.succeededFuture(
         LoanPolicyStorageResource.PostLoanPolicyStorageLoanPoliciesResponse
           .withPlainInternalServerError(e.getMessage())));
@@ -247,7 +257,8 @@ public class LoanPoliciesAPI implements LoanPolicyStorageResource {
 
                 }
               } catch (Exception e) {
-                log.error(e);
+                logWriter.error(e);
+
                 asyncResultHandler.handle(io.vertx.core.Future.succeededFuture(
                   LoanPolicyStorageResource.
                     GetLoanPolicyStorageLoanPoliciesByLoanPolicyIdResponse.
@@ -255,7 +266,8 @@ public class LoanPoliciesAPI implements LoanPolicyStorageResource {
               }
             });
         } catch (Exception e) {
-          log.error(e);
+          logWriter.error(e);
+
           asyncResultHandler.handle(io.vertx.core.Future.succeededFuture(
             LoanPolicyStorageResource.
               GetLoanPolicyStorageLoanPoliciesByLoanPolicyIdResponse.
@@ -263,7 +275,8 @@ public class LoanPoliciesAPI implements LoanPolicyStorageResource {
         }
       });
     } catch (Exception e) {
-      log.error(e);
+      logWriter.error(e);
+
       asyncResultHandler.handle(io.vertx.core.Future.succeededFuture(
         LoanPolicyStorageResource.
           GetLoanPolicyStorageLoanPoliciesByLoanPolicyIdResponse.

--- a/src/main/java/org/folio/rest/impl/LoanRulesAPI.java
+++ b/src/main/java/org/folio/rest/impl/LoanRulesAPI.java
@@ -7,6 +7,7 @@ import io.vertx.core.Handler;
 import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
 
+import org.folio.rest.impl.support.LogWriter;
 import org.folio.rest.jaxrs.model.LoanRules;
 import org.folio.rest.jaxrs.resource.LoanRulesStorageResource;
 import org.folio.rest.persist.Criteria.Criterion;
@@ -20,10 +21,13 @@ import java.util.Map;
 
 public class LoanRulesAPI implements LoanRulesStorageResource {
   private static final Logger log = LoggerFactory.getLogger(LoanRulesStorageResource.class);
+  private static final LogWriter logWriter = new LogWriter(log);
+
   private static final String LOAN_RULES_TABLE = "loan_rules";
 
   private void internalErrorGet(Handler<AsyncResult<Response>> asyncResultHandler, Throwable e) {
-    log.error(e);
+    logWriter.error(e);
+
     asyncResultHandler.handle(Future.succeededFuture(
         LoanRulesStorageResource.GetLoanRulesStorageResponse.
         withPlainInternalServerError(e.getMessage())));
@@ -71,7 +75,8 @@ public class LoanRulesAPI implements LoanRulesStorageResource {
   }
 
   private void internalErrorPut(Handler<AsyncResult<Response>> asyncResultHandler, Throwable e) {
-    log.error(e);
+    logWriter.error(e);
+
     asyncResultHandler.handle(Future.succeededFuture(
         LoanRulesStorageResource.PutLoanRulesStorageResponse.
         withPlainInternalServerError(e.getMessage())));

--- a/src/main/java/org/folio/rest/impl/LoansAPI.java
+++ b/src/main/java/org/folio/rest/impl/LoansAPI.java
@@ -23,6 +23,7 @@ import org.joda.time.DateTime;
 import org.z3950.zing.cql.cql2pgjson.CQL2PgJSON;
 
 import javax.ws.rs.core.Response;
+import java.lang.invoke.MethodHandles;
 import java.util.List;
 import java.util.Map;
 import java.util.StringJoiner;
@@ -31,8 +32,7 @@ import java.util.UUID;
 import static org.folio.rest.impl.Headers.TENANT_HEADER;
 
 public class LoansAPI implements LoanStorageResource {
-
-  private static final Logger log = LoggerFactory.getLogger(LoansAPI.class);
+  private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
   private static final String LOAN_TABLE = "loan";
   //TODO: Reinstate when can name audit tables
@@ -124,21 +124,21 @@ public class LoansAPI implements LoanStorageResource {
                       withPlainInternalServerError(reply.cause().getMessage())));
                 }
               } catch (Exception e) {
-                e.printStackTrace();
+                log.error(e);
                 asyncResultHandler.handle(io.vertx.core.Future.succeededFuture(
                   LoanStorageResource.GetLoanStorageLoansResponse.
                     withPlainInternalServerError(e.getMessage())));
               }
             });
         } catch (Exception e) {
-          e.printStackTrace();
+          log.error(e);
           asyncResultHandler.handle(io.vertx.core.Future.succeededFuture(
             LoanStorageResource.GetLoanStorageLoansResponse.
               withPlainInternalServerError(e.getMessage())));
         }
       });
     } catch (Exception e) {
-      e.printStackTrace();
+      log.error(e);
       asyncResultHandler.handle(io.vertx.core.Future.succeededFuture(
         LoanStorageResource.GetLoanStorageLoansResponse.
           withPlainInternalServerError(e.getMessage())));
@@ -205,7 +205,7 @@ public class LoansAPI implements LoanStorageResource {
                   }
                 }
               } catch (Exception e) {
-                e.printStackTrace();
+                log.error(e);
                 asyncResultHandler.handle(
                   io.vertx.core.Future.succeededFuture(
                     LoanStorageResource.PostLoanStorageLoansResponse
@@ -213,14 +213,14 @@ public class LoansAPI implements LoanStorageResource {
               }
             });
         } catch (Exception e) {
-          e.printStackTrace();
+          log.error(e);
           asyncResultHandler.handle(io.vertx.core.Future.succeededFuture(
             LoanStorageResource.PostLoanStorageLoansResponse
               .withPlainInternalServerError(e.getMessage())));
         }
       });
     } catch (Exception e) {
-      e.printStackTrace();
+      log.error(e);
       asyncResultHandler.handle(io.vertx.core.Future.succeededFuture(
         LoanStorageResource.PostLoanStorageLoansResponse
           .withPlainInternalServerError(e.getMessage())));
@@ -281,21 +281,21 @@ public class LoansAPI implements LoanStorageResource {
 
                 }
               } catch (Exception e) {
-                e.printStackTrace();
+                log.error(e);
                 asyncResultHandler.handle(io.vertx.core.Future.succeededFuture(
                   LoanStorageResource.GetLoanStorageLoansByLoanIdResponse.
                     withPlainInternalServerError(e.getMessage())));
               }
             });
         } catch (Exception e) {
-          e.printStackTrace();
+          log.error(e);
           asyncResultHandler.handle(io.vertx.core.Future.succeededFuture(
             LoanStorageResource.GetLoanStorageLoansByLoanIdResponse.
               withPlainInternalServerError(e.getMessage())));
         }
       });
     } catch (Exception e) {
-      e.printStackTrace();
+      log.error(e);
       asyncResultHandler.handle(io.vertx.core.Future.succeededFuture(
         LoanStorageResource.GetLoanStorageLoansByLoanIdResponse.
           withPlainInternalServerError(e.getMessage())));

--- a/src/main/java/org/folio/rest/impl/LoansAPI.java
+++ b/src/main/java/org/folio/rest/impl/LoansAPI.java
@@ -6,6 +6,7 @@ import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.folio.rest.annotations.Validate;
+import org.folio.rest.impl.support.LogWriter;
 import org.folio.rest.jaxrs.model.Errors;
 import org.folio.rest.jaxrs.model.Loan;
 import org.folio.rest.jaxrs.model.Loans;
@@ -33,6 +34,7 @@ import static org.folio.rest.impl.Headers.TENANT_HEADER;
 
 public class LoansAPI implements LoanStorageResource {
   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+  private static final LogWriter logWriter = new LogWriter(log);
 
   private static final String LOAN_TABLE = "loan";
   //TODO: Change loan history table name when can be configured, used to be "loan_history_table"
@@ -120,21 +122,24 @@ public class LoansAPI implements LoanStorageResource {
                       withPlainInternalServerError(reply.cause().getMessage())));
                 }
               } catch (Exception e) {
-                log.error(e);
+                logWriter.error(e);
+
                 asyncResultHandler.handle(io.vertx.core.Future.succeededFuture(
                   LoanStorageResource.GetLoanStorageLoansResponse.
                     withPlainInternalServerError(e.getMessage())));
               }
             });
         } catch (Exception e) {
-          log.error(e);
+          logWriter.error(e);
+
           asyncResultHandler.handle(io.vertx.core.Future.succeededFuture(
             LoanStorageResource.GetLoanStorageLoansResponse.
               withPlainInternalServerError(e.getMessage())));
         }
       });
     } catch (Exception e) {
-      log.error(e);
+      logWriter.error(e);
+
       asyncResultHandler.handle(io.vertx.core.Future.succeededFuture(
         LoanStorageResource.GetLoanStorageLoansResponse.
           withPlainInternalServerError(e.getMessage())));
@@ -201,7 +206,8 @@ public class LoansAPI implements LoanStorageResource {
                   }
                 }
               } catch (Exception e) {
-                log.error(e);
+                logWriter.error(e);
+
                 asyncResultHandler.handle(
                   io.vertx.core.Future.succeededFuture(
                     LoanStorageResource.PostLoanStorageLoansResponse
@@ -209,14 +215,16 @@ public class LoansAPI implements LoanStorageResource {
               }
             });
         } catch (Exception e) {
-          log.error(e);
+          logWriter.error(e);
+
           asyncResultHandler.handle(io.vertx.core.Future.succeededFuture(
             LoanStorageResource.PostLoanStorageLoansResponse
               .withPlainInternalServerError(e.getMessage())));
         }
       });
     } catch (Exception e) {
-      log.error(e);
+      logWriter.error(e);
+
       asyncResultHandler.handle(io.vertx.core.Future.succeededFuture(
         LoanStorageResource.PostLoanStorageLoansResponse
           .withPlainInternalServerError(e.getMessage())));
@@ -277,21 +285,24 @@ public class LoansAPI implements LoanStorageResource {
 
                 }
               } catch (Exception e) {
-                log.error(e);
+                logWriter.error(e);
+
                 asyncResultHandler.handle(io.vertx.core.Future.succeededFuture(
                   LoanStorageResource.GetLoanStorageLoansByLoanIdResponse.
                     withPlainInternalServerError(e.getMessage())));
               }
             });
         } catch (Exception e) {
-          log.error(e);
+          logWriter.error(e);
+
           asyncResultHandler.handle(io.vertx.core.Future.succeededFuture(
             LoanStorageResource.GetLoanStorageLoansByLoanIdResponse.
               withPlainInternalServerError(e.getMessage())));
         }
       });
     } catch (Exception e) {
-      log.error(e);
+      logWriter.error(e);
+
       asyncResultHandler.handle(io.vertx.core.Future.succeededFuture(
         LoanStorageResource.GetLoanStorageLoansByLoanIdResponse.
           withPlainInternalServerError(e.getMessage())));
@@ -338,12 +349,16 @@ public class LoansAPI implements LoanStorageResource {
               }
             });
         } catch (Exception e) {
+          logWriter.error(e);
+
           asyncResultHandler.handle(Future.succeededFuture(
             DeleteLoanStorageLoansByLoanIdResponse
               .withPlainInternalServerError(e.getMessage())));
         }
       });
     } catch (Exception e) {
+      logWriter.error(e);
+
       asyncResultHandler.handle(Future.succeededFuture(
         DeleteLoanStorageLoansByLoanIdResponse
           .withPlainInternalServerError(e.getMessage())));
@@ -424,6 +439,8 @@ public class LoansAPI implements LoanStorageResource {
                             }
                           }
                         } catch (Exception e) {
+                          logWriter.error(e);
+
                           asyncResultHandler.handle(
                             Future.succeededFuture(
                               PutLoanStorageLoansByLoanIdResponse
@@ -431,6 +448,8 @@ public class LoansAPI implements LoanStorageResource {
                         }
                       });
                   } catch (Exception e) {
+                    logWriter.error(e);
+
                     asyncResultHandler.handle(Future.succeededFuture(
                       PutLoanStorageLoansByLoanIdResponse
                         .withPlainInternalServerError(e.getMessage())));
@@ -466,6 +485,8 @@ public class LoansAPI implements LoanStorageResource {
                             }
                           }
                         } catch (Exception e) {
+                          logWriter.error(e);
+
                           asyncResultHandler.handle(
                             Future.succeededFuture(
                               PutLoanStorageLoansByLoanIdResponse
@@ -473,6 +494,8 @@ public class LoansAPI implements LoanStorageResource {
                         }
                       });
                   } catch (Exception e) {
+                    logWriter.error(e);
+
                     asyncResultHandler.handle(Future.succeededFuture(
                       PutLoanStorageLoansByLoanIdResponse
                         .withPlainInternalServerError(e.getMessage())));
@@ -485,12 +508,16 @@ public class LoansAPI implements LoanStorageResource {
               }
             });
         } catch (Exception e) {
+          logWriter.error(e);
+
           asyncResultHandler.handle(Future.succeededFuture(
             PutLoanStorageLoansByLoanIdResponse
               .withPlainInternalServerError(e.getMessage())));
         }
       });
     } catch (Exception e) {
+      logWriter.error(e);
+
       asyncResultHandler.handle(Future.succeededFuture(
         PutLoanStorageLoansByLoanIdResponse
           .withPlainInternalServerError(e.getMessage())));
@@ -585,27 +612,31 @@ public class LoansAPI implements LoanStorageResource {
                       withJsonOK(pagedLoans)));
                 }
                 else {
-                  log.error(reply.cause().getMessage(), reply.cause());
+                  logWriter.error(reply.cause());
+
                   asyncResultHandler.handle(io.vertx.core.Future.succeededFuture(
                     GetLoanStorageLoanHistoryResponse.
                       withPlainInternalServerError(reply.cause().getMessage())));
                 }
               } catch (Exception e) {
-                log.error(e.getMessage(), e);
+                logWriter.error(e);
+
                 asyncResultHandler.handle(io.vertx.core.Future.succeededFuture(
                   GetLoanStorageLoanHistoryResponse.
                     withPlainInternalServerError(e.getMessage())));
               }
             });
         } catch (Exception e) {
-          log.error(e.getMessage(), e);
+          logWriter.error(e);
+
           asyncResultHandler.handle(io.vertx.core.Future.succeededFuture(
             GetLoanStorageLoanHistoryResponse.
               withPlainInternalServerError(e.getMessage())));
         }
       });
     } catch (Exception e) {
-      log.error(e.getMessage(), e);
+      logWriter.error(e);
+
       asyncResultHandler.handle(io.vertx.core.Future.succeededFuture(
         GetLoanStorageLoanHistoryResponse.
           withPlainInternalServerError(e.getMessage())));

--- a/src/main/java/org/folio/rest/impl/LoansAPI.java
+++ b/src/main/java/org/folio/rest/impl/LoansAPI.java
@@ -563,7 +563,9 @@ public class LoansAPI implements LoanStorageResource {
                   .setOffset(new Offset(offset));
               adjustedQuery = cql.toString();
             }
-            System.out.println("CQL Query: " + cql.toString());
+
+            log.debug("CQL Query: " + cql.toString());
+
           } else {
             cql = new CQLWrapper(cql2pgJson, query)
                   .setLimit(new Limit(limit))

--- a/src/main/java/org/folio/rest/impl/LoansAPI.java
+++ b/src/main/java/org/folio/rest/impl/LoansAPI.java
@@ -35,8 +35,7 @@ public class LoansAPI implements LoanStorageResource {
   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
   private static final String LOAN_TABLE = "loan";
-  //TODO: Reinstate when can name audit tables
-//  private static final String LOAN_HISTORY_TABLE = "loan_history_table";
+  //TODO: Change loan history table name when can be configured, used to be "loan_history_table"
   private static final String LOAN_HISTORY_TABLE = "audit_loan";
 
   private static final Class<Loan> LOAN_CLASS = Loan.class;
@@ -61,11 +60,8 @@ public class LoansAPI implements LoanStorageResource {
 
         postgresClient.mutate(String.format("TRUNCATE TABLE %s_%s.loan",
           tenantId, "mod_circulation_storage"),
-          reply -> {
-            asyncResultHandler.handle(io.vertx.core.Future.succeededFuture(
-              LoanStorageResource.DeleteLoanStorageLoansResponse
-                .noContent().build()));
-          });
+          reply -> asyncResultHandler.handle(Future.succeededFuture(
+            DeleteLoanStorageLoansResponse.withNoContent())));
       }
       catch(Exception e) {
         asyncResultHandler.handle(io.vertx.core.Future.succeededFuture(
@@ -157,7 +153,7 @@ public class LoansAPI implements LoanStorageResource {
 
     ImmutablePair<Boolean, String> validationResult = validateLoan(entity);
 
-    if(validationResult.getLeft() == false) {
+    if(!validationResult.getLeft()) {
       asyncResultHandler.handle(
         io.vertx.core.Future.succeededFuture(
           LoanStorageResource.PostLoanStorageLoansResponse
@@ -366,7 +362,7 @@ public class LoansAPI implements LoanStorageResource {
 
     ImmutablePair<Boolean, String> validationResult = validateLoan(entity);
 
-    if(validationResult.getLeft() == false) {
+    if(!validationResult.getLeft()) {
       asyncResultHandler.handle(
         io.vertx.core.Future.succeededFuture(
           LoanStorageResource.PostLoanStorageLoansResponse

--- a/src/main/java/org/folio/rest/impl/RequestsAPI.java
+++ b/src/main/java/org/folio/rest/impl/RequestsAPI.java
@@ -6,6 +6,7 @@ import io.vertx.core.Context;
 import io.vertx.core.Handler;
 import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
+import org.folio.rest.impl.support.LogWriter;
 import org.folio.rest.jaxrs.model.Error;
 import org.folio.rest.jaxrs.model.Errors;
 import org.folio.rest.jaxrs.model.Request;
@@ -35,6 +36,8 @@ import static org.folio.rest.impl.Headers.TENANT_HEADER;
 
 public class RequestsAPI implements RequestStorageResource {
   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+  private static final LogWriter logWriter = new LogWriter(log);
+
   private static final String REQUEST_TABLE = "request";
 
   @Override
@@ -57,6 +60,8 @@ public class RequestsAPI implements RequestStorageResource {
             DeleteRequestStorageRequestsResponse.withNoContent())));
       }
       catch(Exception e) {
+        logWriter.error(e);
+
         asyncResultHandler.handle(succeededFuture(
           DeleteRequestStorageRequestsResponse
             .withPlainInternalServerError(e.getMessage())));
@@ -75,7 +80,8 @@ public class RequestsAPI implements RequestStorageResource {
     Context vertxContext) {
 
     Consumer<Exception> exceptionHandler = e -> {
-      log.error("Getting requests failed", e);
+      logWriter.error(e);
+
       asyncResultHandler.handle(succeededFuture(
         GetRequestStorageRequestsByRequestIdResponse.
           withPlainInternalServerError(e.getMessage())));
@@ -96,8 +102,8 @@ public class RequestsAPI implements RequestStorageResource {
             .setLimit(new Limit(limit))
             .setOffset(new Offset(offset));
 
-          log.error(String.format("CQL query: %s", query));
-          log.error(String.format("SQL generated from CQL: %s", cql.toString()));
+          log.info(String.format("CQL query: %s", query));
+          log.info(String.format("SQL generated from CQL: %s", cql.toString()));
 
           postgresClient.get(REQUEST_TABLE, Request.class, fieldList, cql,
             true, false, reply -> {
@@ -176,18 +182,24 @@ public class RequestsAPI implements RequestStorageResource {
                   }
                 }
               } catch (Exception e) {
+                logWriter.error(e);
+
                 asyncResultHandler.handle(succeededFuture(
                   PostRequestStorageRequestsResponse
                     .withPlainInternalServerError(e.getMessage())));
               }
             });
         } catch (Exception e) {
+          logWriter.error(e);
+
           asyncResultHandler.handle(succeededFuture(
             PostRequestStorageRequestsResponse
               .withPlainInternalServerError(e.getMessage())));
         }
       });
     } catch (Exception e) {
+      logWriter.error(e);
+
       asyncResultHandler.handle(succeededFuture(
         PostRequestStorageRequestsResponse
           .withPlainInternalServerError(e.getMessage())));
@@ -203,7 +215,8 @@ public class RequestsAPI implements RequestStorageResource {
     Context vertxContext) {
 
     Consumer<Exception> exceptionHandler = e -> {
-      log.error("Getting request by ID failed", e);
+      logWriter.error(e);
+
       asyncResultHandler.handle(succeededFuture(
         GetRequestStorageRequestsByRequestIdResponse.
           withPlainInternalServerError(e.getMessage())));
@@ -301,12 +314,16 @@ public class RequestsAPI implements RequestStorageResource {
               }
             });
         } catch (Exception e) {
+          logWriter.error(e);
+
           asyncResultHandler.handle(succeededFuture(
             DeleteRequestStorageRequestsByRequestIdResponse
               .withPlainInternalServerError(e.getMessage())));
         }
       });
     } catch (Exception e) {
+      logWriter.error(e);
+
       asyncResultHandler.handle(succeededFuture(
         DeleteRequestStorageRequestsByRequestIdResponse
           .withPlainInternalServerError(e.getMessage())));
@@ -369,12 +386,16 @@ public class RequestsAPI implements RequestStorageResource {
                             }
                           }
                         } catch (Exception e) {
+                          logWriter.error(e);
+
                           asyncResultHandler.handle(succeededFuture(
                             PutRequestStorageRequestsByRequestIdResponse
                               .withPlainInternalServerError(e.getMessage())));
                         }
                       });
                   } catch (Exception e) {
+                    logWriter.error(e);
+
                     asyncResultHandler.handle(succeededFuture(
                       PutRequestStorageRequestsByRequestIdResponse
                         .withPlainInternalServerError(e.getMessage())));
@@ -405,12 +426,16 @@ public class RequestsAPI implements RequestStorageResource {
                             }
                           }
                         } catch (Exception e) {
+                          logWriter.error(e);
+
                           asyncResultHandler.handle(succeededFuture(
                             PutRequestStorageRequestsByRequestIdResponse
                               .withPlainInternalServerError(e.getMessage())));
                         }
                       });
                   } catch (Exception e) {
+                    logWriter.error(e);
+
                     asyncResultHandler.handle(succeededFuture(
                       PutRequestStorageRequestsByRequestIdResponse
                         .withPlainInternalServerError(e.getMessage())));
@@ -423,12 +448,16 @@ public class RequestsAPI implements RequestStorageResource {
               }
             });
         } catch (Exception e) {
+          logWriter.error(e);
+
           asyncResultHandler.handle(succeededFuture(
             PutRequestStorageRequestsByRequestIdResponse
               .withPlainInternalServerError(e.getMessage())));
         }
       });
     } catch (Exception e) {
+      logWriter.error(e);
+
       asyncResultHandler.handle(succeededFuture(
         PutRequestStorageRequestsByRequestIdResponse
           .withPlainInternalServerError(e.getMessage())));

--- a/src/main/java/org/folio/rest/impl/StaffSlipsAPI.java
+++ b/src/main/java/org/folio/rest/impl/StaffSlipsAPI.java
@@ -1,35 +1,33 @@
 package org.folio.rest.impl;
 
-import static org.folio.rest.impl.Headers.TENANT_HEADER;
-
-import java.util.List;
-import java.util.Map;
-import java.util.StringJoiner;
-import java.util.UUID;
-
-import javax.ws.rs.core.Response;
-
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Context;
+import io.vertx.core.Handler;
+import io.vertx.core.logging.Logger;
+import io.vertx.core.logging.LoggerFactory;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.folio.rest.jaxrs.model.StaffSlip;
 import org.folio.rest.jaxrs.model.StaffSlips;
 import org.folio.rest.jaxrs.resource.LoanStorageResource;
 import org.folio.rest.jaxrs.resource.StaffSlipsStorageResource;
-import org.folio.rest.persist.PostgresClient;
 import org.folio.rest.persist.Criteria.Criteria;
 import org.folio.rest.persist.Criteria.Criterion;
 import org.folio.rest.persist.Criteria.Limit;
 import org.folio.rest.persist.Criteria.Offset;
+import org.folio.rest.persist.PostgresClient;
 import org.folio.rest.persist.cql.CQLWrapper;
 import org.folio.rest.tools.utils.OutStream;
 import org.folio.rest.tools.utils.TenantTool;
 import org.z3950.zing.cql.cql2pgjson.CQL2PgJSON;
 
-import io.vertx.core.AsyncResult;
-import io.vertx.core.Context;
-import io.vertx.core.Future;
-import io.vertx.core.Handler;
-import io.vertx.core.logging.Logger;
-import io.vertx.core.logging.LoggerFactory;
+import javax.ws.rs.core.Response;
+import java.util.List;
+import java.util.Map;
+import java.util.StringJoiner;
+import java.util.UUID;
+
+import static io.vertx.core.Future.succeededFuture;
+import static org.folio.rest.impl.Headers.TENANT_HEADER;
 
 public class StaffSlipsAPI implements StaffSlipsStorageResource {
 
@@ -53,15 +51,16 @@ public class StaffSlipsAPI implements StaffSlipsStorageResource {
 						TenantTool.calculateTenantId(tenantId));
 
 				postgresClient.mutate(
-						String.format("TRUNCATE TABLE %s_%s.%s", tenantId, "mod_circulation_storage", STAFF_SLIP_TABLE), reply -> {
-							asyncResultHandler.handle(Future.succeededFuture(
-									StaffSlipsStorageResource.DeleteStaffSlipsStorageStaffSlipsResponse.noContent().build()));
-						});
+				  //TODO: Need to add 204 response to staff slips RAML interface definition!
+          String.format("TRUNCATE TABLE %s_%s.%s", tenantId, "mod_circulation_storage", STAFF_SLIP_TABLE), reply ->
+            asyncResultHandler.handle(succeededFuture(
+              DeleteStaffSlipsStorageStaffSlipsResponse.noContent().build())));
 
 			} catch (Exception e) {
 				asyncResultHandler
-						.handle(Future.succeededFuture(StaffSlipsStorageResource.DeleteStaffSlipsStorageStaffSlipsResponse
-								.withPlainInternalServerError(e.getMessage())));
+						.handle(succeededFuture(
+						  StaffSlipsStorageResource.DeleteStaffSlipsStorageStaffSlipsResponse
+                .withPlainInternalServerError(e.getMessage())));
 			}
 		});
 
@@ -95,19 +94,19 @@ public class StaffSlipsAPI implements StaffSlipsStorageResource {
 						pagedStaffSlips.setStaffSlips(staffSlips);
 						pagedStaffSlips.setTotalRecords((Integer) reply.result().getResultInfo().getTotalRecords());
 
-						asyncResultHandler.handle(Future.succeededFuture(
+						asyncResultHandler.handle(succeededFuture(
 								StaffSlipsStorageResource.GetStaffSlipsStorageStaffSlipsResponse.withJsonOK(pagedStaffSlips)));
 
 					} else {
 						asyncResultHandler
-								.handle(Future.succeededFuture(StaffSlipsStorageResource.GetStaffSlipsStorageStaffSlipsResponse
+								.handle(succeededFuture(StaffSlipsStorageResource.GetStaffSlipsStorageStaffSlipsResponse
 										.withPlainInternalServerError(reply.cause().getMessage())));
 					}
 
 				} catch (Exception e) {
 					log.error(e.getMessage());
 					asyncResultHandler
-							.handle(Future.succeededFuture(StaffSlipsStorageResource.GetStaffSlipsStorageStaffSlipsResponse
+							.handle(succeededFuture(StaffSlipsStorageResource.GetStaffSlipsStorageStaffSlipsResponse
 									.withPlainInternalServerError(e.getMessage())));
 				}
 
@@ -115,7 +114,7 @@ public class StaffSlipsAPI implements StaffSlipsStorageResource {
 
 		} catch (Exception e) {
 			log.error(e.getMessage());
-			asyncResultHandler.handle(Future.succeededFuture(StaffSlipsStorageResource.GetStaffSlipsStorageStaffSlipsResponse
+			asyncResultHandler.handle(succeededFuture(StaffSlipsStorageResource.GetStaffSlipsStorageStaffSlipsResponse
 					.withPlainInternalServerError(e.getMessage())));
 		}
 
@@ -130,7 +129,7 @@ public class StaffSlipsAPI implements StaffSlipsStorageResource {
 		ImmutablePair<Boolean, String> validationResult = validateStaffSlip(entity);
 
 		if (!validationResult.getLeft()) {
-			asyncResultHandler.handle(Future.succeededFuture(StaffSlipsStorageResource.PostStaffSlipsStorageStaffSlipsResponse
+			asyncResultHandler.handle(succeededFuture(StaffSlipsStorageResource.PostStaffSlipsStorageStaffSlipsResponse
 					.withPlainBadRequest(validationResult.getRight())));
 
 			return;
@@ -173,18 +172,18 @@ public class StaffSlipsAPI implements StaffSlipsStorageResource {
 								StaffSlip staffSlip = staffSlips.get(0);
 
 								asyncResultHandler.handle(
-										Future.succeededFuture(StaffSlipsStorageResource.GetStaffSlipsStorageStaffSlipsByStaffSlipIdResponse
+										succeededFuture(StaffSlipsStorageResource.GetStaffSlipsStorageStaffSlipsByStaffSlipIdResponse
 												.withJsonOK(staffSlip)));
 
 							} else {
 								asyncResultHandler.handle(
-										Future.succeededFuture(StaffSlipsStorageResource.GetStaffSlipsStorageStaffSlipsByStaffSlipIdResponse
+										succeededFuture(StaffSlipsStorageResource.GetStaffSlipsStorageStaffSlipsByStaffSlipIdResponse
 												.withPlainNotFound("Not Found")));
 							}
 
 						} else {
 							asyncResultHandler.handle(
-									Future.succeededFuture(StaffSlipsStorageResource.GetStaffSlipsStorageStaffSlipsByStaffSlipIdResponse
+									succeededFuture(StaffSlipsStorageResource.GetStaffSlipsStorageStaffSlipsByStaffSlipIdResponse
 											.withPlainInternalServerError(reply.cause().getMessage())));
 
 						}
@@ -193,7 +192,7 @@ public class StaffSlipsAPI implements StaffSlipsStorageResource {
 				} catch (Exception e) {
 					log.error(e.getMessage());
 					asyncResultHandler.handle(
-							Future.succeededFuture(StaffSlipsStorageResource.GetStaffSlipsStorageStaffSlipsByStaffSlipIdResponse
+							succeededFuture(StaffSlipsStorageResource.GetStaffSlipsStorageStaffSlipsByStaffSlipIdResponse
 									.withPlainInternalServerError(e.getMessage())));
 				}
 			});
@@ -201,7 +200,7 @@ public class StaffSlipsAPI implements StaffSlipsStorageResource {
 		} catch (Exception e) {
 			log.error(e.getMessage());
 			asyncResultHandler
-					.handle(Future.succeededFuture(StaffSlipsStorageResource.GetStaffSlipsStorageStaffSlipsByStaffSlipIdResponse
+					.handle(succeededFuture(StaffSlipsStorageResource.GetStaffSlipsStorageStaffSlipsByStaffSlipIdResponse
 							.withPlainInternalServerError(e.getMessage())));
 		}
 
@@ -234,25 +233,24 @@ public class StaffSlipsAPI implements StaffSlipsStorageResource {
 						if (reply.succeeded()) {
 
 							asyncResultHandler.handle(
-									Future.succeededFuture(DeleteStaffSlipsStorageStaffSlipsByStaffSlipIdResponse.withNoContent()));
+									succeededFuture(DeleteStaffSlipsStorageStaffSlipsByStaffSlipIdResponse.withNoContent()));
 
 						} else {
-							asyncResultHandler.handle(Future
-									.succeededFuture(StaffSlipsStorageResource.DeleteStaffSlipsStorageStaffSlipsByStaffSlipIdResponse
+							asyncResultHandler.handle(succeededFuture(StaffSlipsStorageResource.DeleteStaffSlipsStorageStaffSlipsByStaffSlipIdResponse
 											.withPlainInternalServerError(reply.cause().getMessage())));
 						}
 					});
 
 				} catch (Exception e) {
 					asyncResultHandler.handle(
-							Future.succeededFuture(StaffSlipsStorageResource.DeleteStaffSlipsStorageStaffSlipsByStaffSlipIdResponse
+							succeededFuture(StaffSlipsStorageResource.DeleteStaffSlipsStorageStaffSlipsByStaffSlipIdResponse
 									.withPlainInternalServerError(e.getMessage())));
 				}
 			});
 
 		} catch (Exception e) {
 			asyncResultHandler.handle(
-					Future.succeededFuture(StaffSlipsStorageResource.DeleteStaffSlipsStorageStaffSlipsByStaffSlipIdResponse
+					succeededFuture(StaffSlipsStorageResource.DeleteStaffSlipsStorageStaffSlipsByStaffSlipIdResponse
 							.withPlainInternalServerError(e.getMessage())));
 		}
 
@@ -268,7 +266,7 @@ public class StaffSlipsAPI implements StaffSlipsStorageResource {
 		ImmutablePair<Boolean, String> validationResult = validateStaffSlip(entity);
 
 		if (!validationResult.getLeft()) {
-			asyncResultHandler.handle(io.vertx.core.Future.succeededFuture(
+			asyncResultHandler.handle(succeededFuture(
 					LoanStorageResource.PostLoanStorageLoansResponse.withPlainBadRequest(validationResult.getRight())));
 
 			return;
@@ -308,26 +306,23 @@ public class StaffSlipsAPI implements StaffSlipsStorageResource {
 												OutStream stream = new OutStream();
 												stream.setData(entity);
 
-												asyncResultHandler.handle(Future
-														.succeededFuture(PutStaffSlipsStorageStaffSlipsByStaffSlipIdResponse.withNoContent()));
+												asyncResultHandler.handle(succeededFuture(PutStaffSlipsStorageStaffSlipsByStaffSlipIdResponse.withNoContent()));
 
 											} else {
-												asyncResultHandler.handle(Future.succeededFuture(
+												asyncResultHandler.handle(succeededFuture(
 														StaffSlipsStorageResource.PutStaffSlipsStorageStaffSlipsByStaffSlipIdResponse
 																.withPlainInternalServerError(reply.cause().getMessage())));
 											}
 
 										} catch (Exception e) {
-											asyncResultHandler.handle(Future
-													.succeededFuture(StaffSlipsStorageResource.PutStaffSlipsStorageStaffSlipsByStaffSlipIdResponse
+											asyncResultHandler.handle(succeededFuture(StaffSlipsStorageResource.PutStaffSlipsStorageStaffSlipsByStaffSlipIdResponse
 															.withPlainInternalServerError(e.getMessage())));
 										}
 
 									});
 
 								} catch (Exception e) {
-									asyncResultHandler.handle(Future
-											.succeededFuture(StaffSlipsStorageResource.PutStaffSlipsStorageStaffSlipsByStaffSlipIdResponse
+									asyncResultHandler.handle(succeededFuture(StaffSlipsStorageResource.PutStaffSlipsStorageStaffSlipsByStaffSlipIdResponse
 													.withPlainInternalServerError(e.getMessage())));
 								}
 
@@ -335,28 +330,27 @@ public class StaffSlipsAPI implements StaffSlipsStorageResource {
 								try {
 									createStaffSlip(entity, tenantId, asyncResultHandler, vertxContext);
 								} catch (Exception e) {
-									asyncResultHandler.handle(Future
-											.succeededFuture(StaffSlipsStorageResource.PutStaffSlipsStorageStaffSlipsByStaffSlipIdResponse
+									asyncResultHandler.handle(succeededFuture(StaffSlipsStorageResource.PutStaffSlipsStorageStaffSlipsByStaffSlipIdResponse
 													.withPlainInternalServerError(e.getMessage())));
 								}
 							}
 						} else {
 							asyncResultHandler.handle(
-									Future.succeededFuture(StaffSlipsStorageResource.PutStaffSlipsStorageStaffSlipsByStaffSlipIdResponse
+									succeededFuture(StaffSlipsStorageResource.PutStaffSlipsStorageStaffSlipsByStaffSlipIdResponse
 											.withPlainInternalServerError(reply.cause().getMessage())));
 						}
 					});
 
 				} catch (Exception e) {
 					asyncResultHandler.handle(
-							Future.succeededFuture(StaffSlipsStorageResource.PutStaffSlipsStorageStaffSlipsByStaffSlipIdResponse
+							succeededFuture(StaffSlipsStorageResource.PutStaffSlipsStorageStaffSlipsByStaffSlipIdResponse
 									.withPlainInternalServerError(e.getMessage())));
 				}
 			});
 
 		} catch (Exception e) {
 			asyncResultHandler
-					.handle(Future.succeededFuture(StaffSlipsStorageResource.PutStaffSlipsStorageStaffSlipsByStaffSlipIdResponse
+					.handle(succeededFuture(StaffSlipsStorageResource.PutStaffSlipsStorageStaffSlipsByStaffSlipIdResponse
 							.withPlainInternalServerError(e.getMessage())));
 		}
 
@@ -388,17 +382,17 @@ public class StaffSlipsAPI implements StaffSlipsStorageResource {
 								stream.setData(entity);
 
 								asyncResultHandler
-										.handle(Future.succeededFuture(StaffSlipsStorageResource.PostStaffSlipsStorageStaffSlipsResponse
+										.handle(succeededFuture(StaffSlipsStorageResource.PostStaffSlipsStorageStaffSlipsResponse
 												.withJsonCreated(reply.result(), stream)));
 
 							} else {
-								asyncResultHandler.handle(Future.succeededFuture(LoanStorageResource.PostLoanStorageLoansResponse
+								asyncResultHandler.handle(succeededFuture(LoanStorageResource.PostLoanStorageLoansResponse
 										.withPlainInternalServerError(reply.cause().toString())));
 							}
 						} catch (Exception e) {
 							log.error(e.getMessage());
 							asyncResultHandler
-									.handle(Future.succeededFuture(StaffSlipsStorageResource.PostStaffSlipsStorageStaffSlipsResponse
+									.handle(succeededFuture(StaffSlipsStorageResource.PostStaffSlipsStorageStaffSlipsResponse
 											.withPlainInternalServerError(e.getMessage())));
 						}
 					});
@@ -406,14 +400,14 @@ public class StaffSlipsAPI implements StaffSlipsStorageResource {
 				} catch (Exception e) {
 					log.error(e.getMessage());
 					asyncResultHandler
-							.handle(Future.succeededFuture(StaffSlipsStorageResource.PostStaffSlipsStorageStaffSlipsResponse
+							.handle(succeededFuture(StaffSlipsStorageResource.PostStaffSlipsStorageStaffSlipsResponse
 									.withPlainInternalServerError(e.getMessage())));
 				}
 			});
 
 		} catch (Exception e) {
 			asyncResultHandler.handle(
-					Future.succeededFuture(PostStaffSlipsStorageStaffSlipsResponse.withPlainInternalServerError(e.getMessage())));
+					succeededFuture(PostStaffSlipsStorageStaffSlipsResponse.withPlainInternalServerError(e.getMessage())));
 		}
 	}
 

--- a/src/main/java/org/folio/rest/impl/StaffSlipsAPI.java
+++ b/src/main/java/org/folio/rest/impl/StaffSlipsAPI.java
@@ -6,6 +6,7 @@ import io.vertx.core.Handler;
 import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
 import org.apache.commons.lang3.tuple.ImmutablePair;
+import org.folio.rest.impl.support.LogWriter;
 import org.folio.rest.jaxrs.model.StaffSlip;
 import org.folio.rest.jaxrs.model.StaffSlips;
 import org.folio.rest.jaxrs.resource.LoanStorageResource;
@@ -21,6 +22,7 @@ import org.folio.rest.tools.utils.TenantTool;
 import org.z3950.zing.cql.cql2pgjson.CQL2PgJSON;
 
 import javax.ws.rs.core.Response;
+import java.lang.invoke.MethodHandles;
 import java.util.List;
 import java.util.Map;
 import java.util.StringJoiner;
@@ -30,12 +32,12 @@ import static io.vertx.core.Future.succeededFuture;
 import static org.folio.rest.impl.Headers.TENANT_HEADER;
 
 public class StaffSlipsAPI implements StaffSlipsStorageResource {
-
-	private static final String STAFF_SLIP_TABLE = "staff_slips";
+	private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+  private static final LogWriter logWriter = new LogWriter(log);
 
 	private static final Class<StaffSlip> STAFF_SLIP_CLASS = StaffSlip.class;
 
-	private static final Logger log = LoggerFactory.getLogger(STAFF_SLIP_CLASS);
+	private static final String STAFF_SLIP_TABLE = "staff_slips";
 
 	@Override
 	public void deleteStaffSlipsStorageStaffSlips(String lang, Map<String, String> okapiHeaders,
@@ -57,6 +59,8 @@ public class StaffSlipsAPI implements StaffSlipsStorageResource {
               DeleteStaffSlipsStorageStaffSlipsResponse.noContent().build())));
 
 			} catch (Exception e) {
+        logWriter.error(e);
+
 				asyncResultHandler
 						.handle(succeededFuture(
 						  StaffSlipsStorageResource.DeleteStaffSlipsStorageStaffSlipsResponse
@@ -104,7 +108,8 @@ public class StaffSlipsAPI implements StaffSlipsStorageResource {
 					}
 
 				} catch (Exception e) {
-					log.error(e.getMessage());
+          logWriter.error(e);
+
 					asyncResultHandler
 							.handle(succeededFuture(StaffSlipsStorageResource.GetStaffSlipsStorageStaffSlipsResponse
 									.withPlainInternalServerError(e.getMessage())));
@@ -113,7 +118,8 @@ public class StaffSlipsAPI implements StaffSlipsStorageResource {
 			});
 
 		} catch (Exception e) {
-			log.error(e.getMessage());
+      logWriter.error(e);
+
 			asyncResultHandler.handle(succeededFuture(StaffSlipsStorageResource.GetStaffSlipsStorageStaffSlipsResponse
 					.withPlainInternalServerError(e.getMessage())));
 		}
@@ -190,7 +196,8 @@ public class StaffSlipsAPI implements StaffSlipsStorageResource {
 					});
 
 				} catch (Exception e) {
-					log.error(e.getMessage());
+          logWriter.error(e);
+
 					asyncResultHandler.handle(
 							succeededFuture(StaffSlipsStorageResource.GetStaffSlipsStorageStaffSlipsByStaffSlipIdResponse
 									.withPlainInternalServerError(e.getMessage())));
@@ -198,7 +205,8 @@ public class StaffSlipsAPI implements StaffSlipsStorageResource {
 			});
 
 		} catch (Exception e) {
-			log.error(e.getMessage());
+      logWriter.error(e);
+
 			asyncResultHandler
 					.handle(succeededFuture(StaffSlipsStorageResource.GetStaffSlipsStorageStaffSlipsByStaffSlipIdResponse
 							.withPlainInternalServerError(e.getMessage())));
@@ -242,6 +250,8 @@ public class StaffSlipsAPI implements StaffSlipsStorageResource {
 					});
 
 				} catch (Exception e) {
+          logWriter.error(e);
+
 					asyncResultHandler.handle(
 							succeededFuture(StaffSlipsStorageResource.DeleteStaffSlipsStorageStaffSlipsByStaffSlipIdResponse
 									.withPlainInternalServerError(e.getMessage())));
@@ -249,6 +259,8 @@ public class StaffSlipsAPI implements StaffSlipsStorageResource {
 			});
 
 		} catch (Exception e) {
+      logWriter.error(e);
+
 			asyncResultHandler.handle(
 					succeededFuture(StaffSlipsStorageResource.DeleteStaffSlipsStorageStaffSlipsByStaffSlipIdResponse
 							.withPlainInternalServerError(e.getMessage())));
@@ -315,6 +327,8 @@ public class StaffSlipsAPI implements StaffSlipsStorageResource {
 											}
 
 										} catch (Exception e) {
+                      logWriter.error(e);
+
 											asyncResultHandler.handle(succeededFuture(StaffSlipsStorageResource.PutStaffSlipsStorageStaffSlipsByStaffSlipIdResponse
 															.withPlainInternalServerError(e.getMessage())));
 										}
@@ -322,6 +336,8 @@ public class StaffSlipsAPI implements StaffSlipsStorageResource {
 									});
 
 								} catch (Exception e) {
+                  logWriter.error(e);
+
 									asyncResultHandler.handle(succeededFuture(StaffSlipsStorageResource.PutStaffSlipsStorageStaffSlipsByStaffSlipIdResponse
 													.withPlainInternalServerError(e.getMessage())));
 								}
@@ -342,6 +358,8 @@ public class StaffSlipsAPI implements StaffSlipsStorageResource {
 					});
 
 				} catch (Exception e) {
+          logWriter.error(e);
+
 					asyncResultHandler.handle(
 							succeededFuture(StaffSlipsStorageResource.PutStaffSlipsStorageStaffSlipsByStaffSlipIdResponse
 									.withPlainInternalServerError(e.getMessage())));
@@ -349,6 +367,8 @@ public class StaffSlipsAPI implements StaffSlipsStorageResource {
 			});
 
 		} catch (Exception e) {
+      logWriter.error(e);
+
 			asyncResultHandler
 					.handle(succeededFuture(StaffSlipsStorageResource.PutStaffSlipsStorageStaffSlipsByStaffSlipIdResponse
 							.withPlainInternalServerError(e.getMessage())));
@@ -390,7 +410,8 @@ public class StaffSlipsAPI implements StaffSlipsStorageResource {
 										.withPlainInternalServerError(reply.cause().toString())));
 							}
 						} catch (Exception e) {
-							log.error(e.getMessage());
+              logWriter.error(e);
+
 							asyncResultHandler
 									.handle(succeededFuture(StaffSlipsStorageResource.PostStaffSlipsStorageStaffSlipsResponse
 											.withPlainInternalServerError(e.getMessage())));
@@ -398,7 +419,8 @@ public class StaffSlipsAPI implements StaffSlipsStorageResource {
 					});
 
 				} catch (Exception e) {
-					log.error(e.getMessage());
+          logWriter.error(e);
+
 					asyncResultHandler
 							.handle(succeededFuture(StaffSlipsStorageResource.PostStaffSlipsStorageStaffSlipsResponse
 									.withPlainInternalServerError(e.getMessage())));
@@ -406,6 +428,8 @@ public class StaffSlipsAPI implements StaffSlipsStorageResource {
 			});
 
 		} catch (Exception e) {
+      logWriter.error(e);
+
 			asyncResultHandler.handle(
 					succeededFuture(PostStaffSlipsStorageStaffSlipsResponse.withPlainInternalServerError(e.getMessage())));
 		}

--- a/src/main/java/org/folio/rest/impl/support/LogWriter.java
+++ b/src/main/java/org/folio/rest/impl/support/LogWriter.java
@@ -1,0 +1,15 @@
+package org.folio.rest.impl.support;
+
+import io.vertx.core.logging.Logger;
+
+public class LogWriter {
+  private final Logger logger;
+
+  public LogWriter(Logger logger) {
+    this.logger = logger;
+  }
+
+  public void error(Throwable cause) {
+    logger.error(cause.getMessage(), cause);
+  }
+}


### PR DESCRIPTION
Change code which outputs messages to standard out to use a logger instead, in order to resolve vulnerabilities reported by SonarQube