### PR TITLE
Implement CRUD

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -611,7 +611,7 @@
       "permissionName": "circulation-storage.request-policies.item.delete",
       "displayName": "Circulation storage - delete individual request policy",
       "description": "Delete individual request policy from storage"
-    },
+    }
   ],
   "launchDescriptor": {
     "dockerImage" : "${artifactId}:${version}",

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -253,6 +253,37 @@
       ]
     },
     {
+      "id": "request-policy-storage",
+      "version": "1.0",
+      "handlers": [
+        {
+          "methods": ["GET"],
+          "pathPattern": "/request-policy-storage/request-policies",
+          "permissionsRequired": ["circulation-storage.request-policies.collection.get"]
+        }, {
+          "methods": ["GET"],
+          "pathPattern": "/request-policy-storage/request-policies/{id}",
+          "permissionsRequired": ["circulation-storage.request-policies.item.get"]
+        }, {
+          "methods": ["POST"],
+          "pathPattern": "/request-policy-storage/request-policies",
+          "permissionsRequired": ["circulation-storage.request-policies.item.post"]
+        }, {
+          "methods": ["PUT"],
+          "pathPattern": "/request-policy-storage/request-policies/{id}",
+          "permissionsRequired": ["circulation-storage.request-policies.item.put"]
+        }, {
+          "methods": ["DELETE"],
+          "pathPattern": "/request-policy-storage/request-policies/{id}",
+          "permissionsRequired": ["circulation-storage.request-policies.item.delete"]
+        }, {
+          "methods": ["DELETE"],
+          "pathPattern": "/request-policy-storage/request-policies",
+          "permissionsRequired": ["circulation-storage.request-policies.collection.delete"]
+        }
+      ]
+    },
+    {
       "id": "_tenant",
       "version": "1.0",
       "interfaceType": "system",
@@ -542,9 +573,45 @@
         "circulation-storage.patron-notice-policies.item.put",
         "circulation-storage.patron-notice-policies.item.delete",
         "circulation-storage.patron-notice-policies.collection.get",
-        "circulation-storage.patron-notice-policies.item.get"
+        "circulation-storage.patron-notice-policies.item.get",
+        "circulation-storage.request-policies.collection.get",
+        "circulation-storage.request-policies.item.get",
+        "circulation-storage.request-policies.collection.delete",
+        "circulation-storage.request-policies.item.delete",
+        "circulation-storage.request-policies.item.post",
+        "circulation-storage.request-policies.item.put"
       ]
-    }
+    },
+    {
+      "permissionName": "circulation-storage.request-policies.collection.get",
+      "displayName": "Circulation storage - get request policy collection",
+      "description": "Get request policy collection from storage"
+    },
+    {
+      "permissionName": "circulation-storage.request-policies.collection.delete",
+      "displayName": "Circulation storage - delete entire request policy collection",
+      "description": "Delete entire request policy collection from storage"
+    },
+    {
+      "permissionName": "circulation-storage.request-policies.item.get",
+      "displayName": "Circulation storage - get individual request policy",
+      "description": "Get individual request policy from storage"
+    },
+    {
+      "permissionName": "circulation-storage.request-policies.item.post",
+      "displayName": "Circulation storage - create individual request policy",
+      "description": "Create individual request policy in storage"
+    },
+    {
+      "permissionName": "circulation-storage.request-policies.item.put",
+      "displayName": "Circulation storage - modify individual request policy",
+      "description": "Modify request policy in storage"
+    },
+    {
+      "permissionName": "circulation-storage.request-policies.item.delete",
+      "displayName": "Circulation storage - delete individual request policy",
+      "description": "Delete individual request policy from storage"
+    },
   ],
   "launchDescriptor": {
     "dockerImage" : "${artifactId}:${version}",

--- a/ramls/examples/request-policies.json
+++ b/ramls/examples/request-policies.json
@@ -1,0 +1,23 @@
+{
+  "requestPolicies": [
+    {
+      "id": "d9cd0bed-1b49-4b5e-a7bd-064b8d177231",
+      "name": "Example Request Policy",
+      "description" : "Description of request policy",
+      "requestTypes" : ["Hold", "Page"]
+    },
+    {
+      "id": "d9cd0bed-1b49-4b5e-a7bd-064b8d177232",
+      "name": "Example Recall Request Policy",
+      "description" : "Description of request policy",
+      "requestTypes" : ["Recall"]
+    },
+    {
+      "id": "d9cd0bed-1b49-4b5e-a7bd-064b8d177233",
+      "name": "Example all-request-types Request Policy",
+      "description" : "Description of request policy",
+      "requestTypes" : ["Hold", "Page", "Recall"]
+    }
+  ],
+  "totalRecords": 3
+}

--- a/ramls/examples/request-policy.json
+++ b/ramls/examples/request-policy.json
@@ -1,0 +1,6 @@
+{
+  "id": "d9cd0bed-1b49-4b5e-a7bd-064b8d177231",
+  "name": "Example Request Policy",
+  "description" : "Description of request policy",
+  "requestTypes" : ["Hold", "Page"]
+}

--- a/ramls/request-policies.json
+++ b/ramls/request-policies.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "description": "Collection of request policies",
+  "type": "object",
+  "properties": {
+    "requestPolicies": {
+      "description": "List of request policies",
+      "id": "requestPolicies",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "$ref": "request-policy.json"
+      }
+    },
+    "totalRecords": {
+      "type": "integer"
+    }
+  },
+  "required": [
+    "requestPolicies",
+    "totalRecords"
+  ]
+}

--- a/ramls/request-policy-storage.raml
+++ b/ramls/request-policy-storage.raml
@@ -1,6 +1,6 @@
 #%RAML 1.0
 title: Request Policy Storage
-version: v1.4
+version: v1.0
 protocols: [ HTTP, HTTPS ]
 baseUri: http://localhost:9130
 

--- a/ramls/request-policy.json
+++ b/ramls/request-policy.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "description": "request policy schema",
+  "properties": {
+    "id": {
+      "type": "string"
+    },
+    "name": {
+      "type": "string"
+    },
+    "description": {
+      "type": "string"
+    },
+    "requestTypes": {
+      "description": "Whether the item should be held upon return, recalled or paged for",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "$ref": "request-type.json"
+      }
+    },
+    "metadata": {
+      "$ref": "raml-util/schemas/metadata.schema",
+      "readonly": true
+    }
+  },
+  "additionalProperties": false,
+  "required": [
+    "name"
+  ]
+}

--- a/ramls/request-policy.json
+++ b/ramls/request-policy.json
@@ -4,12 +4,15 @@
   "description": "request policy schema",
   "properties": {
     "id": {
+      "description": "Unique request policy ID",
       "type": "string"
     },
     "name": {
+      "description": "Unique request policy name, required",
       "type": "string"
     },
     "description": {
+      "description": "Description of request policy",
       "type": "string"
     },
     "requestTypes": {
@@ -21,6 +24,7 @@
       }
     },
     "metadata": {
+      "description": "Metadata about creation and changes to request policy, provided by the server (client should not provide)",
       "$ref": "raml-util/schemas/metadata.schema",
       "readonly": true
     }

--- a/ramls/request-policy.raml
+++ b/ramls/request-policy.raml
@@ -1,0 +1,93 @@
+#%RAML 1.0
+title: Request Policy Storage
+version: v1.4
+protocols: [ HTTP, HTTPS ]
+baseUri: http://localhost:9130
+
+documentation:
+  - title: Request Policy Storage API
+    content: <b>Storage for request policies</b>
+
+types:
+  request-policy: !include request-policy.json
+  request-policies: !include request-policies.json
+  errors: !include raml-util/schemas/errors.schema
+
+traits:
+  language: !include raml-util/traits/language.raml
+  pageable: !include raml-util/traits/pageable.raml
+  searchable: !include raml-util/traits/searchable.raml
+
+resourceTypes:
+  collection: !include raml-util/rtypes/collection.raml
+  collection-item: !include raml-util/rtypes/item-collection.raml
+
+/request-policy-storage:
+  /request-policies:
+    displayName: Request Policies
+    type:
+      collection:
+        exampleCollection: !include examples/request-policies.json
+        exampleItem: !include examples/request-policy.json
+        schemaCollection: request-policies
+        schemaItem: request-policy
+    get:
+      is: [pageable,
+        searchable: {description: "searchable using CQL",
+                        example: "id=\"cf23adf0-61ba-4887-bf82-956c4aae2260\""},
+        ]
+      responses:
+       500:
+         description: "General errors"
+         body:
+           application/json:
+             type: errors
+    post:
+      responses:
+        500:
+           description: "General errors"
+           body:
+             application/json:
+               type: errors
+    delete:
+      is: [language]
+      responses:
+        204:
+          description: "All request policies deleted"
+        500:
+          description: "Internal server error, e.g. due to misconfiguration"
+          body:
+            application/json:
+              example: "Internal server error, contact administrator"
+        501:
+          description: "Not implemented yet"
+    /{requestPolicyId}:
+      type:
+        collection-item:
+          exampleItem: !include examples/request-policy.json
+          schema: request-policy
+      get:
+        responses:
+          501:
+            description: "Not implemented yet"
+          500:
+            description: "General errors"
+            body:
+             application/json:
+               type: errors
+      put:
+        responses:
+          501:
+            description: "Not implemented yet"
+          500:
+             description: "General errors"
+             body:
+               application/json:
+                 type: errors
+      delete:
+        responses:
+          500:
+            description: "General errors"
+            body:
+             application/json:
+               type: errors

--- a/ramls/request-policy.raml
+++ b/ramls/request-policy.raml
@@ -75,6 +75,11 @@ resourceTypes:
             body:
              application/json:
                type: errors
+          404:
+            description: "Not found"
+            body:
+              application/json:
+                type: errors
       put:
         responses:
           501:

--- a/ramls/request-type.json
+++ b/ramls/request-type.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "string",
+  "description": "Whether the item should be held upon return, recalled or paged for",
+  "enum":["Hold", "Recall", "Page"],
+  "additionalProperties": false
+}

