### PR TITLE
Default status to open CIRCSTORE-71

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,8 @@
-## 5.6.0 2018-008-29
+## 5.7.0 Unreleased
+
+* Default loan `status` to `Open` (CIRCSTORE-71)
+
+## 5.6.0 2018-08-29
 
 * Use declarative unique index for request queue position, instead of custom snippet (CIRCSTORE-70)
 * Upgrade to RAML Module Builder 19.3.1 (CIRCSTORE-70, RMB-176)

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,11 +1,12 @@
 ## 5.7.0 Unreleased
 
 * Default loan `status` to `Open` (CIRCSTORE-71)
+* Upgrades to RAML Module Builder 19.4.1 (RMB-231) 
 
 ## 5.6.0 2018-08-29
 
 * Use declarative unique index for request queue position, instead of custom snippet (CIRCSTORE-70)
-* Upgrade to RAML Module Builder 19.3.1 (CIRCSTORE-70, RMB-176)
+* Upgrades to RAML Module Builder 19.3.1 (CIRCSTORE-70, RMB-176)
 
 ## 5.5.0 2018-08-02
 

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     <dependency>
       <groupId>org.folio</groupId>
       <artifactId>domain-models-runtime</artifactId>
-      <version>19.3.1</version>
+      <version>19.4.1</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <artifactId>mod-circulation-storage</artifactId>
   <groupId>org.folio</groupId>
-  <version>5.6.1-SNAPSHOT</version>
+  <version>5.7.0-SNAPSHOT</version>
   <licenses>
     <license>
       <name>Apache License 2.0</name>

--- a/src/main/java/org/folio/rest/impl/LoansAPI.java
+++ b/src/main/java/org/folio/rest/impl/LoansAPI.java
@@ -9,6 +9,7 @@ import org.folio.rest.annotations.Validate;
 import org.folio.rest.jaxrs.model.Errors;
 import org.folio.rest.jaxrs.model.Loan;
 import org.folio.rest.jaxrs.model.Loans;
+import org.folio.rest.jaxrs.model.Status;
 import org.folio.rest.jaxrs.resource.LoanStorageResource;
 import org.folio.rest.persist.Criteria.Criteria;
 import org.folio.rest.persist.Criteria.Criterion;
