### PR TITLE
Anonymize single users closed loans CIRCSTORE-73

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 ## 6.1.0 Unreleased
 
+* Can anonymize all closed loans for a single user (CIRCSTORE-73)
 * Provides `loan-stoage` 5.1 (CIRCSTORE-73)
 
 ## 6.0.0 2018-09-09

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+## 6.1.0 Unreleased
+
+* Provides `loan-stoage` 5.1 (CIRCSTORE-73)
+
 ## 6.0.0 2018-09-09
 
 * Only requires `userId` for open loans (CIRCSTORE-71) 

--- a/README.MD
+++ b/README.MD
@@ -55,6 +55,14 @@ for a given item can be at a particular position in the request queue for that i
 HTTP Requests (either POST or PUT) which could result two open requests with the
 same `itemId` and `position` should be rejected with a error (422) response
 
+### Known Limitations
+
+#### Anonymization SQL
+
+At the moment, this is constructed with string concatenation (it will hopefully soon be replaced by prepared statements).
+
+The `userId` parameter is checked to take the form of a UUID to try to reduce the exposure of this.
+
 ## Prerequisites
 
 ## Required

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -4,7 +4,7 @@
   "provides": [
     {
       "id": "loan-storage",
-      "version": "5.0",
+      "version": "5.1",
       "handlers": [
         {
           "methods": ["GET"],

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -34,6 +34,10 @@
           "methods": ["GET"],
           "pathPattern": "/loan-storage/loan-history",
           "permissionsRequired": ["circulation-storage.loans-history.collection.get"]
+        }, {
+          "methods": ["POST"],
+          "pathPattern": "/loan-storage/loans/anonymize/{userId}",
+          "permissionsRequired": ["circulation-storage.loans.collection.anonymize.user.post"]
         }
       ]
     },
@@ -264,6 +268,11 @@
       "description": "Delete individual loan from storage"
     },
     {
+      "permissionName": "circulation-storage.loans.collection.anonymize.user.post",
+      "displayName": "Circulation storage - anonymize loans for a user",
+      "description": "Anonymize closed loans for a single user"
+    },
+    {
       "permissionName": "circulation-storage.loan-rules.get",
       "displayName": "Circulation storage - get loan rules",
       "description": "Get loan rules from storage"
@@ -439,6 +448,7 @@
         "circulation-storage.loans.item.put",
         "circulation-storage.loans.item.delete",
         "circulation-storage.loans.collection.delete",
+        "circulation-storage.loans.collection.anonymize.user.post",
         "circulation-storage.loans-history.collection.get",
         "circulation-storage.loan-rules.get",
         "circulation-storage.loan-rules.put",

--- a/pom.xml
+++ b/pom.xml
@@ -2,14 +2,13 @@
   <modelVersion>4.0.0</modelVersion>
   <artifactId>mod-circulation-storage</artifactId>
   <groupId>org.folio</groupId>
-  <version>6.0.1-SNAPSHOT</version>
+  <version>6.1.0-SNAPSHOT</version>
   <licenses>
     <license>
       <name>Apache License 2.0</name>
       <url>http://spdx.org/licenses/Apache-2.0</url>
     </license>
   </licenses>
-
   <repositories>
     <repository>
       <id>folio-nexus</id>

--- a/pom.xml
+++ b/pom.xml
@@ -321,7 +321,7 @@
         <version>2.19.1</version>
         <configuration>
           <excludes>
-            <exclude>org/folio/rest/api/*Test.java</exclude>
+            <exclude>org/folio/rest/api/**/*Test.java</exclude>
           </excludes>
           <includes>
             <include>org/folio/rest/api/StorageTestSuite.java</include>

--- a/pom.xml
+++ b/pom.xml
@@ -325,7 +325,7 @@
           </excludes>
           <includes>
             <include>org/folio/rest/api/StorageTestSuite.java</include>
-            <include>org/folio/rest/**</include>
+            <include>org/folio/**</include>
           </includes>
         </configuration>
       </plugin>

--- a/ramls/loan-storage.raml
+++ b/ramls/loan-storage.raml
@@ -1,6 +1,6 @@
 #%RAML 0.8
 title: Loan Storage
-version: v5.0
+version: v5.1
 protocols: [ HTTP, HTTPS ]
 baseUri: http://localhost:9130
 

--- a/ramls/loan-storage.raml
+++ b/ramls/loan-storage.raml
@@ -56,6 +56,16 @@ resourceTypes:
           body:
             text/plain:
               example: "Internal server error, contact administrator"
+    /anonymize/{userId}:
+      post:
+        responses:
+          204:
+            description: "Closed loans for this user have been anonymized"
+          500:
+            description: "Internal server error, e.g. due to misconfiguration"
+            body:
+              text/plain:
+                example: "Internal server error, contact administrator"
     /{loanId}:
       type:
         collection-item:

--- a/ramls/loan-storage.raml
+++ b/ramls/loan-storage.raml
@@ -58,6 +58,7 @@ resourceTypes:
               example: "Internal server error, contact administrator"
     /anonymize/{userId}:
       post:
+        is: [validate]
         responses:
           204:
             description: "Closed loans for this user have been anonymized"
@@ -66,6 +67,10 @@ resourceTypes:
             body:
               text/plain:
                 example: "Internal server error, contact administrator"
+          400:
+            description: "Bad request, e.g. malformed request body or query parameter."
+            body:
+              text/plain:
     /{loanId}:
       type:
         collection-item:

--- a/src/main/java/org/folio/rest/impl/LoansAPI.java
+++ b/src/main/java/org/folio/rest/impl/LoansAPI.java
@@ -33,6 +33,7 @@ import org.folio.rest.persist.cql.CQLWrapper;
 import org.folio.rest.tools.utils.OutStream;
 import org.folio.rest.tools.utils.TenantTool;
 import org.folio.rest.tools.utils.ValidationHelper;
+import org.folio.support.UUIDValidation;
 import org.joda.time.DateTime;
 import org.z3950.zing.cql.cql2pgjson.CQL2PgJSON;
 
@@ -259,9 +260,7 @@ public class LoansAPI implements LoanStorageResource {
 
     vertxContext.runOnContext(v -> {
       try {
-        final String uuidPattern = "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$";
-
-        if(!Pattern.matches(uuidPattern, userId)) {
+        if(!UUIDValidation.isValidUUID(userId)) {
           final Errors errors = ValidationHelper.createValidationErrorMessage(
             "userId", userId, "Invalid user ID, should be a UUID");
 

--- a/src/main/java/org/folio/rest/impl/LoansAPI.java
+++ b/src/main/java/org/folio/rest/impl/LoansAPI.java
@@ -10,11 +10,9 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.StringJoiner;
 import java.util.UUID;
-import java.util.function.Consumer;
 import java.util.function.Function;
 
 import javax.validation.constraints.NotNull;
-import javax.ws.rs.HEAD;
 import javax.ws.rs.core.Response;
 
 import org.apache.commons.lang3.tuple.ImmutablePair;
@@ -34,6 +32,7 @@ import org.folio.rest.persist.cql.CQLWrapper;
 import org.folio.rest.tools.utils.OutStream;
 import org.folio.rest.tools.utils.TenantTool;
 import org.folio.rest.tools.utils.ValidationHelper;
+import org.folio.support.ResultHandlerFactory;
 import org.folio.support.ServerErrorResponder;
 import org.folio.support.UUIDValidation;
 import org.joda.time.DateTime;
@@ -45,6 +44,7 @@ import io.vertx.core.AsyncResult;
 import io.vertx.core.Context;
 import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
+
 import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
 
@@ -288,7 +288,7 @@ public class LoansAPI implements LoanStorageResource {
         log.info(String.format("Anonymization SQL: %s", combinedAnonymizationSql));
 
         postgresClient.mutate(combinedAnonymizationSql,
-          resultHandlerFrom(
+          new ResultHandlerFactory().when(
             s -> responseHandler.handle(succeededFuture(
               PostLoanStorageLoansAnonymizeByUserIdResponse.withNoContent())),
             e -> {
@@ -768,22 +768,4 @@ public class LoansAPI implements LoanStorageResource {
     return anonymizeLoansActionHistorySql + "; " + anonymizeLoansSql;
   }
 
-  private Handler<AsyncResult<String>> resultHandlerFrom(
-    Consumer<String> onSuccess,
-    Consumer<Throwable> onFailure) {
-
-    return reply -> {
-      try {
-        if(reply.succeeded()) {
-          onSuccess.accept(reply.result());
-        }
-        else {
-          onFailure.accept(reply.cause());
-        }
-      }
-      catch(Exception e) {
-        onFailure.accept(e);
-      }
-    };
-  }
 }

--- a/src/main/java/org/folio/rest/impl/LoansAPI.java
+++ b/src/main/java/org/folio/rest/impl/LoansAPI.java
@@ -44,7 +44,6 @@ import io.vertx.core.AsyncResult;
 import io.vertx.core.Context;
 import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
-
 import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
 
@@ -263,7 +262,7 @@ public class LoansAPI implements LoanStorageResource {
 
     final ServerErrorResponder serverErrorResponder =
       new ServerErrorResponder(PostLoanStorageLoansAnonymizeByUserIdResponse
-        ::withPlainInternalServerError, responseHandler);
+        ::withPlainInternalServerError, responseHandler, log);
 
     vertxContext.runOnContext(v -> {
       try {
@@ -291,19 +290,9 @@ public class LoansAPI implements LoanStorageResource {
           new ResultHandlerFactory().when(
             s -> responseHandler.handle(succeededFuture(
               PostLoanStorageLoansAnonymizeByUserIdResponse.withNoContent())),
-            e -> {
-                if(e != null) {
-                  log.error(e, e.getMessage());
-                  serverErrorResponder.withError(e);
-                }
-                else {
-                  log.error("Unknown error occurred");
-                  serverErrorResponder.withMessage("Unknown error occurred");
-                }
-              }));
+            serverErrorResponder::withError));
       }
       catch(Exception e) {
-        log.error(e, e.getMessage());
         serverErrorResponder.withError(e);
       }
     });

--- a/src/main/java/org/folio/rest/impl/LoansAPI.java
+++ b/src/main/java/org/folio/rest/impl/LoansAPI.java
@@ -263,9 +263,13 @@ public class LoansAPI implements LoanStorageResource {
         final PostgresClient postgresClient = PostgresClient.getInstance(
             vertxContext.owner(), tenantId);
 
-        postgresClient.mutate(String.format("UPDATE %s_%s.loan " +
-            "SET jsonb = jsonb - 'userId' WHERE jsonb->>'userId' = '" + userId + "'",
-          tenantId, "mod_circulation_storage"),
+        final String anonymizeLoansSql = String.format(
+          "UPDATE %s_%s.loan SET jsonb = jsonb - 'userId'"
+            + " WHERE jsonb->>'userId' = '" + userId + "'"
+            + " AND jsonb->'status'->>'name' = 'Closed'",
+          tenantId, "mod_circulation_storage");
+
+        postgresClient.mutate(anonymizeLoansSql,
           reply -> {
             if(reply.succeeded()) {
               asyncResultHandler.handle(succeededFuture(

--- a/src/main/java/org/folio/rest/impl/LoansAPI.java
+++ b/src/main/java/org/folio/rest/impl/LoansAPI.java
@@ -12,6 +12,7 @@ import java.util.StringJoiner;
 import java.util.UUID;
 import java.util.function.Function;
 
+import javax.validation.constraints.NotNull;
 import javax.ws.rs.core.Response;
 
 import org.apache.commons.lang3.tuple.ImmutablePair;
@@ -246,6 +247,18 @@ public class LoansAPI implements LoanStorageResource {
         LoanStorageResource.PostLoanStorageLoansResponse
           .withPlainInternalServerError(e.getMessage())));
     }
+  }
+
+  @Override
+  public void postLoanStorageLoansAnonymizeByUserId(
+    @NotNull String userId,
+    Map<String, String> okapiHeaders,
+    Handler<AsyncResult<Response>> asyncResultHandler,
+    Context vertxContext) {
+
+    asyncResultHandler.handle(succeededFuture(
+      LoanStorageResource.PostLoanStorageLoansAnonymizeByUserIdResponse
+        .withNoContent()));
   }
 
   @Validate

--- a/src/main/java/org/folio/rest/impl/LoansAPI.java
+++ b/src/main/java/org/folio/rest/impl/LoansAPI.java
@@ -11,6 +11,7 @@ import java.util.Objects;
 import java.util.StringJoiner;
 import java.util.UUID;
 import java.util.function.Function;
+import java.util.regex.Pattern;
 
 import javax.validation.constraints.NotNull;
 import javax.ws.rs.core.Response;
@@ -258,6 +259,18 @@ public class LoansAPI implements LoanStorageResource {
 
     vertxContext.runOnContext(v -> {
       try {
+        final String uuidPattern = "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$";
+
+        if(!Pattern.matches(uuidPattern, userId)) {
+          final Errors errors = ValidationHelper.createValidationErrorMessage(
+            "userId", userId, "Invalid user ID, should be a UUID");
+
+          asyncResultHandler.handle(succeededFuture(
+            LoanStorageResource.PostLoanStorageLoansAnonymizeByUserIdResponse
+              .withJsonUnprocessableEntity(errors)));
+          return;
+        }
+
         final String tenantId = TenantTool.tenantId(okapiHeaders);
 
         final PostgresClient postgresClient = PostgresClient.getInstance(

--- a/src/main/java/org/folio/rest/impl/LoansAPI.java
+++ b/src/main/java/org/folio/rest/impl/LoansAPI.java
@@ -269,7 +269,15 @@ public class LoansAPI implements LoanStorageResource {
             + " AND jsonb->'status'->>'name' = 'Closed'",
           tenantId, "mod_circulation_storage");
 
-        postgresClient.mutate(anonymizeLoansSql,
+        final String anonymizeLoansActionHistorySql = String.format(
+          "UPDATE %s_%s.%s SET jsonb = jsonb - 'userId'"
+            + " WHERE jsonb->>'userId' = '" + userId + "'",
+          tenantId, "mod_circulation_storage", LOAN_HISTORY_TABLE);
+
+        final String combinedAnonymizationSql = anonymizeLoansSql + "; "
+          + anonymizeLoansActionHistorySql;
+
+        postgresClient.mutate(combinedAnonymizationSql,
           reply -> {
             if(reply.succeeded()) {
               asyncResultHandler.handle(succeededFuture(

--- a/src/main/java/org/folio/rest/impl/LoansAPI.java
+++ b/src/main/java/org/folio/rest/impl/LoansAPI.java
@@ -280,7 +280,6 @@ public class LoansAPI implements LoanStorageResource {
           tenantId, "mod_circulation_storage", LOAN_HISTORY_TABLE,
             tenantId, "mod_circulation_storage");
 
-
         //Loan action history needs to go first, as needs to be for specific loans
         final String combinedAnonymizationSql = anonymizeLoansActionHistorySql + "; "
           + anonymizeLoansSql;

--- a/src/main/java/org/folio/rest/impl/LoansAPI.java
+++ b/src/main/java/org/folio/rest/impl/LoansAPI.java
@@ -265,9 +265,10 @@ public class LoansAPI implements LoanStorageResource {
       new ServerErrorResponder(PostLoanStorageLoansAnonymizeByUserIdResponse
         ::withPlainInternalServerError, responseHandler, log);
 
-    final VertxContextRunner runner = new VertxContextRunner();
+    final VertxContextRunner runner = new VertxContextRunner(
+      vertxContext, serverErrorResponder::withError);
 
-    runner.runOnContext(vertxContext, serverErrorResponder::withError, () -> {
+    runner.runOnContext(() -> {
       if(!UUIDValidation.isValidUUID(userId)) {
         final Errors errors = ValidationHelper.createValidationErrorMessage(
           "userId", userId, "Invalid user ID, should be a UUID");

--- a/src/main/java/org/folio/support/ResultHandlerFactory.java
+++ b/src/main/java/org/folio/support/ResultHandlerFactory.java
@@ -4,7 +4,6 @@ import java.util.function.Consumer;
 
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Handler;
-import io.vertx.core.impl.NoStackTraceThrowable;
 
 public class ResultHandlerFactory {
   public Handler<AsyncResult<String>> when(
@@ -35,9 +34,6 @@ public class ResultHandlerFactory {
   }
 
   private boolean hasNoCause(AsyncResult<String> result) {
-    //When a failed vert.x future received a null cause,
-    // it is replaced by an instance of NoStackTraceThrowable
-    return result.cause() == null
-      || result.cause() instanceof NoStackTraceThrowable;
+    return new ServerError().isUnknown(result.cause());
   }
 }

--- a/src/main/java/org/folio/support/ResultHandlerFactory.java
+++ b/src/main/java/org/folio/support/ResultHandlerFactory.java
@@ -1,0 +1,27 @@
+package org.folio.support;
+
+import java.util.function.Consumer;
+
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Handler;
+
+public class ResultHandlerFactory {
+  public Handler<AsyncResult<String>> when(
+    Consumer<String> onSuccess,
+    Consumer<Throwable> onFailure) {
+
+    return reply -> {
+      try {
+        if(reply.succeeded()) {
+          onSuccess.accept(reply.result());
+        }
+        else {
+          onFailure.accept(reply.cause());
+        }
+      }
+      catch(Exception e) {
+        onFailure.accept(e);
+      }
+    };
+  }
+}

--- a/src/main/java/org/folio/support/ResultHandlerFactory.java
+++ b/src/main/java/org/folio/support/ResultHandlerFactory.java
@@ -4,24 +4,40 @@ import java.util.function.Consumer;
 
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Handler;
+import io.vertx.core.impl.NoStackTraceThrowable;
 
 public class ResultHandlerFactory {
   public Handler<AsyncResult<String>> when(
     Consumer<String> onSuccess,
     Consumer<Throwable> onFailure) {
 
-    return reply -> {
+    return result -> {
       try {
-        if(reply.succeeded()) {
-          onSuccess.accept(reply.result());
+        if(result == null) {
+          onFailure.accept(new RuntimeException("Result should not be null"));
+        }
+        else if(result.succeeded()) {
+          onSuccess.accept(result.result());
         }
         else {
-          onFailure.accept(reply.cause());
+          if(hasNoCause(result)) {
+            onFailure.accept(new RuntimeException("Unknown error cause"));
+          }
+          else {
+            onFailure.accept(result.cause());
+          }
         }
       }
       catch(Exception e) {
         onFailure.accept(e);
       }
     };
+  }
+
+  private boolean hasNoCause(AsyncResult<String> result) {
+    //When a failed vert.x future received a null cause,
+    // it is replaced by an instance of NoStackTraceThrowable
+    return result.cause() == null
+      || result.cause() instanceof NoStackTraceThrowable;
   }
 }

--- a/src/main/java/org/folio/support/ServerError.java
+++ b/src/main/java/org/folio/support/ServerError.java
@@ -1,0 +1,11 @@
+package org.folio.support;
+
+import io.vertx.core.impl.NoStackTraceThrowable;
+
+class ServerError {
+  boolean isUnknown(Throwable error) {
+    //When a failed vert.x future received a null cause,
+    // it is replaced by an instance of NoStackTraceThrowable
+    return error == null || error instanceof NoStackTraceThrowable;
+  }
+}

--- a/src/main/java/org/folio/support/ServerErrorResponder.java
+++ b/src/main/java/org/folio/support/ServerErrorResponder.java
@@ -26,9 +26,9 @@ public class ServerErrorResponder {
   }
 
   public void withError(Throwable error) {
-    if (error == null) {
-      final String unknownErrorMessage = "Unknown error cause";
+    final String unknownErrorMessage = "Unknown error cause";
 
+    if (new ServerError().isUnknown(error)) {
       log.error(unknownErrorMessage);
       withMessage(unknownErrorMessage);
     } else {

--- a/src/main/java/org/folio/support/ServerErrorResponder.java
+++ b/src/main/java/org/folio/support/ServerErrorResponder.java
@@ -8,29 +8,36 @@ import javax.ws.rs.core.Response;
 
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Handler;
+import io.vertx.core.logging.Logger;
 
 public class ServerErrorResponder {
   private final Function<String, Response> responseCreator;
   private final Handler<AsyncResult<Response>> handler;
+  private final Logger log;
 
   public ServerErrorResponder(
     Function<String, Response> responseCreator,
-    Handler<AsyncResult<Response>> handler) {
+    Handler<AsyncResult<Response>> handler,
+    Logger log) {
 
     this.responseCreator = responseCreator;
     this.handler = handler;
+    this.log = log;
   }
 
   public void withError(Throwable error) {
-    if(error == null) {
-      withMessage("Unknown error cause");
-    }
-    else {
+    if (error == null) {
+      final String unknownErrorMessage = "Unknown error cause";
+
+      log.error(unknownErrorMessage);
+      withMessage(unknownErrorMessage);
+    } else {
+      log.error(error, error.getMessage());
       withMessage(error.getMessage());
     }
   }
 
-  public void withMessage(String message) {
+  void withMessage(String message) {
     handler.handle(succeededFuture(
       responseCreator.apply(message)));
   }

--- a/src/main/java/org/folio/support/ServerErrorResponder.java
+++ b/src/main/java/org/folio/support/ServerErrorResponder.java
@@ -22,7 +22,12 @@ public class ServerErrorResponder {
   }
 
   public void withError(Throwable error) {
-    withMessage(error.getMessage());
+    if(error == null) {
+      withMessage("Unknown error cause");
+    }
+    else {
+      withMessage(error.getMessage());
+    }
   }
 
   public void withMessage(String message) {

--- a/src/main/java/org/folio/support/ServerErrorResponder.java
+++ b/src/main/java/org/folio/support/ServerErrorResponder.java
@@ -1,0 +1,32 @@
+package org.folio.support;
+
+import static io.vertx.core.Future.succeededFuture;
+
+import java.util.function.Function;
+
+import javax.ws.rs.core.Response;
+
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Handler;
+
+public class ServerErrorResponder {
+  private final Function<String, Response> responseCreator;
+  private final Handler<AsyncResult<Response>> handler;
+
+  public ServerErrorResponder(
+    Function<String, Response> responseCreator,
+    Handler<AsyncResult<Response>> handler) {
+
+    this.responseCreator = responseCreator;
+    this.handler = handler;
+  }
+
+  public void withError(Throwable error) {
+    withMessage(error.getMessage());
+  }
+
+  public void withMessage(String message) {
+    handler.handle(succeededFuture(
+      responseCreator.apply(message)));
+  }
+}

--- a/src/main/java/org/folio/support/UUIDValidation.java
+++ b/src/main/java/org/folio/support/UUIDValidation.java
@@ -1,0 +1,13 @@
+package org.folio.support;
+
+import java.util.regex.Pattern;
+
+public class UUIDValidation {
+  private static final String UUID_PATTERN = "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$";
+
+  private UUIDValidation() { }
+
+  public static Boolean isValidUUID(String prospectiveUuid) {
+    return Pattern.matches(UUID_PATTERN, prospectiveUuid);
+  }
+}

--- a/src/main/java/org/folio/support/VertxContextRunner.java
+++ b/src/main/java/org/folio/support/VertxContextRunner.java
@@ -5,17 +5,24 @@ import java.util.function.Consumer;
 import io.vertx.core.Context;
 
 public class VertxContextRunner {
-  public void runOnContext(
-    Context vertxContext,
-    Consumer<Throwable> onError,
-    Runnable runnable) {
+  private final Context vertxContext;
+  private final Consumer<Throwable> onError;
 
-    vertxContext.runOnContext(v -> {
+  public VertxContextRunner(
+    Context vertxContext,
+    Consumer<Throwable> onError) {
+
+    this.vertxContext = vertxContext;
+    this.onError = onError;
+  }
+
+  public void runOnContext(Runnable runnable) {
+    this.vertxContext.runOnContext(v -> {
       try {
         runnable.run();
       }
       catch(Exception e) {
-        onError.accept(e);
+        this.onError.accept(e);
       }
     });
   }

--- a/src/main/java/org/folio/support/VertxContextRunner.java
+++ b/src/main/java/org/folio/support/VertxContextRunner.java
@@ -22,7 +22,7 @@ public class VertxContextRunner {
         runnable.run();
       }
       catch(Exception e) {
-        this.onError.accept(e);
+        onError.accept(e);
       }
     });
   }

--- a/src/main/java/org/folio/support/VertxContextRunner.java
+++ b/src/main/java/org/folio/support/VertxContextRunner.java
@@ -1,0 +1,22 @@
+package org.folio.support;
+
+import java.util.function.Consumer;
+
+import io.vertx.core.Context;
+
+public class VertxContextRunner {
+  public void runOnContext(
+    Context vertxContext,
+    Consumer<Throwable> onError,
+    Runnable runnable) {
+
+    vertxContext.runOnContext(v -> {
+      try {
+        runnable.run();
+      }
+      catch(Exception e) {
+        onError.accept(e);
+      }
+    });
+  }
+}

--- a/src/test/java/org/folio/rest/api/StorageTestSuite.java
+++ b/src/test/java/org/folio/rest/api/StorageTestSuite.java
@@ -84,8 +84,8 @@ public class StorageTestSuite {
           "org.folio.circulation.storage.test.config",
             "/postgres-conf-local.json");
 
-        log.info("Using external configuration settings: '%s'",
-          postgresConfigPath);
+        log.info(String.format(
+          "Using external configuration settings: '%s'", postgresConfigPath));
 
         PostgresClient.setConfigFilePath(postgresConfigPath);
         break;

--- a/src/test/java/org/folio/rest/api/StorageTestSuite.java
+++ b/src/test/java/org/folio/rest/api/StorageTestSuite.java
@@ -13,6 +13,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
 import org.folio.rest.RestVerticle;
+import org.folio.rest.api.loans.LoansAnonymizationApiTest;
 import org.folio.rest.persist.PostgresClient;
 import org.folio.rest.support.HttpClient;
 import org.folio.rest.support.Response;
@@ -35,6 +36,7 @@ import io.vertx.ext.sql.ResultSet;
 
 @Suite.SuiteClasses({
   LoansApiTest.class,
+  LoansAnonymizationApiTest.class,
   LoanRulesApiTest.class,
   FixedDueDateApiTest.class,
   LoanPoliciesApiTest.class,
@@ -150,7 +152,7 @@ public class StorageTestSuite {
 		return !initialised;
 	}
 
-	static void deleteAll(URL rootUrl) {
+	public static void deleteAll(URL rootUrl) {
 		HttpClient client = new HttpClient(getVertx());
 
 		CompletableFuture<Response> deleteAllFinished = new CompletableFuture<>();
@@ -170,7 +172,7 @@ public class StorageTestSuite {
 		}
 	}
 
-	static void checkForMismatchedIDs(String table) {
+	public static void checkForMismatchedIDs(String table) {
 		try {
 			ResultSet results = getRecordsWithUnmatchedIds(TENANT_ID, table);
 

--- a/src/test/java/org/folio/rest/api/loans/LoansAnonymizationApiTest.java
+++ b/src/test/java/org/folio/rest/api/loans/LoansAnonymizationApiTest.java
@@ -254,6 +254,48 @@ public class LoansAnonymizationApiTest extends ApiTests {
     hasLoanHistoryForUser(firstUserId, loanForOtherUser.getId());
   }
 
+  @Test
+  public void shouldOnlyAnonymizeClosedLoansHistoryWhenBothArePresent()
+    throws MalformedURLException,
+    ExecutionException,
+    InterruptedException,
+    TimeoutException {
+
+    final UUID userId = UUID.randomUUID();
+
+    final LoanRequestBuilder loanForUser = new LoanRequestBuilder()
+      .withUserId(userId);
+
+    loansClient.create(loanForUser
+      .closed()
+      .withItemId(UUID.randomUUID())
+      .withId(UUID.randomUUID())).getId();
+
+    loansClient.create(loanForUser
+      .closed()
+      .withItemId(UUID.randomUUID())
+      .withId(UUID.randomUUID())).getId();
+
+    final String firstOpenLoanId = loansClient.create(loanForUser
+      .open()
+      .withItemId(UUID.randomUUID())
+      .withId(UUID.randomUUID())).getId();
+
+    final String secondOpenLoanId = loansClient.create(loanForUser
+      .open()
+      .withItemId(UUID.randomUUID())
+      .withId(UUID.randomUUID())).getId();
+
+    loansClient.create(loanForUser
+      .closed()
+      .withItemId(UUID.randomUUID())
+      .withId(UUID.randomUUID())).getId();
+
+    anonymizeLoansFor(userId);
+
+    hasLoanHistoryForUser(userId, firstOpenLoanId, secondOpenLoanId);
+  }
+  
   private void anonymizeLoansFor(UUID userId)
     throws MalformedURLException,
     InterruptedException,

--- a/src/test/java/org/folio/rest/api/loans/LoansAnonymizationApiTest.java
+++ b/src/test/java/org/folio/rest/api/loans/LoansAnonymizationApiTest.java
@@ -107,20 +107,7 @@ public class LoansAnonymizationApiTest extends ApiTests {
 
     anonymizeLoansFor(userId);
 
-    final MultipleRecords<JsonObject> wrappedLoans = getLoansForUser(userId);
-
-    assertThat(wrappedLoans.getTotalRecords(), is(2));
-
-    final Collection<JsonObject> fetchedLoans = wrappedLoans.getRecords();
-
-    assertThat(fetchedLoans.size(), is(2));
-
-    final List<String> fetchedLoanIds = fetchedLoans.stream()
-      .map(loan -> loan.getString("id"))
-      .collect(Collectors.toList());
-
-    assertThat(fetchedLoanIds,
-      containsInAnyOrder(firstOpenLoanId, secondOpenLoanId));
+    hasOpenLoansForUser(userId, firstOpenLoanId, secondOpenLoanId);
   }
 
   @Test
@@ -162,20 +149,7 @@ public class LoansAnonymizationApiTest extends ApiTests {
 
     anonymizeLoansFor(userId);
 
-    final MultipleRecords<JsonObject> wrappedLoans = getLoansForUser(userId);
-
-    assertThat(wrappedLoans.getTotalRecords(), is(2));
-
-    final Collection<JsonObject> fetchedLoans = wrappedLoans.getRecords();
-
-    assertThat(fetchedLoans.size(), is(2));
-
-    final List<String> fetchedLoanIds = fetchedLoans.stream()
-      .map(loan -> loan.getString("id"))
-      .collect(Collectors.toList());
-
-    assertThat(fetchedLoanIds,
-      containsInAnyOrder(firstOpenLoanId, secondOpenLoanId));
+    hasOpenLoansForUser(userId, firstOpenLoanId, secondOpenLoanId);
   }
 
   @Test
@@ -224,5 +198,26 @@ public class LoansAnonymizationApiTest extends ApiTests {
     TimeoutException {
 
     return loansClient.getMany(String.format("userId==%s", userId));
+  }
+
+  private void hasOpenLoansForUser(UUID userId, String... openLoanIds)
+    throws MalformedURLException,
+    InterruptedException,
+    ExecutionException,
+    TimeoutException {
+
+    final MultipleRecords<JsonObject> wrappedLoans = getLoansForUser(userId);
+
+    assertThat(wrappedLoans.getTotalRecords(), is(openLoanIds.length));
+
+    final Collection<JsonObject> fetchedLoans = wrappedLoans.getRecords();
+
+    assertThat(fetchedLoans.size(), is(openLoanIds.length));
+
+    final List<String> fetchedLoanIds = fetchedLoans.stream()
+      .map(loan -> loan.getString("id"))
+      .collect(Collectors.toList());
+
+    assertThat(fetchedLoanIds, containsInAnyOrder(openLoanIds));
   }
 }

--- a/src/test/java/org/folio/rest/api/loans/LoansAnonymizationApiTest.java
+++ b/src/test/java/org/folio/rest/api/loans/LoansAnonymizationApiTest.java
@@ -1,5 +1,6 @@
 package org.folio.rest.api.loans;
 
+import static org.folio.rest.support.http.InterfaceUrls.loanStorageUrl;
 import static org.folio.rest.support.matchers.HttpResponseStatusCodeMatchers.isNoContent;
 import static org.hamcrest.junit.MatcherAssert.assertThat;
 
@@ -14,7 +15,6 @@ import org.folio.rest.api.StorageTestSuite;
 import org.folio.rest.support.ApiTests;
 import org.folio.rest.support.ResponseHandler;
 import org.folio.rest.support.TextResponse;
-import org.folio.rest.support.http.InterfaceUrls;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -24,7 +24,7 @@ public class LoansAnonymizationApiTest extends ApiTests {
   public void beforeEach()
     throws MalformedURLException {
 
-    StorageTestSuite.deleteAll(InterfaceUrls.loanStorageUrl());
+    StorageTestSuite.deleteAll(loanStorageUrl());
   }
 
   @After
@@ -39,11 +39,20 @@ public class LoansAnonymizationApiTest extends ApiTests {
     InterruptedException,
     TimeoutException {
 
-    final UUID unknownUser = UUID.randomUUID();
+    final UUID unknownUserId = UUID.randomUUID();
+
+    anonymizeLoansFor(unknownUserId);
+  }
+
+  private void anonymizeLoansFor(UUID userId)
+    throws MalformedURLException,
+    InterruptedException,
+    ExecutionException,
+    TimeoutException {
 
     final CompletableFuture<TextResponse> postCompleted = new CompletableFuture<>();
 
-    client.post(InterfaceUrls.loanStorageUrl("/anonymize/" + unknownUser),
+    client.post(loanStorageUrl("/anonymize/" + userId),
       StorageTestSuite.TENANT_ID, ResponseHandler.text(postCompleted));
 
     final TextResponse postResponse = postCompleted.get(5, TimeUnit.SECONDS);

--- a/src/test/java/org/folio/rest/api/loans/LoansAnonymizationApiTest.java
+++ b/src/test/java/org/folio/rest/api/loans/LoansAnonymizationApiTest.java
@@ -3,6 +3,7 @@ package org.folio.rest.api.loans;
 import static org.folio.rest.support.http.InterfaceUrls.loanStorageUrl;
 import static org.folio.rest.support.matchers.HttpResponseStatusCodeMatchers.isNoContent;
 import static org.folio.rest.support.matchers.UUIDMatchers.isUUID;
+import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.junit.MatcherAssert.assertThat;
 
 import java.net.MalformedURLException;
@@ -50,6 +51,29 @@ public class LoansAnonymizationApiTest extends ApiTests {
     final UUID unknownUserId = UUID.randomUUID();
 
     anonymizeLoansFor(unknownUserId);
+  }
+
+  @Test
+  public void shouldAnonymizeSingleClosedLoanForUser()
+    throws MalformedURLException,
+    ExecutionException,
+    InterruptedException,
+    TimeoutException {
+
+    final UUID userId = UUID.randomUUID();
+
+    final IndividualResource loan = loansClient.create(
+      new LoanRequestBuilder()
+        .closed()
+        .withUserId(userId));
+
+    anonymizeLoansFor(userId);
+
+    final IndividualResource fetchedLoan = loansClient.getById(
+      loan.getId());
+
+    assertThat("Should no longer have a user ID",
+      fetchedLoan.getJson().containsKey("userId"), is(false));
   }
 
   @Test

--- a/src/test/java/org/folio/rest/api/loans/LoansAnonymizationApiTest.java
+++ b/src/test/java/org/folio/rest/api/loans/LoansAnonymizationApiTest.java
@@ -2,6 +2,7 @@ package org.folio.rest.api.loans;
 
 import static org.folio.rest.support.http.InterfaceUrls.loanStorageUrl;
 import static org.folio.rest.support.matchers.HttpResponseStatusCodeMatchers.isNoContent;
+import static org.hamcrest.core.Is.is;
 import static org.hamcrest.junit.MatcherAssert.assertThat;
 
 import java.net.MalformedURLException;
@@ -13,13 +14,20 @@ import java.util.concurrent.TimeoutException;
 
 import org.folio.rest.api.StorageTestSuite;
 import org.folio.rest.support.ApiTests;
+import org.folio.rest.support.IndividualResource;
 import org.folio.rest.support.ResponseHandler;
 import org.folio.rest.support.TextResponse;
+import org.folio.rest.support.builders.LoanRequestBuilder;
+import org.folio.rest.support.http.AssertingRecordClient;
+import org.folio.rest.support.http.InterfaceUrls;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
 public class LoansAnonymizationApiTest extends ApiTests {
+  private final AssertingRecordClient loansClient = new AssertingRecordClient(
+    client, StorageTestSuite.TENANT_ID, InterfaceUrls::loanStorageUrl);
+
   @Before
   public void beforeEach()
     throws MalformedURLException {
@@ -42,6 +50,29 @@ public class LoansAnonymizationApiTest extends ApiTests {
     final UUID unknownUserId = UUID.randomUUID();
 
     anonymizeLoansFor(unknownUserId);
+  }
+
+  @Test
+  public void shouldNotAnonymizeLoansForOtherUser()
+    throws MalformedURLException,
+    ExecutionException,
+    InterruptedException,
+    TimeoutException {
+
+    final UUID firstUserId = UUID.randomUUID();
+    final UUID secondUserId = UUID.randomUUID();
+
+    final IndividualResource otherUsersLoan = loansClient.create(
+      new LoanRequestBuilder()
+        .closed()
+        .withUserId(firstUserId));
+
+    anonymizeLoansFor(secondUserId);
+
+    final IndividualResource fetchedLoan = loansClient.getById(
+      otherUsersLoan.getId());
+
+    assertThat(fetchedLoan.getJson().getString("userId"), is(firstUserId.toString()));
   }
 
   private void anonymizeLoansFor(UUID userId)

--- a/src/test/java/org/folio/rest/api/loans/LoansAnonymizationApiTest.java
+++ b/src/test/java/org/folio/rest/api/loans/LoansAnonymizationApiTest.java
@@ -83,6 +83,9 @@ public class LoansAnonymizationApiTest extends ApiTests {
 
     assertThat("Should no longer have a user ID",
       fetchedLoan.getJson().containsKey("userId"), is(false));
+
+    assertThat("Anonymized loans should still be present",
+      loansClient.getAll().getTotalRecords(), is(1));
   }
 
   @Test
@@ -110,6 +113,9 @@ public class LoansAnonymizationApiTest extends ApiTests {
     anonymizeLoansFor(userId);
 
     hasOpenLoansForUser(userId, firstOpenLoanId, secondOpenLoanId);
+
+    assertThat("Anonymized loans should still be present",
+      loansClient.getAll().getTotalRecords(), is(2));
   }
 
   @Test
@@ -152,6 +158,9 @@ public class LoansAnonymizationApiTest extends ApiTests {
     anonymizeLoansFor(userId);
 
     hasOpenLoansForUser(userId, firstOpenLoanId, secondOpenLoanId);
+
+    assertThat("Anonymized loans should still be present",
+      loansClient.getAll().getTotalRecords(), is(5));
   }
 
   @Test
@@ -175,6 +184,9 @@ public class LoansAnonymizationApiTest extends ApiTests {
       otherUsersLoan.getId());
 
     assertThat(fetchedLoan.getJson().getString("userId"), isUUID(firstUserId));
+
+    assertThat("Anonymized loans should still be present",
+      loansClient.getAll().getTotalRecords(), is(1));
   }
 
   @Test
@@ -295,7 +307,7 @@ public class LoansAnonymizationApiTest extends ApiTests {
 
     hasLoanHistoryForUser(userId, firstOpenLoanId, secondOpenLoanId);
   }
-  
+
   private void anonymizeLoansFor(UUID userId)
     throws MalformedURLException,
     InterruptedException,

--- a/src/test/java/org/folio/rest/api/loans/LoansAnonymizationApiTest.java
+++ b/src/test/java/org/folio/rest/api/loans/LoansAnonymizationApiTest.java
@@ -3,6 +3,7 @@ package org.folio.rest.api.loans;
 import static org.folio.rest.support.JsonArrayHelper.toList;
 import static org.folio.rest.support.http.InterfaceUrls.loanStorageUrl;
 import static org.folio.rest.support.matchers.HttpResponseStatusCodeMatchers.isNoContent;
+import static org.folio.rest.support.matchers.HttpResponseStatusCodeMatchers.isOk;
 import static org.folio.rest.support.matchers.UUIDMatchers.isUUID;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.collection.IsIterableContainingInAnyOrder.containsInAnyOrder;
@@ -107,16 +108,7 @@ public class LoansAnonymizationApiTest extends ApiTests {
 
     anonymizeLoansFor(userId);
 
-    final CompletableFuture<JsonResponse> fetchAllCompleted = new CompletableFuture<>();
-
-    client.get(loanStorageUrl(),
-      String.format("query=userId==%s", userId), StorageTestSuite.TENANT_ID,
-      ResponseHandler.json(fetchAllCompleted));
-
-    final JsonResponse fetchedLoansResponse = fetchAllCompleted
-      .get(5, TimeUnit.SECONDS);
-
-    final JsonObject wrappedLoans = fetchedLoansResponse.getJson();
+    final JsonObject wrappedLoans = getLoansForUser(userId);
 
     assertThat(wrappedLoans.getInteger("totalRecords"), is(2));
 
@@ -170,16 +162,7 @@ public class LoansAnonymizationApiTest extends ApiTests {
 
     anonymizeLoansFor(userId);
 
-    final CompletableFuture<JsonResponse> fetchAllCompleted = new CompletableFuture<>();
-
-    client.get(loanStorageUrl(),
-      String.format("query=userId==%s", userId), StorageTestSuite.TENANT_ID,
-      ResponseHandler.json(fetchAllCompleted));
-
-    final JsonResponse fetchedLoansResponse = fetchAllCompleted
-      .get(5, TimeUnit.SECONDS);
-
-    final JsonObject wrappedLoans = fetchedLoansResponse.getJson();
+    final JsonObject wrappedLoans = getLoansForUser(userId);
 
     assertThat(wrappedLoans.getInteger("totalRecords"), is(2));
 
@@ -231,5 +214,25 @@ public class LoansAnonymizationApiTest extends ApiTests {
     final TextResponse postResponse = postCompleted.get(5, TimeUnit.SECONDS);
 
     assertThat(postResponse, isNoContent());
+  }
+
+  private JsonObject getLoansForUser(UUID userId)
+    throws MalformedURLException,
+    InterruptedException,
+    ExecutionException,
+    TimeoutException {
+
+    final CompletableFuture<JsonResponse> fetchAllCompleted = new CompletableFuture<>();
+
+    client.get(loanStorageUrl(),
+      "query=" + String.format("userId==%s", userId), StorageTestSuite.TENANT_ID,
+      ResponseHandler.json(fetchAllCompleted));
+
+    final JsonResponse fetchedLoansResponse = fetchAllCompleted
+      .get(5, TimeUnit.SECONDS);
+
+    assertThat(fetchedLoansResponse, isOk());
+
+    return fetchedLoansResponse.getJson();
   }
 }

--- a/src/test/java/org/folio/rest/api/loans/LoansAnonymizationApiTest.java
+++ b/src/test/java/org/folio/rest/api/loans/LoansAnonymizationApiTest.java
@@ -1,0 +1,53 @@
+package org.folio.rest.api.loans;
+
+import static org.folio.rest.support.matchers.HttpResponseStatusCodeMatchers.isNoContent;
+import static org.hamcrest.junit.MatcherAssert.assertThat;
+
+import java.net.MalformedURLException;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import org.folio.rest.api.StorageTestSuite;
+import org.folio.rest.support.ApiTests;
+import org.folio.rest.support.ResponseHandler;
+import org.folio.rest.support.TextResponse;
+import org.folio.rest.support.http.InterfaceUrls;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+public class LoansAnonymizationApiTest extends ApiTests {
+  @Before
+  public void beforeEach()
+    throws MalformedURLException {
+
+    StorageTestSuite.deleteAll(InterfaceUrls.loanStorageUrl());
+  }
+
+  @After
+  public void checkIdsAfterEach() {
+    StorageTestSuite.checkForMismatchedIDs("loan");
+  }
+
+  @Test
+  public void shouldDoNothingWhenNoLoansForUser()
+    throws MalformedURLException,
+    ExecutionException,
+    InterruptedException,
+    TimeoutException {
+
+    final UUID unknownUser = UUID.randomUUID();
+
+    final CompletableFuture<TextResponse> postCompleted = new CompletableFuture<>();
+
+    client.post(InterfaceUrls.loanStorageUrl("/anonymize/" + unknownUser),
+      StorageTestSuite.TENANT_ID, ResponseHandler.text(postCompleted));
+
+    final TextResponse postResponse = postCompleted.get(5, TimeUnit.SECONDS);
+
+    assertThat(postResponse, isNoContent());
+  }
+}

--- a/src/test/java/org/folio/rest/api/loans/LoansAnonymizationApiTest.java
+++ b/src/test/java/org/folio/rest/api/loans/LoansAnonymizationApiTest.java
@@ -3,7 +3,6 @@ package org.folio.rest.api.loans;
 import static org.folio.rest.support.JsonArrayHelper.toList;
 import static org.folio.rest.support.http.InterfaceUrls.loanStorageUrl;
 import static org.folio.rest.support.matchers.HttpResponseStatusCodeMatchers.isNoContent;
-import static org.folio.rest.support.matchers.HttpResponseStatusCodeMatchers.isOk;
 import static org.folio.rest.support.matchers.UUIDMatchers.isUUID;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.collection.IsIterableContainingInAnyOrder.containsInAnyOrder;
@@ -21,7 +20,6 @@ import java.util.stream.Collectors;
 import org.folio.rest.api.StorageTestSuite;
 import org.folio.rest.support.ApiTests;
 import org.folio.rest.support.IndividualResource;
-import org.folio.rest.support.JsonResponse;
 import org.folio.rest.support.ResponseHandler;
 import org.folio.rest.support.TextResponse;
 import org.folio.rest.support.builders.LoanRequestBuilder;
@@ -222,17 +220,6 @@ public class LoansAnonymizationApiTest extends ApiTests {
     ExecutionException,
     TimeoutException {
 
-    final CompletableFuture<JsonResponse> fetchAllCompleted = new CompletableFuture<>();
-
-    client.get(loanStorageUrl(),
-      "query=" + String.format("userId==%s", userId), StorageTestSuite.TENANT_ID,
-      ResponseHandler.json(fetchAllCompleted));
-
-    final JsonResponse fetchedLoansResponse = fetchAllCompleted
-      .get(5, TimeUnit.SECONDS);
-
-    assertThat(fetchedLoansResponse, isOk());
-
-    return fetchedLoansResponse.getJson();
+    return loansClient.getMany(String.format("userId==%s", userId));
   }
 }

--- a/src/test/java/org/folio/rest/api/loans/LoansAnonymizationApiTest.java
+++ b/src/test/java/org/folio/rest/api/loans/LoansAnonymizationApiTest.java
@@ -2,7 +2,7 @@ package org.folio.rest.api.loans;
 
 import static org.folio.rest.support.http.InterfaceUrls.loanStorageUrl;
 import static org.folio.rest.support.matchers.HttpResponseStatusCodeMatchers.isNoContent;
-import static org.hamcrest.core.Is.is;
+import static org.folio.rest.support.matchers.UUIDMatchers.isUUID;
 import static org.hamcrest.junit.MatcherAssert.assertThat;
 
 import java.net.MalformedURLException;
@@ -72,7 +72,7 @@ public class LoansAnonymizationApiTest extends ApiTests {
     final IndividualResource fetchedLoan = loansClient.getById(
       otherUsersLoan.getId());
 
-    assertThat(fetchedLoan.getJson().getString("userId"), is(firstUserId.toString()));
+    assertThat(fetchedLoan.getJson().getString("userId"), isUUID(firstUserId));
   }
 
   private void anonymizeLoansFor(UUID userId)

--- a/src/test/java/org/folio/rest/api/loans/LoansAnonymizationApiTest.java
+++ b/src/test/java/org/folio/rest/api/loans/LoansAnonymizationApiTest.java
@@ -46,7 +46,7 @@ public class LoansAnonymizationApiTest extends ApiTests {
   }
 
   @Test
-  public void shouldDoNothingWhenNoLoansForUser()
+  public void shouldSucceedEvenWhenNoLoansForUser()
     throws MalformedURLException,
     ExecutionException,
     InterruptedException,

--- a/src/test/java/org/folio/rest/api/loans/LoansAnonymizationApiTest.java
+++ b/src/test/java/org/folio/rest/api/loans/LoansAnonymizationApiTest.java
@@ -1,6 +1,5 @@
 package org.folio.rest.api.loans;
 
-import static org.folio.rest.support.JsonArrayHelper.toList;
 import static org.folio.rest.support.http.InterfaceUrls.loanStorageUrl;
 import static org.folio.rest.support.matchers.HttpResponseStatusCodeMatchers.isNoContent;
 import static org.folio.rest.support.matchers.UUIDMatchers.isUUID;
@@ -9,6 +8,7 @@ import static org.hamcrest.collection.IsIterableContainingInAnyOrder.containsInA
 import static org.hamcrest.junit.MatcherAssert.assertThat;
 
 import java.net.MalformedURLException;
+import java.util.Collection;
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
@@ -20,6 +20,7 @@ import java.util.stream.Collectors;
 import org.folio.rest.api.StorageTestSuite;
 import org.folio.rest.support.ApiTests;
 import org.folio.rest.support.IndividualResource;
+import org.folio.rest.support.MultipleRecords;
 import org.folio.rest.support.ResponseHandler;
 import org.folio.rest.support.TextResponse;
 import org.folio.rest.support.builders.LoanRequestBuilder;
@@ -106,11 +107,11 @@ public class LoansAnonymizationApiTest extends ApiTests {
 
     anonymizeLoansFor(userId);
 
-    final JsonObject wrappedLoans = getLoansForUser(userId);
+    final MultipleRecords<JsonObject> wrappedLoans = getLoansForUser(userId);
 
-    assertThat(wrappedLoans.getInteger("totalRecords"), is(2));
+    assertThat(wrappedLoans.getTotalRecords(), is(2));
 
-    final List<JsonObject> fetchedLoans = toList(wrappedLoans, "loans");
+    final Collection<JsonObject> fetchedLoans = wrappedLoans.getRecords();
 
     assertThat(fetchedLoans.size(), is(2));
 
@@ -118,7 +119,8 @@ public class LoansAnonymizationApiTest extends ApiTests {
       .map(loan -> loan.getString("id"))
       .collect(Collectors.toList());
 
-    assertThat(fetchedLoanIds, containsInAnyOrder(firstOpenLoanId, secondOpenLoanId));
+    assertThat(fetchedLoanIds,
+      containsInAnyOrder(firstOpenLoanId, secondOpenLoanId));
   }
 
   @Test
@@ -160,11 +162,11 @@ public class LoansAnonymizationApiTest extends ApiTests {
 
     anonymizeLoansFor(userId);
 
-    final JsonObject wrappedLoans = getLoansForUser(userId);
+    final MultipleRecords<JsonObject> wrappedLoans = getLoansForUser(userId);
 
-    assertThat(wrappedLoans.getInteger("totalRecords"), is(2));
+    assertThat(wrappedLoans.getTotalRecords(), is(2));
 
-    final List<JsonObject> fetchedLoans = toList(wrappedLoans, "loans");
+    final Collection<JsonObject> fetchedLoans = wrappedLoans.getRecords();
 
     assertThat(fetchedLoans.size(), is(2));
 
@@ -172,7 +174,8 @@ public class LoansAnonymizationApiTest extends ApiTests {
       .map(loan -> loan.getString("id"))
       .collect(Collectors.toList());
 
-    assertThat(fetchedLoanIds, containsInAnyOrder(firstOpenLoanId, secondOpenLoanId));
+    assertThat(fetchedLoanIds,
+      containsInAnyOrder(firstOpenLoanId, secondOpenLoanId));
   }
 
   @Test
@@ -214,7 +217,7 @@ public class LoansAnonymizationApiTest extends ApiTests {
     assertThat(postResponse, isNoContent());
   }
 
-  private JsonObject getLoansForUser(UUID userId)
+  private MultipleRecords<JsonObject> getLoansForUser(UUID userId)
     throws MalformedURLException,
     InterruptedException,
     ExecutionException,

--- a/src/test/java/org/folio/rest/support/MultipleRecords.java
+++ b/src/test/java/org/folio/rest/support/MultipleRecords.java
@@ -1,0 +1,39 @@
+package org.folio.rest.support;
+
+import java.util.Collection;
+import java.util.List;
+
+import io.vertx.core.json.JsonObject;
+
+public class MultipleRecords<T> {
+  private static final String TOTAL_RECORDS_PROPERTY_NAME = "totalRecords";
+
+  private final Collection<T> records;
+  private final Integer totalRecords;
+
+  private MultipleRecords(Collection<T> records, Integer totalRecords) {
+    this.records = records;
+    this.totalRecords = totalRecords;
+  }
+
+  public static MultipleRecords<JsonObject> fromJson(
+    JsonObject wrapper,
+    String collectionPropertyName) {
+
+    List<JsonObject> wrappedRecords = JsonArrayHelper.toList(wrapper,
+      collectionPropertyName);
+
+    Integer totalRecords = wrapper.getInteger(TOTAL_RECORDS_PROPERTY_NAME);
+
+    return new MultipleRecords<>(
+      wrappedRecords, totalRecords);
+  }
+
+  public Collection<T> getRecords() {
+    return records;
+  }
+
+  public Integer getTotalRecords() {
+    return totalRecords;
+  }
+}

--- a/src/test/java/org/folio/rest/support/http/AssertingRecordClient.java
+++ b/src/test/java/org/folio/rest/support/http/AssertingRecordClient.java
@@ -17,6 +17,7 @@ import org.folio.rest.api.StorageTestSuite;
 import org.folio.rest.support.HttpClient;
 import org.folio.rest.support.IndividualResource;
 import org.folio.rest.support.JsonResponse;
+import org.folio.rest.support.MultipleRecords;
 import org.folio.rest.support.ResponseHandler;
 import org.folio.rest.support.TextResponse;
 import org.folio.rest.support.builders.Builder;
@@ -193,7 +194,7 @@ public class AssertingRecordClient {
     assertThat("Failed to delete record", deleteResponse, isNoContent());
   }
 
-  public JsonObject getMany(String cqlQuery)
+  public MultipleRecords<JsonObject> getMany(String cqlQuery)
     throws MalformedURLException,
     InterruptedException,
     ExecutionException,
@@ -210,6 +211,6 @@ public class AssertingRecordClient {
 
     assertThat(fetchedLoansResponse, isOk());
 
-    return fetchedLoansResponse.getJson();
+    return MultipleRecords.fromJson(fetchedLoansResponse.getJson(), "loans");
   }
 }

--- a/src/test/java/org/folio/rest/support/http/AssertingRecordClient.java
+++ b/src/test/java/org/folio/rest/support/http/AssertingRecordClient.java
@@ -213,4 +213,23 @@ public class AssertingRecordClient {
 
     return MultipleRecords.fromJson(fetchedLoansResponse.getJson(), "loans");
   }
+
+  public MultipleRecords<JsonObject> getAll()
+    throws MalformedURLException,
+    InterruptedException,
+    ExecutionException,
+    TimeoutException {
+
+    final CompletableFuture<JsonResponse> fetchManyCompleted = new CompletableFuture<>();
+
+    this.client.get(urlMaker.combine(""), StorageTestSuite.TENANT_ID,
+      ResponseHandler.json(fetchManyCompleted));
+
+    final JsonResponse fetchedLoansResponse = fetchManyCompleted
+      .get(5, TimeUnit.SECONDS);
+
+    assertThat(fetchedLoansResponse, isOk());
+
+    return MultipleRecords.fromJson(fetchedLoansResponse.getJson(), "loans");
+  }
 }

--- a/src/test/java/org/folio/rest/support/http/AssertingRecordClient.java
+++ b/src/test/java/org/folio/rest/support/http/AssertingRecordClient.java
@@ -20,6 +20,7 @@ import org.folio.rest.support.JsonResponse;
 import org.folio.rest.support.ResponseHandler;
 import org.folio.rest.support.TextResponse;
 import org.folio.rest.support.builders.Builder;
+import org.folio.rest.support.builders.LoanRequestBuilder;
 
 import io.vertx.core.json.JsonObject;
 
@@ -35,6 +36,15 @@ public class AssertingRecordClient {
     this.client = client;
     this.tenantId = tenantId;
     this.urlMaker = urlMaker;
+  }
+
+  public IndividualResource create(LoanRequestBuilder builder)
+    throws InterruptedException,
+    ExecutionException,
+    TimeoutException,
+    MalformedURLException {
+
+    return create(builder.create());
   }
 
   public IndividualResource create(JsonObject representation)
@@ -71,6 +81,15 @@ public class AssertingRecordClient {
       ResponseHandler.json(createCompleted));
 
     return createCompleted.get(5, TimeUnit.SECONDS);
+  }
+
+  public IndividualResource getById(String id)
+    throws InterruptedException,
+    ExecutionException,
+    TimeoutException,
+    MalformedURLException {
+
+    return getById(UUID.fromString(id));
   }
 
   public IndividualResource getById(UUID id)

--- a/src/test/java/org/folio/rest/support/http/AssertingRecordClient.java
+++ b/src/test/java/org/folio/rest/support/http/AssertingRecordClient.java
@@ -192,4 +192,24 @@ public class AssertingRecordClient {
 
     assertThat("Failed to delete record", deleteResponse, isNoContent());
   }
+
+  public JsonObject getMany(String cqlQuery)
+    throws MalformedURLException,
+    InterruptedException,
+    ExecutionException,
+    TimeoutException {
+
+    final CompletableFuture<JsonResponse> fetchManyCompleted = new CompletableFuture<>();
+
+    this.client.get(urlMaker.combine(""),
+      "query=" + cqlQuery, StorageTestSuite.TENANT_ID,
+      ResponseHandler.json(fetchManyCompleted));
+
+    final JsonResponse fetchedLoansResponse = fetchManyCompleted
+      .get(5, TimeUnit.SECONDS);
+
+    assertThat(fetchedLoansResponse, isOk());
+
+    return fetchedLoansResponse.getJson();
+  }
 }

--- a/src/test/java/org/folio/rest/support/matchers/UUIDMatchers.java
+++ b/src/test/java/org/folio/rest/support/matchers/UUIDMatchers.java
@@ -1,0 +1,30 @@
+package org.folio.rest.support.matchers;
+
+import static org.hamcrest.CoreMatchers.is;
+
+import java.util.UUID;
+
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.TypeSafeDiagnosingMatcher;
+
+public class UUIDMatchers {
+  public static TypeSafeDiagnosingMatcher<String> isUUID(UUID expected) {
+    return new TypeSafeDiagnosingMatcher<String>() {
+      @Override
+      public void describeTo(Description description) {
+        description
+          .appendText("a string UUID of ").appendValue(expected);
+      }
+
+      @Override
+      protected boolean matchesSafely(String actual, Description description) {
+        Matcher<String> uuidMatcher = is(expected.toString());
+
+        uuidMatcher.describeMismatch(actual, description);
+
+        return uuidMatcher.matches(actual);
+      }
+    };
+  }
+}

--- a/src/test/java/org/folio/support/ResultHandlerFactoryTest.java
+++ b/src/test/java/org/folio/support/ResultHandlerFactoryTest.java
@@ -1,0 +1,57 @@
+package org.folio.support;
+
+import static io.vertx.core.Future.failedFuture;
+import static io.vertx.core.Future.succeededFuture;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.junit.Test;
+
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Handler;
+
+public class ResultHandlerFactoryTest {
+  @Test
+  public void shouldExecuteConsumerOnSuccess() {
+    final ResultHandlerFactory resultHandlerFactory = new ResultHandlerFactory();
+
+    AtomicBoolean onSuccessCalled = new AtomicBoolean(false);
+    AtomicBoolean onFailureCalled = new AtomicBoolean(false);
+
+    final Handler<AsyncResult<String>> resultHandler =
+      resultHandlerFactory.when(
+        s -> onSuccessCalled.set(true),
+        e -> onFailureCalled.set(true));
+
+    resultHandler.handle(succeededFuture("foo"));
+
+    assertThat("Success consumer should be called",
+      onSuccessCalled.get(), is(true));
+
+    assertThat("Failure consumer should not be called",
+      onFailureCalled.get(), is(false));
+  }
+
+  @Test
+  public void shouldExecuteConsumerOnFailure() {
+    final ResultHandlerFactory resultHandlerFactory = new ResultHandlerFactory();
+
+    AtomicBoolean onSuccessCalled = new AtomicBoolean(false);
+    AtomicBoolean onFailureCalled = new AtomicBoolean(false);
+
+    final Handler<AsyncResult<String>> resultHandler =
+      resultHandlerFactory.when(
+        s -> onSuccessCalled.set(true),
+        e -> onFailureCalled.set(true));
+
+    resultHandler.handle(failedFuture(new RuntimeException("unexpected failure")));
+
+    assertThat("Failure consumer should be called",
+      onFailureCalled.get(), is(true));
+
+    assertThat("Success consumer should not be called",
+      onSuccessCalled.get(), is(false));
+  }
+}

--- a/src/test/java/org/folio/support/ResultHandlerTest.java
+++ b/src/test/java/org/folio/support/ResultHandlerTest.java
@@ -1,5 +1,0 @@
-package org.folio.support;
-
-public class ResultHandlerTest {
-
-}

--- a/src/test/java/org/folio/support/ResultHandlerTest.java
+++ b/src/test/java/org/folio/support/ResultHandlerTest.java
@@ -1,0 +1,5 @@
+package org.folio.support;
+
+public class ResultHandlerTest {
+
+}

--- a/src/test/java/org/folio/support/ServerErrorResponderTest.java
+++ b/src/test/java/org/folio/support/ServerErrorResponderTest.java
@@ -1,0 +1,61 @@
+package org.folio.support;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import javax.ws.rs.core.Response;
+
+import org.junit.Test;
+
+import io.vertx.core.AsyncResult;
+
+public class ServerErrorResponderTest {
+  @Test
+  public void shouldRespondWithMessage()
+    throws InterruptedException,
+    ExecutionException,
+    TimeoutException {
+
+    final CompletableFuture<AsyncResult<Response>> responseFuture
+      = new CompletableFuture<>();
+
+    final ServerErrorResponder responder = new ServerErrorResponder(
+      s -> Response.serverError().entity(s).build(),
+      responseFuture::complete);
+
+    responder.withMessage("Something went wrong");
+
+    final AsyncResult<Response> result = responseFuture.get(1, TimeUnit.SECONDS);
+
+    assertThat("Should succeed", result.succeeded(), is(true));
+    assertThat(result.result().getStatus(), is(500));
+    assertThat(result.result().getEntity(), is("Something went wrong"));
+  }
+
+  @Test
+  public void shouldRespondWithMessageFromException()
+    throws InterruptedException,
+    ExecutionException,
+    TimeoutException {
+
+    final CompletableFuture<AsyncResult<Response>> responseFuture
+      = new CompletableFuture<>();
+
+    final ServerErrorResponder responder = new ServerErrorResponder(
+      s -> Response.serverError().entity(s).build(),
+      responseFuture::complete);
+
+    responder.withError(new RuntimeException("An exceptional occurrence"));
+
+    final AsyncResult<Response> result = responseFuture.get(1, TimeUnit.SECONDS);
+
+    assertThat("Should succeed", result.succeeded(), is(true));
+    assertThat(result.result().getStatus(), is(500));
+    assertThat(result.result().getEntity(), is("An exceptional occurrence"));
+  }
+}

--- a/src/test/java/org/folio/support/ServerErrorResponderTest.java
+++ b/src/test/java/org/folio/support/ServerErrorResponderTest.java
@@ -3,6 +3,7 @@ package org.folio.support;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
+import java.lang.invoke.MethodHandles;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
@@ -13,8 +14,12 @@ import javax.ws.rs.core.Response;
 import org.junit.Test;
 
 import io.vertx.core.AsyncResult;
+import io.vertx.core.logging.Logger;
+import io.vertx.core.logging.LoggerFactory;
 
 public class ServerErrorResponderTest {
+  private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
   @Test
   public void shouldRespondWithMessage()
     throws InterruptedException,
@@ -26,7 +31,7 @@ public class ServerErrorResponderTest {
 
     final ServerErrorResponder responder = new ServerErrorResponder(
       s -> Response.serverError().entity(s).build(),
-      responseFuture::complete);
+      responseFuture::complete, log);
 
     responder.withMessage("Something went wrong");
 
@@ -48,7 +53,7 @@ public class ServerErrorResponderTest {
 
     final ServerErrorResponder responder = new ServerErrorResponder(
       s -> Response.serverError().entity(s).build(),
-      responseFuture::complete);
+      responseFuture::complete, log);
 
     responder.withError(new RuntimeException("An exceptional occurrence"));
 
@@ -68,9 +73,9 @@ public class ServerErrorResponderTest {
     final CompletableFuture<AsyncResult<Response>> responseFuture
       = new CompletableFuture<>();
 
-    final InternalErrorResponder responder = new InternalErrorResponder(
+    final ServerErrorResponder responder = new ServerErrorResponder(
       s -> Response.serverError().entity(s).build(),
-      responseFuture::complete);
+      responseFuture::complete, log);
 
     responder.withError(null);
 

--- a/src/test/java/org/folio/support/ServerErrorResponderTest.java
+++ b/src/test/java/org/folio/support/ServerErrorResponderTest.java
@@ -58,4 +58,26 @@ public class ServerErrorResponderTest {
     assertThat(result.result().getStatus(), is(500));
     assertThat(result.result().getEntity(), is("An exceptional occurrence"));
   }
+
+  @Test
+  public void shouldRespondWhenErrorIsNull()
+    throws InterruptedException,
+    ExecutionException,
+    TimeoutException {
+
+    final CompletableFuture<AsyncResult<Response>> responseFuture
+      = new CompletableFuture<>();
+
+    final InternalErrorResponder responder = new InternalErrorResponder(
+      s -> Response.serverError().entity(s).build(),
+      responseFuture::complete);
+
+    responder.withError(null);
+
+    final AsyncResult<Response> result = responseFuture.get(1, TimeUnit.SECONDS);
+
+    assertThat("Should succeed", result.succeeded(), is(true));
+    assertThat(result.result().getStatus(), is(500));
+    assertThat(result.result().getEntity(), is("Unknown error cause"));
+  }
 }

--- a/src/test/java/org/folio/support/VertxContextRunnerTest.java
+++ b/src/test/java/org/folio/support/VertxContextRunnerTest.java
@@ -1,0 +1,53 @@
+package org.folio.support;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import io.vertx.core.Vertx;
+
+public class VertxContextRunnerTest {
+  private Vertx vertx;
+
+  @Before
+  public void beforeAll() {
+    vertx = Vertx.vertx();
+  }
+
+  @Before
+  public void afterAll() {
+    if(vertx != null) {
+      vertx.close();
+    }
+  }
+
+  @Test
+  public void shouldExecuteErrorConsumerWhenExceptionIsThrown()
+    throws InterruptedException,
+    ExecutionException,
+    TimeoutException {
+
+    final CompletableFuture<Throwable> exceptionFuture = new CompletableFuture<>();
+
+    final VertxContextRunner runner = new VertxContextRunner(
+      vertx.getOrCreateContext(), exceptionFuture::complete);
+
+    final RuntimeException expectedException
+      = new RuntimeException("Something went wrong in runner");
+
+    runner.runOnContext(() -> { throw expectedException; });
+
+    Throwable receivedException = exceptionFuture.get(1, TimeUnit.SECONDS);
+
+    assertThat("Failure consumer should be called with exception",
+      receivedException, is(expectedException));
+
+  }
+}


### PR DESCRIPTION
*Purpose*

https://issues.folio.org/browse/CIRCSTORE-73

In order to anonymize all of the closed loans (and related action history) for a single user whilst reducing the quantity of HTTP requests to achieve this, we could introduce an endpoint that anonymizes a single users closed loans and loan action history in a single request.

*Approach*

* Chose to use SQL instead of fetching and updating all loans and then all related loan action history records, as two statements seemed simpler than nested asynchronous requests (see limitations below for improvements needed)

*Limitations*

The SQL is constructed with string concatenation, due to the `userId` being an external parameter this could potentially be used for injection (the validation below is an attempt to partly mitigate that). This should be replaced with prepared statements when the capability is available in RAML Module Builder.

In order to provide interface level description of the expectations about the `userId` URI parameter being a UUID, I attempted to introduce validation to the URI parameter (and changing it to a query string parameter) and both attempts failed.

Instead, a check is performed in the code. This is less clear, and is a compromise, as we do not enforce that `userId` in a loan is a UUID (this should be added when the next major interface version is made).