--- a/src/main/java/org/folio/rest/impl/RequestPoliciesAPI.java
+++ b/src/main/java/org/folio/rest/impl/RequestPoliciesAPI.java
@@ -251,66 +251,52 @@ public class RequestPoliciesAPI implements RequestPolicyStorage {
 
       Criterion criterion = getRequestByIdCriterion(requestPolicyId);
 
-      vertxContext.runOnContext(v -> {
+      vertxContext.runOnContext(v ->
         postgresClient.get(REQUEST_POLICY_TABLE, REQUEST_POLICY_CLASS, criterion, true, false,
           reply -> {
-            if(reply.succeeded()) {
+            if (reply.succeeded()) {
               @SuppressWarnings("unchecked")
               List<RequestPolicy> requestPolicyList = reply.result().getResults();
-
               if (requestPolicyList.size() == 1) {
-                try {
-                  postgresClient.update(REQUEST_POLICY_TABLE, entity, criterion,
-                    true,
-                    update -> {
-                        if(update.succeeded()) {
-                          OutStream stream = new OutStream();
-                          stream.setData(entity);
+                postgresClient.update(REQUEST_POLICY_TABLE, entity, criterion,
+                  true,
+                  update -> {
+                    if (update.succeeded()) {
+                      OutStream stream = new OutStream();
+                      stream.setData(entity);
 
-                          asyncResultHandler.handle(
-                            Future.succeededFuture( PutRequestPolicyStorageRequestPoliciesByRequestPolicyIdResponse
-                                .respond204()));
-                        }
-                        else {
-                          asyncResultHandler.handle(
-                            Future.succeededFuture( PutRequestPolicyStorageRequestPoliciesByRequestPolicyIdResponse
-                              .respond500WithApplicationJson(ValidationHelper.createValidationErrorMessage("name", entity.getName(), update.cause().getMessage()))));
-                        }
-                    });
-                } catch (Exception e) {
-                  asyncResultHandler.handle(Future.succeededFuture( PutRequestPolicyStorageRequestPoliciesByRequestPolicyIdResponse
-                    .respond500WithApplicationJson(ValidationHelper.createValidationErrorMessage("name", entity.getName(), e.getMessage()))));
-                }
-              }
-              else {
-                try {
-                  postgresClient.save(REQUEST_POLICY_TABLE, entity.getId(), entity,
-                    save -> {
-                      if(save.succeeded()) {
-                        OutStream stream = new OutStream();
-                        stream.setData(entity);
+                      asyncResultHandler.handle(
+                        Future.succeededFuture(PutRequestPolicyStorageRequestPoliciesByRequestPolicyIdResponse
+                          .respond204()));
+                    } else {
+                      asyncResultHandler.handle(
+                        Future.succeededFuture(PutRequestPolicyStorageRequestPoliciesByRequestPolicyIdResponse
+                          .respond500WithApplicationJson(ValidationHelper.createValidationErrorMessage("name", entity.getName(), update.cause().getMessage()))));
+                    }
+                  });
+              } else {
+                postgresClient.save(REQUEST_POLICY_TABLE, entity.getId(), entity,
+                  save -> {
+                    if (save.succeeded()) {
+                      OutStream stream = new OutStream();
+                      stream.setData(entity);
 
-                        asyncResultHandler.handle(
-                          Future.succeededFuture( PutRequestPolicyStorageRequestPoliciesByRequestPolicyIdResponse
-                              .respond204()));
-                      }
-                      else {
-                        asyncResultHandler.handle(
-                          Future.succeededFuture(PutRequestPolicyStorageRequestPoliciesByRequestPolicyIdResponse
-                            .respond500WithApplicationJson(ValidationHelper.createValidationErrorMessage("name", entity.getName(), save.cause().getMessage()))));
-                      }
-                    });
-                } catch (Exception e) {
-                  asyncResultHandler.handle(Future.succeededFuture(PutRequestPolicyStorageRequestPoliciesByRequestPolicyIdResponse
-                    .respond500WithApplicationJson(ValidationHelper.createValidationErrorMessage("name", entity.getName(), e.getMessage()))));
-                }
+                      asyncResultHandler.handle(
+                        Future.succeededFuture(PutRequestPolicyStorageRequestPoliciesByRequestPolicyIdResponse
+                          .respond204()));
+                    } else {
+                      asyncResultHandler.handle(
+                        Future.succeededFuture(PutRequestPolicyStorageRequestPoliciesByRequestPolicyIdResponse
+                          .respond500WithApplicationJson(ValidationHelper.createValidationErrorMessage("name", entity.getName(), save.cause().getMessage()))));
+                    }
+                  });
               }
             } else {
               asyncResultHandler.handle(Future.succeededFuture(PutRequestPolicyStorageRequestPoliciesByRequestPolicyIdResponse
                 .respond500WithApplicationJson(ValidationHelper.createValidationErrorMessage("name", entity.getName(), reply.cause().getMessage()))));
             }
-          });
-      });
+          })
+      );
     } catch (Exception e) {
       asyncResultHandler.handle(Future.succeededFuture(PutRequestPolicyStorageRequestPoliciesByRequestPolicyIdResponse
         .respond500WithApplicationJson(ValidationHelper.createValidationErrorMessage("name", entity.getName(), e.getMessage()))));
@@ -364,8 +350,6 @@ public class RequestPoliciesAPI implements RequestPolicyStorage {
     a.addField("'id'");
     a.setOperation("=");
     a.setValue(id);
-    Criterion criterion = new Criterion(a);
-
-    return criterion;
+    return new Criterion(a);
   }
 }

--- a/src/main/java/org/folio/rest/impl/RequestPoliciesAPI.java
+++ b/src/main/java/org/folio/rest/impl/RequestPoliciesAPI.java
@@ -164,8 +164,6 @@ public class RequestPoliciesAPI implements RequestPolicyStorage {
           vertxContext.owner(), TenantTool.calculateTenantId(tenantId));
 
         CQL2PgJSON cql2pgJson = new CQL2PgJSON("request_policy.jsonb");