@@ -150,6 +151,10 @@ public class LoansAPI implements LoanStorageResource {
     Context vertxContext) {
 
     String tenantId = okapiHeaders.get(TENANT_HEADER);
+
+    if(entity.getStatus() == null) {
+      entity.setStatus(new Status().withName("Open"));
+    }
 
     ImmutablePair<Boolean, String> validationResult = validateLoan(entity);
 
@@ -360,12 +365,16 @@ public class LoansAPI implements LoanStorageResource {
 
     String tenantId = okapiHeaders.get(TENANT_HEADER);
 
+    if(entity.getStatus() == null) {
+      entity.setStatus(new Status().withName("Open"));
+    }
+
     ImmutablePair<Boolean, String> validationResult = validateLoan(entity);
 
     if(!validationResult.getLeft()) {
       asyncResultHandler.handle(
         io.vertx.core.Future.succeededFuture(
-          LoanStorageResource.PostLoanStorageLoansResponse
+          LoanStorageResource.PutLoanStorageLoansByLoanIdResponse
             .withPlainBadRequest(
               validationResult.getRight())));
 

--- a/src/test/java/org/folio/rest/api/StorageTestSuite.java
+++ b/src/test/java/org/folio/rest/api/StorageTestSuite.java
@@ -2,7 +2,10 @@ package org.folio.rest.api;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 
+import java.io.IOException;
+import java.lang.invoke.MethodHandles;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.concurrent.CompletableFuture;
@@ -25,6 +28,8 @@ import org.junit.runners.Suite;
 import io.vertx.core.DeploymentOptions;
 import io.vertx.core.Vertx;
 import io.vertx.core.json.JsonObject;
+import io.vertx.core.logging.Logger;
+import io.vertx.core.logging.LoggerFactory;
 import io.vertx.ext.sql.ResultSet;
 
 @RunWith(Suite.class)
@@ -41,7 +46,9 @@ import io.vertx.ext.sql.ResultSet;
 })
 
 public class StorageTestSuite {
-	public static final String TENANT_ID = "test_tenant";
+  private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
+	static final String TENANT_ID = "test_tenant";
 
 	private static Vertx vertx;
 	private static int port;
@@ -56,34 +63,51 @@ public class StorageTestSuite {
 	}
 
 	@BeforeClass
-	public static void before() throws Exception {
+	public static void before()
+    throws IOException,
+    InterruptedException,
+    ExecutionException,
+    TimeoutException {
 
 		vertx = Vertx.vertx();
 
-		String useExternalDatabase = System.getProperty("org.folio.circulation.storage.test.database", "embedded");
+		String useExternalDatabase = System.getProperty(
+		  "org.folio.circulation.storage.test.database",
+            "embedded");
 
 		switch (useExternalDatabase) {
-		case "environment":
-			System.out.println("Using environment settings");
-			break;
+      case "environment":
+        log.info("Using environment settings");
+        break;
 
-		case "external":
-			String postgresConfigPath = System.getProperty("org.folio.circulation.storage.test.config",
-					"/postgres-conf-local.json");
+      case "external":
+        String postgresConfigPath = System.getProperty(
+          "org.folio.circulation.storage.test.config",
+            "/postgres-conf-local.json");
 
-			PostgresClient.setConfigFilePath(postgresConfigPath);
-			break;
-		case "embedded":
-			PostgresClient.setIsEmbedded(true);
-			PostgresClient.setEmbeddedPort(NetworkUtils.nextFreePort());
-			PostgresClient client = PostgresClient.getInstance(vertx);
-			client.startEmbeddedPostgres();
-			break;
-		default:
-			String message = "No understood database choice made." + "Please set org.folio.circulation.storage.test.config"
-					+ "to 'external', 'environment' or 'embedded'";
+        log.info("Using external configuration settings: '%s'",
+          postgresConfigPath);
 
-			throw new Exception(message);
+        PostgresClient.setConfigFilePath(postgresConfigPath);
+        break;
+
+      case "embedded":
+        log.info("Using embedded PostgreSQL");
+
+        PostgresClient.setIsEmbedded(true);
+        PostgresClient.setEmbeddedPort(NetworkUtils.nextFreePort());
+
+        PostgresClient client = PostgresClient.getInstance(vertx);
+        client.startEmbeddedPostgres();
+        break;
+
+      default:
+        String message = "No understood database choice made."
+          + "Please set org.folio.circulation.storage.test.config"
+          + "to 'external', 'environment' or 'embedded'";
+
+        log.error(message);
+        assert false;
 		}
 
 		port = NetworkUtils.nextFreePort();
@@ -101,7 +125,10 @@ public class StorageTestSuite {
 	}
 
 	@AfterClass
-	public static void after() throws InterruptedException, ExecutionException, TimeoutException {
+	public static void after()
+    throws InterruptedException,
+    ExecutionException,
+    TimeoutException {
 
 		initialised = false;
 
@@ -135,10 +162,12 @@ public class StorageTestSuite {
 			Response response = deleteAllFinished.get(5, TimeUnit.SECONDS);
 
 			if (response.getStatusCode() != 204) {
-				System.out.println("WARNING!!!!! Delete all resources preparation failed");
+				log.warn(String.format("Deleting all records at '%s' failed",
+          rootUrl));
 			}
 		} catch (Exception e) {
-			System.out.println("WARNING!!!!! Unable to delete all resources: " + e.getMessage());
+			log.error("Unable to delete all resources: " + e.getMessage(), e);
+			assert false;
 		}
 	}
 
@@ -149,22 +178,31 @@ public class StorageTestSuite {
 			Integer mismatchedRowCount = results.getNumRows();
 
 			assertThat(mismatchedRowCount, is(0));
+
 		} catch (Exception e) {
-			System.out.println(String.format("WARNING!!!!! Unable to determine mismatched ID rows for %s", table));
+      log.error(String.format(
+        "Unable to determine mismatched ID rows for '%s': '%s'",
+        table, e.getMessage()), e);
+      assert false;
 		}
 	}
 
-	private static ResultSet getRecordsWithUnmatchedIds(String tenantId, String tableName)
-			throws InterruptedException, ExecutionException, TimeoutException {
+	private static ResultSet getRecordsWithUnmatchedIds(
+	  String tenantId,
+    String tableName)
+    throws InterruptedException,
+    ExecutionException,
+    TimeoutException {
 
-		PostgresClient dbClient = PostgresClient.getInstance(getVertx(), tenantId);
+		PostgresClient postgresClient = PostgresClient.getInstance(getVertx(), tenantId);
 
 		CompletableFuture<ResultSet> selectCompleted = new CompletableFuture<>();
 
-		String sql = String.format("SELECT null FROM %s_%s.%s" + " WHERE CAST(_id AS VARCHAR(50)) != jsonb->>'id'",
+		String sql = String.format(
+		  "SELECT null FROM %s_%s.%s" + " WHERE CAST(_id AS VARCHAR(50)) != jsonb->>'id'",
 				tenantId, "mod_circulation_storage", tableName);
 
-		dbClient.select(sql, result -> {
+		postgresClient.select(sql, result -> {
 			if (result.succeeded()) {
 				selectCompleted.complete(result.result());
 			} else {
@@ -176,7 +214,9 @@ public class StorageTestSuite {
 	}
 
 	private static void startVerticle(DeploymentOptions options)
-			throws InterruptedException, ExecutionException, TimeoutException {
+    throws InterruptedException,
+    ExecutionException,
+    TimeoutException {
 
 		CompletableFuture<String> deploymentComplete = new CompletableFuture<>();
 
@@ -194,20 +234,23 @@ public class StorageTestSuite {
 	private static void prepareTenant(String tenantId) {
 		CompletableFuture<TextResponse> tenantPrepared = new CompletableFuture<>();
 
+		log.info("Making request to prepare tenant in module");
+
 		try {
 			HttpClient client = new HttpClient(vertx);
 
-			client.post(storageUrl("/_/tenant"), null, tenantId, ResponseHandler.text(tenantPrepared));
+			client.post(storageUrl("/_/tenant"), null, tenantId,
+        ResponseHandler.text(tenantPrepared));
 
 			TextResponse response = tenantPrepared.get(10, TimeUnit.SECONDS);
 
-			String failureMessage = String.format("Tenant preparation failed: %s: %s", response.getStatusCode(),
-					response.getBody());
+			String failureMessage = String.format("Tenant preparation failed: %s: %s",
+        response.getStatusCode(), response.getBody());
 
 			assertThat(failureMessage, response.getStatusCode(), is(201));
 
 		} catch (Exception e) {
-			System.out.println("WARNING!!!!! Tenant preparation failed: " + e.getMessage());
+			log.error("Tenant preparation failed: " + e.getMessage(), e);
 			assert false;
 		}
 	}
@@ -215,20 +258,23 @@ public class StorageTestSuite {
 	private static void removeTenant(String tenantId) {
 		CompletableFuture<TextResponse> tenantDeleted = new CompletableFuture<>();
 
+    log.info("Making request to clean up tenant in module");
+
 		try {
 			HttpClient client = new HttpClient(vertx);
 
-			client.delete(storageUrl("/_/tenant"), tenantId, ResponseHandler.text(tenantDeleted));
+			client.delete(storageUrl("/_/tenant"), tenantId,
+        ResponseHandler.text(tenantDeleted));
 
 			TextResponse response = tenantDeleted.get(10, TimeUnit.SECONDS);
 
-			String failureMessage = String.format("Tenant cleanup failed: %s: %s", response.getStatusCode(),
-					response.getBody());
+			String failureMessage = String.format("Tenant clean up failed: %s: %s",
+        response.getStatusCode(), response.getBody());
 
 			assertThat(failureMessage, response.getStatusCode(), is(204));
 
 		} catch (Exception e) {
-			System.out.println("WARNING!!!!! Tenant cleanup failed: " + e.getMessage());
+      log.error("Tenant clean up failed: " + e.getMessage(), e);
 			assert false;
 		}
 	}


### PR DESCRIPTION
*Purpose*

In order to support loan anonymization, we need to allow closed loans to no longer be associated with a user. 

In order to limit this to only closed loans (as open loans should always have a user) the module needs to decide based upon the status whether a loan representation is valid.

*Approach*

Loan status is currently optional (as making it required would be a compatibility breaking change and so has been deferred).

Previously loan status had been defaulted to Open by the business logic module, mod-circulation, however mod-circulation-storage now needs to ensure that a loan has a status, as it is now making decisions based upon it.