### PR TITLE
Circstore 77

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+## 6.2.0 UNRELEASED
+
+* Added `checkinServicePointId` and `checkoutServicePointId` to the loan schema (CIRCSTORE-77)
+
 ## 6.1.0 2018-09-11
 
 * Can anonymize all closed loans for a single user (CIRCSTORE-73)

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -4,7 +4,7 @@
   "provides": [
     {
       "id": "loan-storage",
-      "version": "5.1",
+      "version": "5.2",
       "handlers": [
         {
           "methods": ["GET"],

--- a/ramls/examples/loan.json
+++ b/ramls/examples/loan.json
@@ -5,6 +5,8 @@
   "itemId": "cb20f34f-b773-462f-a091-b233cc96b9e6",
   "loanDate": "2017-03-01T23:11:00-01:00",
   "dueDate": "2017-03-15T23:11:00-01:00",
+  "checkoutServicePointId": "8bb53832-c9fb-47ef-986d-5b1a498a8b30",
+  "checkinServicePointId": "8bb53832-c9fb-47ef-986d-5b1a498a8b30",
   "status": {
     "name": "Open"
   },

--- a/ramls/loan.json
+++ b/ramls/loan.json
@@ -66,6 +66,14 @@
       "description": "ID of last policy used in relation to this loan",
       "type": "string"
     },
+    "checkoutServicePointId": {
+      "description": "ID of the Service Point where the last checkout occured",
+      "type": "string"
+    },
+    "checkinServicePointId": {
+      "description": "ID of the Service Point where the last checkin occured",
+      "type": "string"
+    },
     "metadata": {
       "description": "Metadata about creation and changes to loan, provided by the server (client should not provide)",
       "type": "object",

--- a/ramls/loan.json
+++ b/ramls/loan.json
@@ -68,10 +68,12 @@
     },
     "checkoutServicePointId": {
       "description": "ID of the Service Point where the last checkout occured",
+      "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
       "type": "string"
     },
     "checkinServicePointId": {
       "description": "ID of the Service Point where the last checkin occured",
+      "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
       "type": "string"
     },
     "metadata": {


### PR DESCRIPTION
Resolves [CIRCSTORE-77](https://issues.folio.org/browse/CIRCSTORE-77):

This adds the properties checkinServicePointId and checkoutServicePointId, both strings pattern matched to UUIDs, to the loan schema. This is a perquisite for [CIRC-104](https://issues.folio.org/browse/CIRC-104)