-        String query = String.format("TRUNCATE TABLE %s_%s.%s",
-          tenantId, "mod_circulation_storage", REQUEST_POLICY_TABLE);
         CQLWrapper cql = new CQLWrapper(cql2pgJson, null);
 
         postgresClient.delete(REQUEST_POLICY_TABLE, cql,
@@ -188,13 +186,7 @@ public class RequestPoliciesAPI implements RequestPolicyStorage {
       PostgresClient postgresClient = PostgresClient.getInstance(
         vertxContext.owner(), TenantTool.calculateTenantId(tenantId));
 
-      Criteria a = new Criteria();
-
-      a.addField("'id'");
-      a.setOperation("=");
-      a.setValue(requestPolicyId);
-
-      Criterion criterion = new Criterion(a);
+      Criterion criterion = getRequestByIdCriterion(requestPolicyId);
 
       vertxContext.runOnContext(v -> {
         try {
@@ -257,91 +249,67 @@ public class RequestPoliciesAPI implements RequestPolicyStorage {
       PostgresClient postgresClient = PostgresClient.getInstance(
           vertxContext.owner(), TenantTool.calculateTenantId(tenantId));
 
-      Criteria a = new Criteria();
-
-      a.addField("'id'");
-      a.setOperation("=");
-      a.setValue(requestPolicyId);
-
-      Criterion criterion = new Criterion(a);
+      Criterion criterion = getRequestByIdCriterion(requestPolicyId);
 
       vertxContext.runOnContext(v -> {
-        try {
-          postgresClient.get(REQUEST_POLICY_TABLE, REQUEST_POLICY_CLASS, criterion, true, false,
-            reply -> {
-              if(reply.succeeded()) {
-                @SuppressWarnings("unchecked")
-                List<RequestPolicy> requestPolicyList = reply.result().getResults();
+        postgresClient.get(REQUEST_POLICY_TABLE, REQUEST_POLICY_CLASS, criterion, true, false,
+          reply -> {
+            if(reply.succeeded()) {
+              @SuppressWarnings("unchecked")
+              List<RequestPolicy> requestPolicyList = reply.result().getResults();
 
-                if (requestPolicyList.size() == 1) {
-                  try {
-                    postgresClient.update(REQUEST_POLICY_TABLE, entity, criterion,
-                      true,
-                      update -> {
-                        try {
-                          if(update.succeeded()) {
-                            OutStream stream = new OutStream();
-                            stream.setData(entity);
+              if (requestPolicyList.size() == 1) {
+                try {
+                  postgresClient.update(REQUEST_POLICY_TABLE, entity, criterion,
+                    true,
+                    update -> {
+                        if(update.succeeded()) {
+                          OutStream stream = new OutStream();
+                          stream.setData(entity);
 
-                            asyncResultHandler.handle(
-                              Future.succeededFuture( PutRequestPolicyStorageRequestPoliciesByRequestPolicyIdResponse
-                                  .respond204()));
-                          }
-                          else {
-                            asyncResultHandler.handle(
-                              Future.succeededFuture( PutRequestPolicyStorageRequestPoliciesByRequestPolicyIdResponse
-                                .respond500WithApplicationJson(ValidationHelper.createValidationErrorMessage("name", entity.getName(), update.cause().getMessage()))));
-
-                          }
-                        } catch (Exception e) {
                           asyncResultHandler.handle(
                             Future.succeededFuture( PutRequestPolicyStorageRequestPoliciesByRequestPolicyIdResponse
-                              .respond500WithApplicationJson(ValidationHelper.createValidationErrorMessage("name", entity.getName(), e.getMessage()))));
+                                .respond204()));
                         }
-                      });
-                  } catch (Exception e) {
-                    asyncResultHandler.handle(Future.succeededFuture( PutRequestPolicyStorageRequestPoliciesByRequestPolicyIdResponse
-                      .respond500WithApplicationJson(ValidationHelper.createValidationErrorMessage("name", entity.getName(), e.getMessage()))));
-                  }
-                }
-                else {
-                  try {
-                    postgresClient.save(REQUEST_POLICY_TABLE, entity.getId(), entity,
-                      save -> {
-                        try {
-                          if(save.succeeded()) {
-                            OutStream stream = new OutStream();
-                            stream.setData(entity);
-
-                            asyncResultHandler.handle(
-                              Future.succeededFuture( PutRequestPolicyStorageRequestPoliciesByRequestPolicyIdResponse
-                                  .respond204()));
-                          }
-                          else {
-                            asyncResultHandler.handle(
-                              Future.succeededFuture(PutRequestPolicyStorageRequestPoliciesByRequestPolicyIdResponse
-                                .respond500WithApplicationJson(ValidationHelper.createValidationErrorMessage("name", entity.getName(), save.cause().getMessage()))));
-                          }
-                        } catch (Exception e) {
+                        else {
                           asyncResultHandler.handle(
-                            Future.succeededFuture(PutRequestPolicyStorageRequestPoliciesByRequestPolicyIdResponse
-                                .respond500WithApplicationJson(ValidationHelper.createValidationErrorMessage("name", entity.getName(), e.getMessage()))));
+                            Future.succeededFuture( PutRequestPolicyStorageRequestPoliciesByRequestPolicyIdResponse
+                              .respond500WithApplicationJson(ValidationHelper.createValidationErrorMessage("name", entity.getName(), update.cause().getMessage()))));
                         }
-                      });
-                  } catch (Exception e) {
-                    asyncResultHandler.handle(Future.succeededFuture(PutRequestPolicyStorageRequestPoliciesByRequestPolicyIdResponse
-                      .respond500WithApplicationJson(ValidationHelper.createValidationErrorMessage("name", entity.getName(), e.getMessage()))));
-                  }
+                    });
+                } catch (Exception e) {
+                  asyncResultHandler.handle(Future.succeededFuture( PutRequestPolicyStorageRequestPoliciesByRequestPolicyIdResponse
+                    .respond500WithApplicationJson(ValidationHelper.createValidationErrorMessage("name", entity.getName(), e.getMessage()))));
                 }
-              } else {
-                asyncResultHandler.handle(Future.succeededFuture(PutRequestPolicyStorageRequestPoliciesByRequestPolicyIdResponse
-                  .respond500WithApplicationJson(ValidationHelper.createValidationErrorMessage("name", entity.getName(), reply.cause().getMessage()))));
               }
-            });
-        } catch (Exception e) {
-          asyncResultHandler.handle(Future.succeededFuture(PutRequestPolicyStorageRequestPoliciesByRequestPolicyIdResponse
-            .respond500WithApplicationJson(ValidationHelper.createValidationErrorMessage("name", entity.getName(), e.getMessage()))));
-        }
+              else {
+                try {
+                  postgresClient.save(REQUEST_POLICY_TABLE, entity.getId(), entity,
+                    save -> {
+                      if(save.succeeded()) {
+                        OutStream stream = new OutStream();
+                        stream.setData(entity);
+
+                        asyncResultHandler.handle(
+                          Future.succeededFuture( PutRequestPolicyStorageRequestPoliciesByRequestPolicyIdResponse
+                              .respond204()));
+                      }
+                      else {
+                        asyncResultHandler.handle(
+                          Future.succeededFuture(PutRequestPolicyStorageRequestPoliciesByRequestPolicyIdResponse
+                            .respond500WithApplicationJson(ValidationHelper.createValidationErrorMessage("name", entity.getName(), save.cause().getMessage()))));
+                      }
+                    });
+                } catch (Exception e) {
+                  asyncResultHandler.handle(Future.succeededFuture(PutRequestPolicyStorageRequestPoliciesByRequestPolicyIdResponse
+                    .respond500WithApplicationJson(ValidationHelper.createValidationErrorMessage("name", entity.getName(), e.getMessage()))));
+                }
+              }
+            } else {
+              asyncResultHandler.handle(Future.succeededFuture(PutRequestPolicyStorageRequestPoliciesByRequestPolicyIdResponse
+                .respond500WithApplicationJson(ValidationHelper.createValidationErrorMessage("name", entity.getName(), reply.cause().getMessage()))));
+            }
+          });
       });
     } catch (Exception e) {
       asyncResultHandler.handle(Future.succeededFuture(PutRequestPolicyStorageRequestPoliciesByRequestPolicyIdResponse
@@ -359,13 +327,7 @@ public class RequestPoliciesAPI implements RequestPolicyStorage {
           PostgresClient.getInstance(
             vertxContext.owner(), TenantTool.calculateTenantId(tenantId));
 
-        Criteria a = new Criteria();
-
-        a.addField("'id'");
-        a.setOperation("=");
-        a.setValue(requestPolicyId);
-
-        Criterion criterion = new Criterion(a);
+        Criterion criterion = getRequestByIdCriterion(requestPolicyId);
 
         vertxContext.runOnContext(v -> {
           try {
@@ -394,5 +356,16 @@ public class RequestPoliciesAPI implements RequestPolicyStorage {
           DeleteRequestPolicyStorageRequestPoliciesByRequestPolicyIdResponse
             .respond500WithApplicationJson(ValidationHelper.createValidationErrorMessage("name", RequestPolicy.class.getName(), e.getMessage()))));
       }
+  }
+
+  private Criterion getRequestByIdCriterion( String id){
+
+    Criteria a = new Criteria();
+    a.addField("'id'");
+    a.setOperation("=");
+    a.setValue(id);
+    Criterion criterion = new Criterion(a);
+
+    return criterion;
   }
 }

--- a/src/main/java/org/folio/rest/impl/RequestPoliciesAPI.java
+++ b/src/main/java/org/folio/rest/impl/RequestPoliciesAPI.java
@@ -1,0 +1,396 @@
+package org.folio.rest.impl;
+
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Context;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.core.logging.Logger;
+import io.vertx.core.logging.LoggerFactory;
+import org.folio.rest.annotations.Validate;
+import org.folio.rest.jaxrs.model.RequestPolicies;
+import org.folio.rest.jaxrs.model.RequestPolicy;
+import org.folio.rest.jaxrs.resource.LoanPolicyStorage;
+import org.folio.rest.jaxrs.resource.RequestPolicyStorage;
+import org.folio.rest.persist.Criteria.Criteria;
+import org.folio.rest.persist.Criteria.Criterion;
+import org.folio.rest.persist.Criteria.Limit;
+import org.folio.rest.persist.Criteria.Offset;
+import org.folio.rest.persist.PostgresClient;
+import org.folio.rest.persist.cql.CQLWrapper;
+import org.folio.rest.tools.utils.OutStream;
+import org.folio.rest.tools.utils.TenantTool;
+import org.folio.rest.tools.utils.ValidationHelper;
+import org.z3950.zing.cql.cql2pgjson.CQL2PgJSON;
+
+import javax.ws.rs.core.Response;
+import java.lang.invoke.MethodHandles;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.folio.rest.impl.Headers.TENANT_HEADER;
+
+public class RequestPoliciesAPI implements RequestPolicyStorage {
+  private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
+  private static final String REQUEST_POLICY_TABLE = "request_policy";
+  private static final Class<RequestPolicy> REQUEST_POLICY_CLASS = RequestPolicy.class;
+
+  @Override
+  public void getRequestPolicyStorageRequestPolicies(int offset, int limit, String query, String lang, Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
+
+    String tenantId = okapiHeaders.get(TENANT_HEADER);
+
+    try {
+      vertxContext.runOnContext(v -> {
+        try {
+          PostgresClient postgresClient = PostgresClient.getInstance(
+            vertxContext.owner(), TenantTool.calculateTenantId(tenantId));
+
+          String[] fieldList = {"*"};
+
+          CQL2PgJSON cql2pgJson = new CQL2PgJSON("request_policy.jsonb");
+          CQLWrapper cql = new CQLWrapper(cql2pgJson, query)
+            .setLimit(new Limit(limit))
+            .setOffset(new Offset(offset));
+
+          postgresClient.get(REQUEST_POLICY_TABLE,  REQUEST_POLICY_CLASS, fieldList, cql,
+            true, false, reply -> {
+              try {
+                if(reply.succeeded()) {
+
+                  @SuppressWarnings("unchecked")
+                  List<RequestPolicy> requestPolicies = (List<RequestPolicy>) reply.result().getResults();
+
+                  RequestPolicies pagedRequestPolicies = new RequestPolicies();
+                  pagedRequestPolicies.setRequestPolicies(requestPolicies);
+                  pagedRequestPolicies.setTotalRecords(reply.result().getResultInfo().getTotalRecords());
+
+                  asyncResultHandler.handle(io.vertx.core.Future.succeededFuture(
+                    RequestPolicyStorage.GetRequestPolicyStorageRequestPoliciesResponse.
+                      respond200WithApplicationJson(pagedRequestPolicies)));
+                }
+                else {
+                  asyncResultHandler.handle(io.vertx.core.Future.succeededFuture(
+                    RequestPolicyStorage.GetRequestPolicyStorageRequestPoliciesResponse
+                      .respond500WithApplicationJson(ValidationHelper.createValidationErrorMessage("name", RequestPolicies.class.getName(), reply.cause().getMessage()))));
+                }
+              } catch (Exception e) {
+                log.error(e);
+                asyncResultHandler.handle(io.vertx.core.Future.succeededFuture(
+                  RequestPolicyStorage.GetRequestPolicyStorageRequestPoliciesResponse
+                    .respond500WithApplicationJson(ValidationHelper.createValidationErrorMessage("name", RequestPolicies.class.getName(), e.getMessage()))));
+              }
+            });
+        } catch (Exception e) {
+          log.error(e);
+          asyncResultHandler.handle(io.vertx.core.Future.succeededFuture(
+            RequestPolicyStorage.GetRequestPolicyStorageRequestPoliciesResponse
+            .respond500WithApplicationJson(ValidationHelper.createValidationErrorMessage("name", RequestPolicies.class.getName(), e.getMessage()))));
+        }
+      });
+    } catch (Exception e) {
+      log.error(e);
+      asyncResultHandler.handle(io.vertx.core.Future.succeededFuture(
+        RequestPolicyStorage.GetRequestPolicyStorageRequestPoliciesResponse
+          .respond500WithApplicationJson(ValidationHelper.createValidationErrorMessage("name", RequestPolicies.class.getName(), e.getMessage()))));
+    }
+  }
+
+  @Override
+  public void postRequestPolicyStorageRequestPolicies(String lang, RequestPolicy entity, Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
+    String tenantId = okapiHeaders.get(TENANT_HEADER);
+
+    try {
+      PostgresClient postgresClient =
+        PostgresClient.getInstance(
+          vertxContext.owner(), TenantTool.calculateTenantId(tenantId));
+
+      vertxContext.runOnContext(v -> {
+        try {
+          if(entity.getId() == null) {
+            entity.setId(UUID.randomUUID().toString());
+          }
+
+          postgresClient.save(REQUEST_POLICY_TABLE, entity.getId(), entity,
+            reply -> {
+              try {
+                if(reply.succeeded()) {
+                  OutStream stream = new OutStream();
+                  stream.setData(entity);
+
+                  asyncResultHandler.handle(
+                    io.vertx.core.Future.succeededFuture(
+                      RequestPolicyStorage.PostRequestPolicyStorageRequestPoliciesResponse
+                        .respond201WithApplicationJson(entity,
+                          RequestPolicyStorage.PostRequestPolicyStorageRequestPoliciesResponse.headersFor201().withLocation(reply.result()))));
+                }
+                else {
+                  asyncResultHandler.handle(
+                    io.vertx.core.Future.succeededFuture(
+                      RequestPolicyStorage.PostRequestPolicyStorageRequestPoliciesResponse
+                        .respond500WithApplicationJson(ValidationHelper.createValidationErrorMessage("name", entity.getName(), reply.cause().toString()))));
+                }
+              } catch (Exception e) {
+                log.error(e);
+                asyncResultHandler.handle(
+                  io.vertx.core.Future.succeededFuture(
+                    RequestPolicyStorage.PostRequestPolicyStorageRequestPoliciesResponse
+                      .respond500WithApplicationJson(ValidationHelper.createValidationErrorMessage("name", entity.getName(), e.getMessage()))));
+              }
+            });
+        } catch (Exception e) {
+          log.error(e);
+          asyncResultHandler.handle(io.vertx.core.Future.succeededFuture(
+            RequestPolicyStorage.PostRequestPolicyStorageRequestPoliciesResponse
+              .respond500WithApplicationJson(ValidationHelper.createValidationErrorMessage("name", entity.getName(), e.getMessage()))));
+        }
+      });
+    } catch (Exception e) {
+      log.error(e);
+      asyncResultHandler.handle(io.vertx.core.Future.succeededFuture(
+        RequestPolicyStorage.PostRequestPolicyStorageRequestPoliciesResponse
+          .respond500WithApplicationJson(ValidationHelper.createValidationErrorMessage("name", entity.getName(), e.getMessage()))));
+
+    }
+  }
+
+  @Override
+  public void deleteRequestPolicyStorageRequestPolicies(String lang, Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
+
+    String tenantId = okapiHeaders.get(TENANT_HEADER);
+
+    vertxContext.runOnContext(v -> {
+      try {
+        PostgresClient postgresClient = PostgresClient.getInstance(
+          vertxContext.owner(), TenantTool.calculateTenantId(tenantId));
+
+        postgresClient.mutate(String.format("TRUNCATE TABLE %s_%s.%s",
+          tenantId, "mod_circulation_storage", REQUEST_POLICY_TABLE),
+          reply -> asyncResultHandler.handle(Future.succeededFuture(
+            DeleteRequestPolicyStorageRequestPoliciesResponse.respond204())));
+      }
+      catch(Exception e) {
+        asyncResultHandler.handle(io.vertx.core.Future.succeededFuture(
+          RequestPolicyStorage.DeleteRequestPolicyStorageRequestPoliciesResponse
+            .respond500WithApplicationJson(e.getMessage())));
+      }
+    });
+  }
+
+  @Override
+  public void getRequestPolicyStorageRequestPoliciesByRequestPolicyId(String requestPolicyId, String lang, Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
+    String tenantId = okapiHeaders.get(TENANT_HEADER);
+
+    try {
+      PostgresClient postgresClient = PostgresClient.getInstance(
+        vertxContext.owner(), TenantTool.calculateTenantId(tenantId));
+
+      Criteria a = new Criteria();
+
+      a.addField("'id'");
+      a.setOperation("=");
+      a.setValue(requestPolicyId);
+
+      Criterion criterion = new Criterion(a);
+
+      vertxContext.runOnContext(v -> {
+        try {
+          postgresClient.get(REQUEST_POLICY_TABLE, REQUEST_POLICY_CLASS, criterion, true, false,
+            reply -> {
+              try {
+                if (reply.succeeded()) {
+                  @SuppressWarnings("unchecked")
+                  List<RequestPolicy> requestPolicies = (List<RequestPolicy>) reply.result().getResults();
+
+                  if (requestPolicies.size() == 1) {
+                    RequestPolicy requestPolicy = requestPolicies.get(0);
+
+                    asyncResultHandler.handle(
+                      io.vertx.core.Future.succeededFuture(
+                        RequestPolicyStorage.GetRequestPolicyStorageRequestPoliciesByRequestPolicyIdResponse.
+                          respond200WithApplicationJson(requestPolicy)));
+                  }
+                  else {
+                    asyncResultHandler.handle(
+                      Future.succeededFuture(
+                        RequestPolicyStorage.GetRequestPolicyStorageRequestPoliciesByRequestPolicyIdResponse.
+                          respond404WithTextPlain("Not Found")));
+                  }
+                } else {
+                  asyncResultHandler.handle(
+                    Future.succeededFuture(
+                      RequestPolicyStorage.GetRequestPolicyStorageRequestPoliciesByRequestPolicyIdResponse
+                        .respond500WithApplicationJson(ValidationHelper.createValidationErrorMessage("name", RequestPolicy.class.getName(), reply.cause().getMessage()))));
+                }
+              } catch (Exception e) {
+                log.error(e);
+                asyncResultHandler.handle(io.vertx.core.Future.succeededFuture(
+                  RequestPolicyStorage.GetRequestPolicyStorageRequestPoliciesByRequestPolicyIdResponse
+                  .respond500WithApplicationJson(ValidationHelper.createValidationErrorMessage("name", RequestPolicy.class.getName(), e.getMessage()))));
+              }
+            });
+        } catch (Exception e) {
+          log.error(e);
+          asyncResultHandler.handle(io.vertx.core.Future.succeededFuture(
+            RequestPolicyStorage.GetRequestPolicyStorageRequestPoliciesByRequestPolicyIdResponse
+            .respond500WithApplicationJson(ValidationHelper.createValidationErrorMessage("name", RequestPolicy.class.getName(), e.getMessage()))));
+        }
+      });
+    } catch (Exception e) {
+      log.error(e);
+      asyncResultHandler.handle(io.vertx.core.Future.succeededFuture(
+        RequestPolicyStorage.
+          GetRequestPolicyStorageRequestPoliciesByRequestPolicyIdResponse
+            .respond500WithApplicationJson(ValidationHelper.createValidationErrorMessage("name", RequestPolicy.class.getName(), e.getMessage()))));
+    }
+  }
+
+  @Override
+  public void putRequestPolicyStorageRequestPoliciesByRequestPolicyId(String requestPolicyId, String lang, RequestPolicy entity, Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
+
+    String tenantId = okapiHeaders.get(TENANT_HEADER);
+
+    try {
+      PostgresClient postgresClient = PostgresClient.getInstance(
+          vertxContext.owner(), TenantTool.calculateTenantId(tenantId));
+
+      Criteria a = new Criteria();
+
+      a.addField("'id'");
+      a.setOperation("=");
+      a.setValue(requestPolicyId);
+
+      Criterion criterion = new Criterion(a);
+
+      vertxContext.runOnContext(v -> {
+        try {
+          postgresClient.get(REQUEST_POLICY_TABLE, REQUEST_POLICY_CLASS, criterion, true, false,
+            reply -> {
+              if(reply.succeeded()) {
+                @SuppressWarnings("unchecked")
+                List<RequestPolicy> requestPolicyList = reply.result().getResults();
+
+                if (requestPolicyList.size() == 1) {
+                  try {
+                    postgresClient.update(REQUEST_POLICY_TABLE, entity, criterion,
+                      true,
+                      update -> {
+                        try {
+                          if(update.succeeded()) {
+                            OutStream stream = new OutStream();
+                            stream.setData(entity);
+
+                            asyncResultHandler.handle(
+                              Future.succeededFuture( PutRequestPolicyStorageRequestPoliciesByRequestPolicyIdResponse
+                                  .respond204()));
+                          }
+                          else {
+                            asyncResultHandler.handle(
+                              Future.succeededFuture( PutRequestPolicyStorageRequestPoliciesByRequestPolicyIdResponse
+                                .respond500WithApplicationJson(ValidationHelper.createValidationErrorMessage("name", entity.getName(), update.cause().getMessage()))));
+
+                          }
+                        } catch (Exception e) {
+                          asyncResultHandler.handle(
+                            Future.succeededFuture( PutRequestPolicyStorageRequestPoliciesByRequestPolicyIdResponse
+                              .respond500WithApplicationJson(ValidationHelper.createValidationErrorMessage("name", entity.getName(), e.getMessage()))));
+                        }
+                      });
+                  } catch (Exception e) {
+                    asyncResultHandler.handle(Future.succeededFuture( PutRequestPolicyStorageRequestPoliciesByRequestPolicyIdResponse
+                      .respond500WithApplicationJson(ValidationHelper.createValidationErrorMessage("name", entity.getName(), e.getMessage()))));
+                  }
+                }
+                else {
+                  try {
+                    postgresClient.save(REQUEST_POLICY_TABLE, entity.getId(), entity,
+                      save -> {
+                        try {
+                          if(save.succeeded()) {
+                            OutStream stream = new OutStream();
+                            stream.setData(entity);
+
+                            asyncResultHandler.handle(
+                              Future.succeededFuture( PutRequestPolicyStorageRequestPoliciesByRequestPolicyIdResponse
+                                  .respond204()));
+                          }
+                          else {
+                            asyncResultHandler.handle(
+                              Future.succeededFuture(PutRequestPolicyStorageRequestPoliciesByRequestPolicyIdResponse
+                                .respond500WithApplicationJson(ValidationHelper.createValidationErrorMessage("name", entity.getName(), save.cause().getMessage()))));
+                          }
+                        } catch (Exception e) {
+                          asyncResultHandler.handle(
+                            Future.succeededFuture(PutRequestPolicyStorageRequestPoliciesByRequestPolicyIdResponse
+                                .respond500WithApplicationJson(ValidationHelper.createValidationErrorMessage("name", entity.getName(), e.getMessage()))));
+                        }
+                      });
+                  } catch (Exception e) {
+                    asyncResultHandler.handle(Future.succeededFuture(PutRequestPolicyStorageRequestPoliciesByRequestPolicyIdResponse
+                      .respond500WithApplicationJson(ValidationHelper.createValidationErrorMessage("name", entity.getName(), e.getMessage()))));
+                  }
+                }
+              } else {
+                asyncResultHandler.handle(Future.succeededFuture(PutRequestPolicyStorageRequestPoliciesByRequestPolicyIdResponse
+                  .respond500WithApplicationJson(ValidationHelper.createValidationErrorMessage("name", entity.getName(), reply.cause().getMessage()))));
+              }
+            });
+        } catch (Exception e) {
+          asyncResultHandler.handle(Future.succeededFuture(PutRequestPolicyStorageRequestPoliciesByRequestPolicyIdResponse
+            .respond500WithApplicationJson(ValidationHelper.createValidationErrorMessage("name", entity.getName(), e.getMessage()))));
+        }
+      });
+    } catch (Exception e) {
+      asyncResultHandler.handle(Future.succeededFuture(PutRequestPolicyStorageRequestPoliciesByRequestPolicyIdResponse
+        .respond500WithApplicationJson(ValidationHelper.createValidationErrorMessage("name", entity.getName(), e.getMessage()))));
+    }
+  }
+
+  @Override
+  public void deleteRequestPolicyStorageRequestPoliciesByRequestPolicyId(String requestPolicyId, String lang, Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
+
+      String tenantId = okapiHeaders.get(TENANT_HEADER);
+
+      try {
+        PostgresClient postgresClient =
+          PostgresClient.getInstance(
+            vertxContext.owner(), TenantTool.calculateTenantId(tenantId));
+
+        Criteria a = new Criteria();
+
+        a.addField("'id'");
+        a.setOperation("=");
+        a.setValue(requestPolicyId);
+
+        Criterion criterion = new Criterion(a);
+
+        vertxContext.runOnContext(v -> {
+          try {
+            postgresClient.delete(REQUEST_POLICY_TABLE, criterion,
+              reply -> {
+                if(reply.succeeded()) {
+                  asyncResultHandler.handle(
+                    Future.succeededFuture(
+                      DeleteRequestPolicyStorageRequestPoliciesByRequestPolicyIdResponse
+                        .respond204()));
+                }
+                else {
+                  asyncResultHandler.handle(Future.succeededFuture(
+                    DeleteRequestPolicyStorageRequestPoliciesByRequestPolicyIdResponse
+                      .respond500WithApplicationJson(ValidationHelper.createValidationErrorMessage("name", RequestPolicy.class.getName(), reply.cause().getMessage()))));
+                }
+              });
+          } catch (Exception e) {
+            asyncResultHandler.handle(Future.succeededFuture(
+              DeleteRequestPolicyStorageRequestPoliciesByRequestPolicyIdResponse
+                .respond500WithApplicationJson(ValidationHelper.createValidationErrorMessage("name", RequestPolicy.class.getName(), e.getMessage()))));
+          }
+        });
+      } catch (Exception e) {
+        asyncResultHandler.handle(Future.succeededFuture(
+          DeleteRequestPolicyStorageRequestPoliciesByRequestPolicyIdResponse
+            .respond500WithApplicationJson(ValidationHelper.createValidationErrorMessage("name", RequestPolicy.class.getName(), e.getMessage()))));
+      }
+  }
+}

--- a/src/main/java/org/folio/rest/impl/RequestPoliciesAPI.java
+++ b/src/main/java/org/folio/rest/impl/RequestPoliciesAPI.java
@@ -209,7 +209,7 @@ public class RequestPoliciesAPI implements RequestPolicyStorage {
                     asyncResultHandler.handle(
                       Future.succeededFuture(
                         RequestPolicyStorage.GetRequestPolicyStorageRequestPoliciesByRequestPolicyIdResponse.
-                          respond404WithTextPlain("Not Found")));
+                          respond404WithApplicationJson(ValidationHelper.createValidationErrorMessage("name", RequestPolicy.class.getName(), "Not Found"))));
                   }
                 } else {
                   asyncResultHandler.handle(

--- a/src/main/resources/templates/db_scripts/schema.json
+++ b/src/main/resources/templates/db_scripts/schema.json
@@ -89,6 +89,20 @@
       ]
     },
     {
+      "tableName": "request_policy",
+      "generateId": false,
+      "pkColumnName": "_id",
+      "withMetadata": true,
+      "withAuditing": false,
+      "uniqueIndex": [
+        {
+          "fieldName": "name",
+          "tOps": "ADD",
+          "caseSensitive": false
+        }
+      ]
+    },
+    {
       "tableName": "loan_rules",
       "generateId": false,
       "pkColumnName": "_id",

--- a/src/test/java/org/folio/rest/api/RequestPoliciesApiTest.java
+++ b/src/test/java/org/folio/rest/api/RequestPoliciesApiTest.java
@@ -1,0 +1,816 @@
+package org.folio.rest.api;
+
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import org.folio.rest.jaxrs.model.Errors;
+import org.folio.rest.jaxrs.model.Request;
+import org.folio.rest.jaxrs.model.RequestPolicy;
+import org.folio.rest.jaxrs.model.RequestType;
+import org.folio.rest.support.ApiTests;
+import org.folio.rest.support.JsonResponse;
+import org.folio.rest.support.ResponseHandler;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.net.HttpURLConnection;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.rmi.server.UID;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsNull.notNullValue;
+
+public class RequestPoliciesApiTest extends ApiTests {
+
+  private static final int CONNECTION_TIMEOUT = 5;
+  private static final String DEFAULT_REQUEST_POLICY_NAME = "default_request_policy";
+/*
+  @After
+  public void CleanupAfterEachTest()
+    throws InterruptedException,
+    MalformedURLException,
+    TimeoutException,
+    ExecutionException {
+    CompletableFuture<JsonResponse> deleteCompleted = new CompletableFuture<>();
+
+    client.delete(requestPolicyStorageUrl(""),
+      StorageTestSuite.TENANT_ID,
+      ResponseHandler.json(deleteCompleted));
+
+    JsonResponse response = deleteCompleted.get(CONNECTION_TIMEOUT, TimeUnit.SECONDS);
+    assertThat("response is null", response != null);
+  }
+*/
+  @Test
+  public void canCreateARequestPolicy()
+    throws InterruptedException,
+    MalformedURLException,
+    TimeoutException,
+    ExecutionException {
+
+    CompletableFuture<JsonResponse> createCompleted = new CompletableFuture<>();
+
+    UUID id = UUID.randomUUID();
+    List<RequestType> requestTypes = Arrays.asList( RequestType.HOLD, RequestType.PAGE);
+
+    RequestPolicy requestPolicy = new RequestPolicy();
+    requestPolicy.withDescription("test policy");
+    requestPolicy.withId(id.toString());
+    requestPolicy.withName("successful_get");
+    requestPolicy.withRequestTypes(requestTypes);
+
+    client.post(requestPolicyStorageUrl(""),
+                requestPolicy,
+                StorageTestSuite.TENANT_ID,
+                ResponseHandler.json(createCompleted));
+
+    JsonResponse response = createCompleted.get(CONNECTION_TIMEOUT, TimeUnit.SECONDS);
+
+    assertThat("Failed to create new request-policy", response.getStatusCode(), is(HttpURLConnection.HTTP_CREATED));
+
+    JsonObject representation = response.getJson();
+
+    assertThat(representation.getString("id"), is(id.toString()));
+    assertThat(representation.getString("name"), is("successful_get"));
+    assertThat(representation.getString("description"), is("test policy"));
+
+    JsonArray resultRequestTypes = representation.getJsonArray("requestTypes");
+
+    for ( Object type : resultRequestTypes) {
+      assertThat("requestType returned: " + type.toString() + " does not exist in input list",
+                        requestTypes.contains(RequestType.fromValue(type.toString())));
+    }
+  }
+
+  @Test
+  public void canCreateRequestPolicyWithoutUID()
+    throws InterruptedException,
+    MalformedURLException,
+    TimeoutException,
+    ExecutionException {
+
+    CompletableFuture<JsonResponse> createCompleted = new CompletableFuture<>();
+
+    List<RequestType> requestTypes = Collections.singletonList(RequestType.HOLD);
+
+    RequestPolicy requestPolicy = new RequestPolicy();
+    requestPolicy.withDescription("test policy");
+    requestPolicy.withName("successful_get");
+    requestPolicy.withRequestTypes(requestTypes);
+
+    client.post(requestPolicyStorageUrl(""),
+      requestPolicy,
+                StorageTestSuite.TENANT_ID,
+                ResponseHandler.json(createCompleted));
+
+    JsonResponse response = createCompleted.get(CONNECTION_TIMEOUT, TimeUnit.SECONDS);
+
+    assertThat(String.format("Failed to create request policy: %s", response.getBody()),
+      response.getStatusCode(), is(HttpURLConnection.HTTP_CREATED));
+
+    JsonObject representation = response.getJson();
+    assertThat(representation.getString("id"), is(notNullValue()));
+    assertThat(representation.getString("name"), is("successful_get"));
+    assertThat(representation.getString("description"), is("test policy"));
+  }
+
+  @Test
+  public void cannotCreateRequestPolicyWithExistingName()
+    throws InterruptedException,
+    MalformedURLException,
+    TimeoutException,
+    ExecutionException{
+      CompletableFuture<JsonResponse> createCompleted = new CompletableFuture<>();
+      CompletableFuture<JsonResponse> failedCompleted = new CompletableFuture<>();
+
+      String reqPolicyName = "request_policy_name";
+
+      List<RequestType> requestTypes = Collections.singletonList(RequestType.HOLD);
+      UUID id = UUID.randomUUID();
+
+      RequestPolicy requestPolicy = new RequestPolicy();
+      requestPolicy.withDescription("test policy");
+      requestPolicy.withName(reqPolicyName);
+      requestPolicy.withRequestTypes(requestTypes);
+      requestPolicy.withId(id.toString());
+
+      client.post(requestPolicyStorageUrl(""),
+        requestPolicy,
+        StorageTestSuite.TENANT_ID,
+        ResponseHandler.json(createCompleted));
+
+      JsonResponse response = createCompleted.get(CONNECTION_TIMEOUT, TimeUnit.SECONDS);
+      assertThat(String.format("Failed to create request policy: %s", response.getBody()),
+      response.getStatusCode(), is(HttpURLConnection.HTTP_CREATED));
+
+      UUID id2 = UUID.randomUUID();
+      RequestPolicy requestPolicy2 = new RequestPolicy();
+      requestPolicy2.withDescription("test policy 2");
+      requestPolicy2.withName(reqPolicyName);
+      requestPolicy2.withRequestTypes(requestTypes);
+      requestPolicy2.withId(id2.toString());
+
+      client.post(requestPolicyStorageUrl(""),
+        requestPolicy2,
+        StorageTestSuite.TENANT_ID,
+        ResponseHandler.json(failedCompleted));
+
+        JsonResponse response2 = failedCompleted.get(CONNECTION_TIMEOUT, TimeUnit.SECONDS);
+        JsonObject representation = response2.getJson();
+
+        assertThat(String.format("Failed to create request policy: %s", response2.getBody()),
+          response2.getStatusCode(), is(HttpURLConnection.HTTP_INTERNAL_ERROR));
+
+        JsonArray errors = representation.getJsonArray("errors");
+        JsonObject error  = errors.getJsonObject(0);
+        assertThat("unexpected error message" , error.getString("message").contains("duplicate key value"));
+  }
+
+  @Test
+  public void cannotCreateRequestPolicyWithBadUID()
+    throws InterruptedException,
+    MalformedURLException,
+    TimeoutException,
+    ExecutionException{
+
+    CompletableFuture<JsonResponse> createCompleted = new CompletableFuture<>();
+
+    List<RequestType> requestTypes = Collections.singletonList(RequestType.HOLD);
+
+    RequestPolicy requestPolicy = new RequestPolicy();
+    requestPolicy.withDescription("test policy");
+    requestPolicy.withName("successful_get");
+    requestPolicy.withRequestTypes(requestTypes);
+    requestPolicy.withId("d9cdbed-1b49-4b5e-a7bd-064b8d231");
+
+    client.post(requestPolicyStorageUrl(""),
+      requestPolicy,
+      StorageTestSuite.TENANT_ID,
+      ResponseHandler.json(createCompleted));
+
+    JsonResponse response = createCompleted.get(CONNECTION_TIMEOUT, TimeUnit.SECONDS);
+    JsonObject representation = response.getJson();
+
+    JsonArray errors = representation.getJsonArray("errors");
+    JsonObject error  = errors.getJsonObject(0);
+
+    assertThat(String.format("Failed to create request policy: %s", response.getBody()),
+      response.getStatusCode(), is(HttpURLConnection.HTTP_INTERNAL_ERROR));
+    assertThat("unexpected error message" , error.getString("message").contains("invalid input syntax for type uuid"));
+  }
+
+  @Test
+  public void canGetRequestPolicies()
+    throws InterruptedException,
+    MalformedURLException,
+    TimeoutException,
+    ExecutionException {
+
+    CompletableFuture<JsonResponse> createCompleted1 = new CompletableFuture<>();
+    CompletableFuture<JsonResponse> createCompleted2 = new CompletableFuture<>();
+    CompletableFuture<JsonResponse> createCompletedGet = new CompletableFuture<>();
+
+    List<RequestType> requestTypes = Arrays.asList( RequestType.HOLD, RequestType.PAGE);
+
+    UUID id1 = UUID.randomUUID();
+    RequestPolicy requestPolicy1 = new RequestPolicy();
+    requestPolicy1.withDescription("test policy");
+    requestPolicy1.withId(id1.toString());
+    requestPolicy1.withName("successful_get1");
+    requestPolicy1.withRequestTypes(requestTypes);
+
+    UUID id2 = UUID.randomUUID();
+    RequestPolicy requestPolicy2 = new RequestPolicy();
+    requestPolicy2.withDescription("test policy");
+    requestPolicy2.withId(id2.toString());
+    requestPolicy2.withName("successful_get2");
+    requestPolicy2.withRequestTypes(requestTypes);
+
+    //Create requestPolicy1
+    client.post(requestPolicyStorageUrl(""),
+      requestPolicy1,
+      StorageTestSuite.TENANT_ID,
+      ResponseHandler.json(createCompleted1));
+
+    JsonResponse response1 = createCompleted1.get(CONNECTION_TIMEOUT, TimeUnit.SECONDS);
+
+    assertThat("Failed to create new request-policy", response1.getStatusCode(), is(HttpURLConnection.HTTP_CREATED));
+
+    //Create requestPolicy2
+    client.post(requestPolicyStorageUrl(""),
+      requestPolicy2,
+      StorageTestSuite.TENANT_ID,
+      ResponseHandler.json(createCompleted2));
+
+    JsonResponse response2 = createCompleted2.get(CONNECTION_TIMEOUT, TimeUnit.SECONDS);
+    assertThat("Failed to create new request-policy", response2.getStatusCode(), is(HttpURLConnection.HTTP_CREATED));
+
+    //Get the newly created request policies
+    client.get(requestPolicyStorageUrl(""), StorageTestSuite.TENANT_ID,
+      ResponseHandler.json(createCompletedGet));
+
+    JsonResponse responseGet = createCompletedGet.get(CONNECTION_TIMEOUT, TimeUnit.SECONDS);
+    JsonObject getResultsJson = responseGet.getJson();
+
+    JsonArray requestPolicies = getResultsJson.getJsonArray("requestPolicies");
+    assertThat(getResultsJson.getInteger("totalRecords"), is(2));
+
+    for (int i = 0; i < 2; i ++) {
+      JsonObject aPolicy = requestPolicies.getJsonObject(i);
+
+      if (i == 0) {
+        assertThat(aPolicy.getString("id"), is(id1.toString()));
+      }
+      else {
+        assertThat(aPolicy.getString("id"), is(id2.toString()));
+      }
+
+      assertThat(aPolicy.getString("name"), is("successful_get" +(i+1)));
+      assertThat(aPolicy.getString("description"), is("test policy"));
+
+      JsonArray resultRequestTypes = aPolicy.getJsonArray("requestTypes");
+
+      for ( Object type : resultRequestTypes) {
+        assertThat("requestType returned: " + type.toString() + " does not exist in input list",
+          requestTypes.contains(RequestType.fromValue(type.toString())));
+      }
+    }
+  }
+
+  @Test
+  public void canGetRequestPoliciesByIdUsingQuery()
+    throws InterruptedException,
+    MalformedURLException,
+    TimeoutException,
+    ExecutionException {
+
+    CompletableFuture<JsonResponse> getCommpleted = new CompletableFuture<>();
+
+    RequestPolicy requestPolicy1 = createDefaultRequestPolicy();
+
+    //Get the newly created request policies
+    client.get(requestPolicyStorageUrl("?query=id="+ requestPolicy1.getId()), StorageTestSuite.TENANT_ID,
+      ResponseHandler.json(getCommpleted));
+
+    JsonResponse responseGet = getCommpleted.get(CONNECTION_TIMEOUT, TimeUnit.SECONDS);
+    JsonObject responseJson = responseGet.getJson();
+
+    JsonArray requestPolicies = responseJson.getJsonArray("requestPolicies");
+    assertThat(responseJson.getInteger("totalRecords"), is(1));
+
+    JsonObject aPolicy = requestPolicies.getJsonObject(0);
+
+    assertThat(aPolicy.getString("id"), is(requestPolicy1.getId()));
+    assertThat(aPolicy.getString("name"), is(requestPolicy1.getName()));
+    assertThat(aPolicy.getString("description"), is(requestPolicy1.getDescription()));
+
+    JsonArray resultRequestTypes = aPolicy.getJsonArray("requestTypes");
+
+    for ( Object type : resultRequestTypes) {
+      assertThat("requestType returned: " + type.toString() + " does not exist in input list",
+        requestPolicy1.getRequestTypes().contains(RequestType.fromValue(type.toString())));
+    }
+  }
+
+  @Test
+  public void cannotGetRequestPoliciesByUsingInvalidOffsetAndLimit()
+    throws InterruptedException,
+    MalformedURLException,
+    TimeoutException,
+    ExecutionException {
+
+    CompletableFuture<JsonResponse> getCommpleted = new CompletableFuture<>();
+
+    RequestPolicy requestPolicy = createDefaultRequestPolicy();
+
+    //Get the newly created request policies
+    client.get(requestPolicyStorageUrl("?query=(name=" + requestPolicy.getId() + ")&limit=-1&offset=-230"), StorageTestSuite.TENANT_ID,
+      ResponseHandler.json(getCommpleted));
+
+    JsonResponse responseGet = getCommpleted.get(CONNECTION_TIMEOUT, TimeUnit.SECONDS);
+    assertThat("Failed to not get request-policy", responseGet.getStatusCode(), is(HttpURLConnection.HTTP_INTERNAL_ERROR));
+    JsonObject response = responseGet.getJson();
+    JsonArray errors = response.getJsonArray("errors");
+    JsonObject anError = errors.getJsonObject(0);
+
+    assertThat("expected error message not found",anError.getString("message").contains("OFFSET must not be negative"));
+  }
+
+  @Test
+  public void cannotGetRequestPoliciesByNonExistentName()
+    throws InterruptedException,
+    MalformedURLException,
+    TimeoutException,
+    ExecutionException {
+
+    CompletableFuture<JsonResponse> getCommpleted = new CompletableFuture<>();
+
+    RequestPolicy requestPolicy = createDefaultRequestPolicy();
+
+    //Get the newly created request policies
+    client.get(requestPolicyStorageUrl("?query=name=" + requestPolicy.getName() + "blabblabla"), StorageTestSuite.TENANT_ID,
+      ResponseHandler.json(getCommpleted));
+
+    JsonResponse responseGet = getCommpleted.get(CONNECTION_TIMEOUT, TimeUnit.SECONDS);
+    assertThat("Failed to not get request-policy", responseGet.getStatusCode(), is(HttpURLConnection.HTTP_OK));
+
+    JsonObject getResultsJson = responseGet.getJson();
+    assertThat(getResultsJson.getInteger("totalRecords"), is(0));
+  }
+
+  @Test
+  public void canGetRequestPoliciesByName()
+    throws InterruptedException,
+    MalformedURLException,
+    TimeoutException,
+    ExecutionException {
+
+    CompletableFuture<JsonResponse> createCompleted1 = new CompletableFuture<>();
+    CompletableFuture<JsonResponse> createCompleted2 = new CompletableFuture<>();
+    CompletableFuture<JsonResponse> getCommpleted = new CompletableFuture<>();
+
+    List<RequestType> requestTypes = Arrays.asList( RequestType.HOLD, RequestType.PAGE);
+
+    UUID id1 = UUID.randomUUID();
+    RequestPolicy requestPolicy1 = new RequestPolicy();
+    requestPolicy1.withDescription("test policy");
+    requestPolicy1.withId(id1.toString());
+    requestPolicy1.withName("successful_get1");
+    requestPolicy1.withRequestTypes(requestTypes);
+
+    UUID id2 = UUID.randomUUID();
+    RequestPolicy requestPolicy2 = new RequestPolicy();
+    requestPolicy2.withDescription("test policy");
+    requestPolicy2.withId(id2.toString());
+    requestPolicy2.withName("successful Get2");
+    requestPolicy2.withRequestTypes(requestTypes);
+
+    //Create requestPolicy1
+    client.post(requestPolicyStorageUrl(""),
+      requestPolicy1,
+      StorageTestSuite.TENANT_ID,
+      ResponseHandler.json(createCompleted1));
+
+    JsonResponse response1 = createCompleted1.get(CONNECTION_TIMEOUT, TimeUnit.SECONDS);
+
+    assertThat("Failed to create new request-policy", response1.getStatusCode(), is(HttpURLConnection.HTTP_CREATED));
+
+    //Create requestPolicy2
+    client.post(requestPolicyStorageUrl(""),
+      requestPolicy2,
+      StorageTestSuite.TENANT_ID,
+      ResponseHandler.json(createCompleted2));
+
+    JsonResponse response2 = createCompleted2.get(CONNECTION_TIMEOUT, TimeUnit.SECONDS);
+    assertThat("Failed to create new request-policy", response2.getStatusCode(), is(HttpURLConnection.HTTP_CREATED));
+
+    //Get the newly created request policies
+    client.get(requestPolicyStorageUrl("?query=name=successful+Get2"), StorageTestSuite.TENANT_ID,
+      ResponseHandler.json(getCommpleted));
+
+    JsonResponse responseGet = getCommpleted.get(CONNECTION_TIMEOUT, TimeUnit.SECONDS);
+    JsonObject getResultsJson = responseGet.getJson();
+
+    JsonArray requestPolicies = getResultsJson.getJsonArray("requestPolicies");
+    assertThat(getResultsJson.getInteger("totalRecords"), is(1));
+
+    JsonObject aPolicy = requestPolicies.getJsonObject(0);
+    assertThat(aPolicy.getString("id"), is(id2.toString()));
+    assertThat(aPolicy.getString("name"), is("successful Get2"));
+    assertThat(aPolicy.getString("description"), is("test policy"));
+
+    JsonArray resultRequestTypes = aPolicy.getJsonArray("requestTypes");
+
+    for ( Object type : resultRequestTypes) {
+      assertThat("requestType returned: " + type.toString() + " does not exist in input list",
+        requestTypes.contains(RequestType.fromValue(type.toString())));
+    }
+  }
+
+  @Test
+  public void canGetRequestPoliciesById()
+    throws InterruptedException,
+    MalformedURLException,
+    TimeoutException,
+    ExecutionException {
+
+    CompletableFuture<JsonResponse> getCommpleted = new CompletableFuture<>();
+    List<RequestType> requestTypes = Arrays.asList( RequestType.HOLD, RequestType.RECALL);
+
+    createDefaultRequestPolicy();
+    RequestPolicy req2 = createDefaultRequestPolicy(UUID.randomUUID(), "request2 name",
+                              "request policy 2 descr", requestTypes );
+
+    //Get the newly created request policies
+    client.get(requestPolicyStorageUrl("/" + req2.getId()), StorageTestSuite.TENANT_ID,
+      ResponseHandler.json(getCommpleted));
+
+    JsonResponse responseGet = getCommpleted.get(CONNECTION_TIMEOUT, TimeUnit.SECONDS);
+    JsonObject aPolicy = responseGet.getJson();
+
+    assertThat(aPolicy.getString("id"), is(req2.getId()));
+    assertThat(aPolicy.getString("name"), is(req2.getName()));
+    assertThat(aPolicy.getString("description"), is(req2.getDescription()));
+
+    JsonArray resultRequestTypes = aPolicy.getJsonArray("requestTypes");
+
+    for ( Object type : resultRequestTypes) {
+      assertThat("requestType returned: " + type.toString() + " does not exist in input list",
+        req2.getRequestTypes().contains(RequestType.fromValue(type.toString())));
+    }
+  }
+
+  @Test
+  public void cannotGetRequestPoliciesByNonexistingId()
+    throws InterruptedException,
+    MalformedURLException,
+    TimeoutException,
+    ExecutionException {
+
+    createDefaultRequestPolicy();
+
+    CompletableFuture<JsonResponse> getCompleted = new CompletableFuture<>();
+    UUID id = UUID.randomUUID();
+
+    //Get the newly created request policies
+    client.get(requestPolicyStorageUrl("/" +id.toString()), StorageTestSuite.TENANT_ID,
+      ResponseHandler.json(getCompleted));
+
+    JsonResponse responseGet = getCompleted.get(CONNECTION_TIMEOUT, TimeUnit.SECONDS);
+    assertThat("Failed to not retrieve a request policy by non-existing ID", responseGet.getStatusCode(), is(HttpURLConnection.HTTP_NOT_FOUND));
+  }
+
+  @Test
+  public void canDeleteRequestPolicies()
+    throws InterruptedException,
+    MalformedURLException,
+    TimeoutException,
+    ExecutionException {
+
+    //Get them to verify that they're in the system.
+    CompletableFuture<JsonResponse> getCompleted = new CompletableFuture<>();
+    CompletableFuture<JsonResponse> delCompleted = new CompletableFuture<>();
+    CompletableFuture<JsonResponse> getCompletedVerify = new CompletableFuture<>();
+
+    //create a couple of request policies to delete.
+    createDefaultRequestPolicy();
+    createDefaultRequestPolicy(UUID.randomUUID(), "test policy 2", "descr of test policy 2", null );
+
+    //Get the newly created request policies
+    client.get(requestPolicyStorageUrl( ""), StorageTestSuite.TENANT_ID,
+      ResponseHandler.json(getCompleted));
+
+    JsonResponse responseGet = getCompleted.get(CONNECTION_TIMEOUT, TimeUnit.SECONDS);
+    JsonObject getResultsJson = responseGet.getJson();
+
+    assertThat(getResultsJson.getInteger("totalRecords"), is(2));
+
+    //Delete all policies
+    client.delete(requestPolicyStorageUrl( ""), StorageTestSuite.TENANT_ID,
+      ResponseHandler.json(delCompleted));
+    JsonResponse responseDel = delCompleted.get(CONNECTION_TIMEOUT, TimeUnit.SECONDS);
+
+    assertThat("Failed to delete all request policies", responseDel.getStatusCode(), is(HttpURLConnection.HTTP_NO_CONTENT));
+
+    //Get all policies again to verify that none comes back
+    client.get(requestPolicyStorageUrl( ""), StorageTestSuite.TENANT_ID,
+      ResponseHandler.json(getCompletedVerify));
+
+    JsonResponse responseGetVerify = getCompletedVerify.get(CONNECTION_TIMEOUT, TimeUnit.SECONDS);
+    JsonObject getResultsVerfiyJson = responseGetVerify.getJson();
+
+    assertThat(getResultsVerfiyJson.getInteger("totalRecords"), is(0));
+  }
+
+  @Test
+  public void canDeleteRequestPoliciesById()
+    throws InterruptedException,
+    MalformedURLException,
+    TimeoutException,
+    ExecutionException {
+
+    //Get them to verify that they're in the system.
+    CompletableFuture<JsonResponse> getCompleted = new CompletableFuture<>();
+    CompletableFuture<JsonResponse> delCompleted = new CompletableFuture<>();
+    CompletableFuture<JsonResponse> getCompletedVerify = new CompletableFuture<>();
+
+    //create a couple of request policies to delete.
+    RequestPolicy rp = createDefaultRequestPolicy();
+
+    //Get the newly created request policies
+    client.get(requestPolicyStorageUrl( "/" + rp.getId()), StorageTestSuite.TENANT_ID,
+      ResponseHandler.json(getCompleted));
+
+    JsonResponse responseGet = getCompleted.get(CONNECTION_TIMEOUT, TimeUnit.SECONDS);
+    JsonObject getResultsJson = responseGet.getJson();
+
+    assertThat("response is null", getResultsJson != null);
+    assertThat(getResultsJson.getString("id"), is(rp.getId()));
+
+    //Delete existing policy
+    client.delete(requestPolicyStorageUrl( "/" + rp.getId()), StorageTestSuite.TENANT_ID,
+      ResponseHandler.json(delCompleted));
+    JsonResponse responseDel = delCompleted.get(CONNECTION_TIMEOUT, TimeUnit.SECONDS);
+
+    assertThat("Failed to delete all request policies", responseDel.getStatusCode(), is(HttpURLConnection.HTTP_NO_CONTENT));
+
+    //Get all policies again to verify that none comes back
+    client.get(requestPolicyStorageUrl( "/" + rp.getId()), StorageTestSuite.TENANT_ID,
+      ResponseHandler.json(getCompletedVerify));
+
+    JsonResponse responseGetVerify = getCompletedVerify.get(CONNECTION_TIMEOUT, TimeUnit.SECONDS);
+    assertThat("Failed to not get request-policy", responseGetVerify.getStatusCode(), is(HttpURLConnection.HTTP_NOT_FOUND));
+  }
+
+  @Test
+  public void cannotDeleteRequestPoliciesByNonExistingId()
+    throws InterruptedException,
+    MalformedURLException,
+    TimeoutException,
+    ExecutionException {
+
+    //Get them to verify that they're in the system.
+    CompletableFuture<JsonResponse> delCompleted = new CompletableFuture<>();
+
+    //Delete existing policy
+    client.delete(requestPolicyStorageUrl( "/" + UUID.randomUUID().toString()), StorageTestSuite.TENANT_ID,
+      ResponseHandler.json(delCompleted));
+    JsonResponse responseDel = delCompleted.get(CONNECTION_TIMEOUT, TimeUnit.SECONDS);
+
+    assertThat("Failed to not delete all request policies", responseDel.getStatusCode(), is(HttpURLConnection.HTTP_NO_CONTENT));
+  }
+
+  @Test
+  public void canUpdateRequestPolicy()
+    throws InterruptedException,
+    MalformedURLException,
+    TimeoutException,
+    ExecutionException {
+
+    CompletableFuture<JsonResponse> updateCompleted = new CompletableFuture<>();
+
+    List<RequestType> requestTypes = Arrays.asList( RequestType.HOLD, RequestType.PAGE);
+    RequestPolicy requestPolicy = createDefaultRequestPolicy(UUID.randomUUID(), "sample requet policy",
+                                                            "plain description", requestTypes);
+    //update requestPolicy to new values
+    requestPolicy.setDescription("new description");
+    requestPolicy.setName("sample request policies");
+    requestPolicy.setRequestTypes(Arrays.asList( RequestType.RECALL, RequestType.HOLD));
+
+    client.put(requestPolicyStorageUrl("/" + requestPolicy.getId()),
+      requestPolicy,
+      StorageTestSuite.TENANT_ID,
+      ResponseHandler.json(updateCompleted));
+
+    JsonResponse response = updateCompleted.get(CONNECTION_TIMEOUT, TimeUnit.SECONDS);
+    assertThat("Failed to update request-policy", response.getStatusCode(), is(HttpURLConnection.HTTP_NO_CONTENT));
+
+    //Get it and examine the updated content
+    CompletableFuture<JsonResponse> getCompleted = new CompletableFuture<>();
+    client.get(requestPolicyStorageUrl("/" + requestPolicy.getId()),
+      StorageTestSuite.TENANT_ID,
+      ResponseHandler.json(getCompleted));
+
+    JsonResponse getResponse = getCompleted.get(CONNECTION_TIMEOUT, TimeUnit.SECONDS);
+    assertThat("Failed to update request-policy", getResponse.getStatusCode(), is(HttpURLConnection.HTTP_OK));
+
+    JsonObject aPolicy = getResponse.getJson();
+
+    assertThat(aPolicy.getString("id"), is(requestPolicy.getId()));
+    assertThat(aPolicy.getString("name"), is(requestPolicy.getName()));
+    assertThat(aPolicy.getString("description"), is(requestPolicy.getDescription()));
+
+    JsonArray resultRequestTypes = aPolicy.getJsonArray("requestTypes");
+
+    for ( Object type : resultRequestTypes) {
+      assertThat("requestType returned: " + type.toString() + " does not exist in input list",
+        requestPolicy.getRequestTypes().contains(RequestType.fromValue(type.toString())));
+    }
+  }
+
+  @Test
+  public void cannotUpdateRequestPolicyWithWrongId()
+    throws InterruptedException,
+    MalformedURLException,
+    TimeoutException,
+    ExecutionException {
+
+    CompletableFuture<JsonResponse> updateCompleted = new CompletableFuture<>();
+
+    List<RequestType> requestTypes = Arrays.asList( RequestType.HOLD, RequestType.PAGE);
+    RequestPolicy requestPolicy = createDefaultRequestPolicy(UUID.randomUUID(), "sample request policy",
+      "plain description", requestTypes);
+    //update
+    String newUid = UUID.randomUUID().toString();
+    requestPolicy.setDescription("new description");
+
+    client.put(requestPolicyStorageUrl("/" + newUid),
+      requestPolicy,
+      StorageTestSuite.TENANT_ID,
+      ResponseHandler.json(updateCompleted));
+
+    //Because of the unique name constraint, instead of getting an error message about a nonexistent object, the message
+    //is about duplicate name. This happens because PUT can also be used to add a new record to the database.
+    JsonResponse response = updateCompleted.get(CONNECTION_TIMEOUT, TimeUnit.SECONDS);
+    JsonObject anError = extractErrorObject(response);
+    assertThat("Failed to update request-policy", response.getStatusCode(), is(HttpURLConnection.HTTP_INTERNAL_ERROR));
+    assertThat("Error message does not contain keyword 'already existed'", anError.getString("message").contains("already exists"));
+  }
+
+  @Test
+  public void cannotUpdateRequestPolicyToExistingPolicyName()
+    throws InterruptedException,
+    MalformedURLException,
+    TimeoutException,
+    ExecutionException {
+
+    CompletableFuture<JsonResponse> updateCompleted = new CompletableFuture<>();
+    String policy1Name = "Policy 1";
+    String policy2Name = "Policy 2";
+
+    List<RequestType> requestTypes = Arrays.asList( RequestType.HOLD, RequestType.PAGE);
+    createDefaultRequestPolicy(UUID.randomUUID(), policy1Name,
+      "plain description", requestTypes);
+
+    RequestPolicy requestPolicy2 = createDefaultRequestPolicy(UUID.randomUUID(), policy2Name,
+      "plain description", requestTypes);
+
+    //update: set the name of requestPolicy2 to be of policy1's.
+    requestPolicy2.setDescription("new description for policy 2");
+    requestPolicy2.setName(policy1Name);
+    requestPolicy2.setRequestTypes(Arrays.asList( RequestType.RECALL, RequestType.HOLD));
+
+    client.put(requestPolicyStorageUrl("/" + requestPolicy2.getId()),
+      requestPolicy2,
+      StorageTestSuite.TENANT_ID,
+      ResponseHandler.json(updateCompleted));
+
+    JsonResponse response = updateCompleted.get(CONNECTION_TIMEOUT, TimeUnit.SECONDS);
+    assertThat("Failed to update request-policy", response.getStatusCode(), is(HttpURLConnection.HTTP_INTERNAL_ERROR));
+
+    JsonObject anError = extractErrorObject(response);
+
+    assertThat("Error message does not contain keyword 'already existed'", anError.getString("message").contains("already exists"));
+  }
+
+  @Test
+  public void canUpdateRequestPolicyWithNewId()
+    throws InterruptedException,
+    MalformedURLException,
+    TimeoutException,
+    ExecutionException {
+
+    CompletableFuture<JsonResponse> updateCompleted = new CompletableFuture<>();
+
+    List<RequestType> requestTypes = Arrays.asList( RequestType.HOLD, RequestType.PAGE);
+    RequestPolicy requestPolicy = createDefaultRequestPolicy(UUID.randomUUID(), "old name",
+      "plain description", requestTypes);
+
+    //update requestPolicy
+    String newUid = UUID.randomUUID().toString();
+    requestPolicy.setDescription("new description");
+    requestPolicy.setName("new name");
+    requestPolicy.setId(newUid);
+
+    client.put(requestPolicyStorageUrl("/" + newUid),
+      requestPolicy,
+      StorageTestSuite.TENANT_ID,
+      ResponseHandler.json(updateCompleted));
+
+    JsonResponse response = updateCompleted.get(CONNECTION_TIMEOUT, TimeUnit.SECONDS);
+    assertThat("Failed to update request-policy", response.getStatusCode(), is(HttpURLConnection.HTTP_NO_CONTENT));
+  }
+
+  @Test
+  public void cannotUpdateRequestPolicyToBadId()
+    throws InterruptedException,
+    MalformedURLException,
+    TimeoutException,
+    ExecutionException {
+
+    CompletableFuture<JsonResponse> updateCompleted = new CompletableFuture<>();
+    String policy1Name = "select count(*)";
+    String badId = "select count(*)";
+
+    List<RequestType> requestTypes = Arrays.asList( RequestType.HOLD, RequestType.PAGE);
+    RequestPolicy requestPolicy = createDefaultRequestPolicy(UUID.randomUUID(), policy1Name,
+      "plain description", requestTypes);
+
+    //update set RequestPolicy's Id to nonexistent.
+    requestPolicy.setId(badId);
+    requestPolicy.setDescription("new description for policy 1");
+    requestPolicy.setRequestTypes(Arrays.asList( RequestType.RECALL, RequestType.HOLD));
+
+    client.put(requestPolicyStorageUrl("/" + requestPolicy.getId()),
+      requestPolicy,
+      StorageTestSuite.TENANT_ID,
+      ResponseHandler.json(updateCompleted));
+
+    JsonResponse response = updateCompleted.get(CONNECTION_TIMEOUT, TimeUnit.SECONDS);
+    assertThat("Failed to update request-policy", response.getStatusCode(), is(HttpURLConnection.HTTP_INTERNAL_ERROR));
+
+    JsonObject anError = extractErrorObject(response);
+
+    assertThat("Error message does not contain keyword 'already existed'", anError.getString("message").contains("already exists"));
+  }
+
+  private URL requestPolicyStorageUrl(String path) throws MalformedURLException {
+    String completePath = "/request-policy-storage/request-policies" + path;
+    return StorageTestSuite.storageUrl(completePath);
+  }
+
+  private RequestPolicy createDefaultRequestPolicy()  throws InterruptedException,
+    MalformedURLException,
+    TimeoutException,
+    ExecutionException {
+
+    List<RequestType> requestTypes = Arrays.asList( RequestType.HOLD, RequestType.PAGE);
+    UUID id1 = UUID.randomUUID();
+
+    return createDefaultRequestPolicy(id1, DEFAULT_REQUEST_POLICY_NAME, "test policy", requestTypes);
+  }
+
+  private RequestPolicy createDefaultRequestPolicy(UUID id, String name, String descr, List<RequestType> requestTypes)  throws InterruptedException,
+    MalformedURLException,
+    TimeoutException,
+    ExecutionException {
+
+    CompletableFuture<JsonResponse> createCommpleted = new CompletableFuture<>();
+
+    RequestPolicy requestPolicy = new RequestPolicy();
+    requestPolicy.withDescription(descr);
+    requestPolicy.withId(id.toString());
+    requestPolicy.withName(name);
+    requestPolicy.withRequestTypes(requestTypes);
+
+    //Create requestPolicy
+    client.post(requestPolicyStorageUrl(""),
+      requestPolicy,
+      StorageTestSuite.TENANT_ID,
+      ResponseHandler.json(createCommpleted));
+
+    JsonResponse response = createCommpleted.get(CONNECTION_TIMEOUT, TimeUnit.SECONDS);
+    assertThat("Failed to create new request-policy", response.getStatusCode(), is(HttpURLConnection.HTTP_CREATED));
+
+    return  requestPolicy;
+  }
+
+  private JsonObject extractErrorObject(JsonResponse response){
+    JsonObject responseJson = response.getJson();
+    JsonArray errors = responseJson.getJsonArray("errors");
+    JsonObject anError = errors.getJsonObject(0);
+
+    return anError;
+  }
+
+}

--- a/src/test/java/org/folio/rest/api/RequestPoliciesApiTest.java
+++ b/src/test/java/org/folio/rest/api/RequestPoliciesApiTest.java
@@ -2,21 +2,17 @@ package org.folio.rest.api;
 
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
-import org.folio.rest.jaxrs.model.Errors;
-import org.folio.rest.jaxrs.model.Request;
 import org.folio.rest.jaxrs.model.RequestPolicy;
 import org.folio.rest.jaxrs.model.RequestType;
 import org.folio.rest.support.ApiTests;
 import org.folio.rest.support.JsonResponse;
 import org.folio.rest.support.ResponseHandler;
 import org.junit.After;
-import org.junit.Before;
 import org.junit.Test;
 
 import java.net.HttpURLConnection;
 import java.net.MalformedURLException;
 import java.net.URL;
-import java.rmi.server.UID;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -34,7 +30,7 @@ public class RequestPoliciesApiTest extends ApiTests {
 
   private static final int CONNECTION_TIMEOUT = 5;
   private static final String DEFAULT_REQUEST_POLICY_NAME = "default_request_policy";
-/*
+
   @After
   public void CleanupAfterEachTest()
     throws InterruptedException,
@@ -50,7 +46,7 @@ public class RequestPoliciesApiTest extends ApiTests {
     JsonResponse response = deleteCompleted.get(CONNECTION_TIMEOUT, TimeUnit.SECONDS);
     assertThat("response is null", response != null);
   }
-*/
+
   @Test
   public void canCreateARequestPolicy()
     throws InterruptedException,
@@ -729,39 +725,6 @@ public class RequestPoliciesApiTest extends ApiTests {
 
     JsonResponse response = updateCompleted.get(CONNECTION_TIMEOUT, TimeUnit.SECONDS);
     assertThat("Failed to update request-policy", response.getStatusCode(), is(HttpURLConnection.HTTP_NO_CONTENT));
-  }
-
-  @Test
-  public void cannotUpdateRequestPolicyToBadId()
-    throws InterruptedException,
-    MalformedURLException,
-    TimeoutException,
-    ExecutionException {
-
-    CompletableFuture<JsonResponse> updateCompleted = new CompletableFuture<>();
-    String policy1Name = "select count(*)";
-    String badId = "select count(*)";
-
-    List<RequestType> requestTypes = Arrays.asList( RequestType.HOLD, RequestType.PAGE);
-    RequestPolicy requestPolicy = createDefaultRequestPolicy(UUID.randomUUID(), policy1Name,
-      "plain description", requestTypes);
-
-    //update set RequestPolicy's Id to nonexistent.
-    requestPolicy.setId(badId);
-    requestPolicy.setDescription("new description for policy 1");
-    requestPolicy.setRequestTypes(Arrays.asList( RequestType.RECALL, RequestType.HOLD));
-
-    client.put(requestPolicyStorageUrl("/" + requestPolicy.getId()),
-      requestPolicy,
-      StorageTestSuite.TENANT_ID,
-      ResponseHandler.json(updateCompleted));
-
-    JsonResponse response = updateCompleted.get(CONNECTION_TIMEOUT, TimeUnit.SECONDS);
-    assertThat("Failed to update request-policy", response.getStatusCode(), is(HttpURLConnection.HTTP_INTERNAL_ERROR));
-
-    JsonObject anError = extractErrorObject(response);
-
-    assertThat("Error message does not contain keyword 'already existed'", anError.getString("message").contains("already exists"));
   }
 
   private URL requestPolicyStorageUrl(String path) throws MalformedURLException {

--- a/src/test/java/org/folio/rest/api/StorageTestSuite.java
+++ b/src/test/java/org/folio/rest/api/StorageTestSuite.java
@@ -44,7 +44,8 @@ import io.vertx.ext.sql.ResultSet;
   LoansApiHistoryTest.class,
   StaffSlipsApiTest.class,
   CancellationReasonsApiTest.class,
-  PatronNoticePoliciesApiTest.class
+  PatronNoticePoliciesApiTest.class,
+  RequestPoliciesApiTest.class
 })
 
 public class StorageTestSuite {


### PR DESCRIPTION
Added a new set of CRUD APIs for RequestPolicy at: /request-policy-storage/request-policies
- created new database table "request_policy" 
- added corresponding ramls and json schemas
- added request-type.json schema for request types, which can be reused elsewhere.
- the only business logic implemented is validation that request-policy name is required and unique
- implementation is based on previous CRUD implementations in the module
- all error messages are wrapped in the Error JSON structure. 

Cannot add tests to cover all the exception and negative cases because it's virtually impossible to trigger errors for them.
