### PR TITLE
Circstore 97 fix

### DIFF
--- a/ramls/request-policy-storage.raml
+++ b/ramls/request-policy-storage.raml
@@ -40,17 +40,20 @@ resourceTypes:
        500:
          description: "General errors"
          body:
-           application/json:
-             type: errors
+          text/plain:
+            example: "Internal server error, contact administrator"
     post:
       responses:
         201:
           description: "Request policy created"
+          body:
+            application/json:
+              type: request-policy
         500:
            description: "General errors"
            body:
-             application/json:
-               type: errors
+            text/plain:
+              example: "Internal server error, contact administrator"
     delete:
       is: [language]
       responses:
@@ -59,8 +62,8 @@ resourceTypes:
         500:
           description: "General errors"
           body:
-            application/json:
-              type: errors
+            text/plain:
+              example: "Internal server error, contact administrator"
         501:
           description: "Not implemented yet"
     /{requestPolicyId}:
@@ -72,18 +75,21 @@ resourceTypes:
         responses:
           200:
             description: "Request policy successfully retreived"
+            body:
+              application/json:
+                type: request-policy
           501:
             description: "Not implemented yet"
           500:
             description: "General errors"
             body:
-             application/json:
-               type: errors
+              text/plain:
+                example: "Internal server error, contact administrator"
           404:
             description: "Not found"
             body:
-              application/json:
-                type: errors
+              text/plain:
+                example: "Internal server error, contact administrator"
       put:
         responses:
           204:
@@ -93,8 +99,8 @@ resourceTypes:
           500:
              description: "General errors"
              body:
-               application/json:
-                 type: errors
+              text/plain:
+                example: "Internal server error, contact administrator"
       delete:
         responses:
           204:
@@ -102,5 +108,5 @@ resourceTypes:
           500:
             description: "General errors"
             body:
-             application/json:
-               type: errors
+              text/plain:
+                example: "Internal server error, contact administrator"

--- a/ramls/request-policy-storage.raml
+++ b/ramls/request-policy-storage.raml
@@ -44,6 +44,8 @@ resourceTypes:
              type: errors
     post:
       responses:
+        201:
+          description: "Request policy created"
         500:
            description: "General errors"
            body:
@@ -55,10 +57,10 @@ resourceTypes:
         204:
           description: "All request policies deleted"
         500:
-          description: "Internal server error, e.g. due to misconfiguration"
+          description: "General errors"
           body:
             application/json:
-              example: "Internal server error, contact administrator"
+              type: errors
         501:
           description: "Not implemented yet"
     /{requestPolicyId}:
@@ -68,6 +70,8 @@ resourceTypes:
           schema: request-policy
       get:
         responses:
+          200:
+            description: "Request policy successfully retreived"
           501:
             description: "Not implemented yet"
           500:
@@ -82,6 +86,8 @@ resourceTypes:
                 type: errors
       put:
         responses:
+          204:
+            description: "Request policy successfully updated"
           501:
             description: "Not implemented yet"
           500:
@@ -91,6 +97,8 @@ resourceTypes:
                  type: errors
       delete:
         responses:
+          204:
+            description: "Request policy successfully deleted"
           500:
             description: "General errors"
             body:

--- a/src/main/java/org/folio/rest/impl/RequestPoliciesAPI.java
+++ b/src/main/java/org/folio/rest/impl/RequestPoliciesAPI.java
@@ -173,7 +173,7 @@ public class RequestPoliciesAPI implements RequestPolicyStorage {
       catch(Exception e) {
         asyncResultHandler.handle(io.vertx.core.Future.succeededFuture(
           RequestPolicyStorage.DeleteRequestPolicyStorageRequestPoliciesResponse
-            .respond500WithApplicationJson(e.getMessage())));
+            .respond500WithApplicationJson(ValidationHelper.createValidationErrorMessage("name", RequestPolicy.class.getName(), e.getMessage()))));
       }
     });
   }

--- a/src/main/java/org/folio/rest/impl/RequestPoliciesAPI.java
+++ b/src/main/java/org/folio/rest/impl/RequestPoliciesAPI.java
@@ -71,27 +71,27 @@ public class RequestPoliciesAPI implements RequestPolicyStorage {
                 else {
                   asyncResultHandler.handle(io.vertx.core.Future.succeededFuture(
                     RequestPolicyStorage.GetRequestPolicyStorageRequestPoliciesResponse
-                      .respond500WithApplicationJson(ValidationHelper.createValidationErrorMessage("name", RequestPolicies.class.getName(), reply.cause().getMessage()))));
+                      .respond500WithTextPlain(reply.cause().getMessage())));
                 }
               } catch (Exception e) {
                 log.error(e);
                 asyncResultHandler.handle(io.vertx.core.Future.succeededFuture(
                   RequestPolicyStorage.GetRequestPolicyStorageRequestPoliciesResponse
-                    .respond500WithApplicationJson(ValidationHelper.createValidationErrorMessage("name", RequestPolicies.class.getName(), e.getMessage()))));
+                    .respond500WithTextPlain(e.getMessage())));
               }
             });
         } catch (Exception e) {
           log.error(e);
           asyncResultHandler.handle(io.vertx.core.Future.succeededFuture(
             RequestPolicyStorage.GetRequestPolicyStorageRequestPoliciesResponse
-            .respond500WithApplicationJson(ValidationHelper.createValidationErrorMessage("name", RequestPolicies.class.getName(), e.getMessage()))));
+            .respond500WithTextPlain(e.getMessage())));
         }
       });
     } catch (Exception e) {
       log.error(e);
       asyncResultHandler.handle(io.vertx.core.Future.succeededFuture(
         RequestPolicyStorage.GetRequestPolicyStorageRequestPoliciesResponse
-          .respond500WithApplicationJson(ValidationHelper.createValidationErrorMessage("name", RequestPolicies.class.getName(), e.getMessage()))));
+          .respond500WithTextPlain(e.getMessage())));
     }
   }
 
@@ -127,28 +127,28 @@ public class RequestPoliciesAPI implements RequestPolicyStorage {
                   asyncResultHandler.handle(
                     io.vertx.core.Future.succeededFuture(
                       RequestPolicyStorage.PostRequestPolicyStorageRequestPoliciesResponse
-                        .respond500WithApplicationJson(ValidationHelper.createValidationErrorMessage("name", entity.getName(), reply.cause().toString()))));
+                        .respond500WithTextPlain(reply.cause().toString())));
                 }
               } catch (Exception e) {
                 log.error(e);
                 asyncResultHandler.handle(
                   io.vertx.core.Future.succeededFuture(
                     RequestPolicyStorage.PostRequestPolicyStorageRequestPoliciesResponse
-                      .respond500WithApplicationJson(ValidationHelper.createValidationErrorMessage("name", entity.getName(), e.getMessage()))));
+                      .respond500WithTextPlain(e.getMessage())));
               }
             });
         } catch (Exception e) {
           log.error(e);
           asyncResultHandler.handle(io.vertx.core.Future.succeededFuture(
             RequestPolicyStorage.PostRequestPolicyStorageRequestPoliciesResponse
-              .respond500WithApplicationJson(ValidationHelper.createValidationErrorMessage("name", entity.getName(), e.getMessage()))));
+              .respond500WithTextPlain(e.getMessage())));
         }
       });
     } catch (Exception e) {
       log.error(e);
       asyncResultHandler.handle(io.vertx.core.Future.succeededFuture(
         RequestPolicyStorage.PostRequestPolicyStorageRequestPoliciesResponse
-          .respond500WithApplicationJson(ValidationHelper.createValidationErrorMessage("name", entity.getName(), e.getMessage()))));
+          .respond500WithTextPlain(e.getMessage())));
 
     }
   }
@@ -173,7 +173,7 @@ public class RequestPoliciesAPI implements RequestPolicyStorage {
       catch(Exception e) {
         asyncResultHandler.handle(io.vertx.core.Future.succeededFuture(
           RequestPolicyStorage.DeleteRequestPolicyStorageRequestPoliciesResponse
-            .respond500WithApplicationJson(ValidationHelper.createValidationErrorMessage("name", RequestPolicy.class.getName(), e.getMessage()))));
+            .respond500WithTextPlain(e.getMessage())));
       }
     });
   }
@@ -209,26 +209,26 @@ public class RequestPoliciesAPI implements RequestPolicyStorage {
                     asyncResultHandler.handle(
                       Future.succeededFuture(
                         RequestPolicyStorage.GetRequestPolicyStorageRequestPoliciesByRequestPolicyIdResponse.
-                          respond404WithApplicationJson(ValidationHelper.createValidationErrorMessage("name", RequestPolicy.class.getName(), "Not Found"))));
+                          respond404WithTextPlain(ValidationHelper.createValidationErrorMessage("name", RequestPolicy.class.getName(), "Not Found"))));
                   }
                 } else {
                   asyncResultHandler.handle(
                     Future.succeededFuture(
                       RequestPolicyStorage.GetRequestPolicyStorageRequestPoliciesByRequestPolicyIdResponse
-                        .respond500WithApplicationJson(ValidationHelper.createValidationErrorMessage("name", RequestPolicy.class.getName(), reply.cause().getMessage()))));
+                        .respond500WithTextPlain(reply.cause().getMessage())));
                 }
               } catch (Exception e) {
                 log.error(e);
                 asyncResultHandler.handle(io.vertx.core.Future.succeededFuture(
                   RequestPolicyStorage.GetRequestPolicyStorageRequestPoliciesByRequestPolicyIdResponse
-                  .respond500WithApplicationJson(ValidationHelper.createValidationErrorMessage("name", RequestPolicy.class.getName(), e.getMessage()))));
+                  .respond500WithTextPlain(e.getMessage())));
               }
             });
         } catch (Exception e) {
           log.error(e);
           asyncResultHandler.handle(io.vertx.core.Future.succeededFuture(
             RequestPolicyStorage.GetRequestPolicyStorageRequestPoliciesByRequestPolicyIdResponse
-            .respond500WithApplicationJson(ValidationHelper.createValidationErrorMessage("name", RequestPolicy.class.getName(), e.getMessage()))));
+            .respond500WithTextPlain(e.getMessage())));
         }
       });
     } catch (Exception e) {
@@ -236,7 +236,7 @@ public class RequestPoliciesAPI implements RequestPolicyStorage {
       asyncResultHandler.handle(io.vertx.core.Future.succeededFuture(
         RequestPolicyStorage.
           GetRequestPolicyStorageRequestPoliciesByRequestPolicyIdResponse
-            .respond500WithApplicationJson(ValidationHelper.createValidationErrorMessage("name", RequestPolicy.class.getName(), e.getMessage()))));
+            .respond500WithTextPlain(e.getMessage())));
     }
   }
 
@@ -271,7 +271,7 @@ public class RequestPoliciesAPI implements RequestPolicyStorage {
                     } else {
                       asyncResultHandler.handle(
                         Future.succeededFuture(PutRequestPolicyStorageRequestPoliciesByRequestPolicyIdResponse
-                          .respond500WithApplicationJson(ValidationHelper.createValidationErrorMessage("name", entity.getName(), update.cause().getMessage()))));
+                          .respond500WithTextPlain(update.cause().getMessage())));
                     }
                   });
               } else {
@@ -287,19 +287,19 @@ public class RequestPoliciesAPI implements RequestPolicyStorage {
                     } else {
                       asyncResultHandler.handle(
                         Future.succeededFuture(PutRequestPolicyStorageRequestPoliciesByRequestPolicyIdResponse
-                          .respond500WithApplicationJson(ValidationHelper.createValidationErrorMessage("name", entity.getName(), save.cause().getMessage()))));
+                          .respond500WithTextPlain(save.cause().getMessage())));
                     }
                   });
               }
             } else {
               asyncResultHandler.handle(Future.succeededFuture(PutRequestPolicyStorageRequestPoliciesByRequestPolicyIdResponse
-                .respond500WithApplicationJson(ValidationHelper.createValidationErrorMessage("name", entity.getName(), reply.cause().getMessage()))));
+                .respond500WithTextPlain(reply.cause().getMessage())));
             }
           })
       );
     } catch (Exception e) {
       asyncResultHandler.handle(Future.succeededFuture(PutRequestPolicyStorageRequestPoliciesByRequestPolicyIdResponse
-        .respond500WithApplicationJson(ValidationHelper.createValidationErrorMessage("name", entity.getName(), e.getMessage()))));
+        .respond500WithTextPlain(e.getMessage())));
     }
   }
 
@@ -328,19 +328,19 @@ public class RequestPoliciesAPI implements RequestPolicyStorage {
                 else {
                   asyncResultHandler.handle(Future.succeededFuture(
                     DeleteRequestPolicyStorageRequestPoliciesByRequestPolicyIdResponse
-                      .respond500WithApplicationJson(ValidationHelper.createValidationErrorMessage("name", RequestPolicy.class.getName(), reply.cause().getMessage()))));
+                      .respond500WithTextPlain(reply.cause().getMessage())));
                 }
               });
           } catch (Exception e) {
             asyncResultHandler.handle(Future.succeededFuture(
               DeleteRequestPolicyStorageRequestPoliciesByRequestPolicyIdResponse
-                .respond500WithApplicationJson(ValidationHelper.createValidationErrorMessage("name", RequestPolicy.class.getName(), e.getMessage()))));
+                .respond500WithTextPlain(e.getMessage())));
           }
         });
       } catch (Exception e) {
         asyncResultHandler.handle(Future.succeededFuture(
           DeleteRequestPolicyStorageRequestPoliciesByRequestPolicyIdResponse
-            .respond500WithApplicationJson(ValidationHelper.createValidationErrorMessage("name", RequestPolicy.class.getName(), e.getMessage()))));
+            .respond500WithTextPlain(e.getMessage())));
       }
   }
 

--- a/src/test/java/org/folio/rest/api/RequestPoliciesApiTest.java
+++ b/src/test/java/org/folio/rest/api/RequestPoliciesApiTest.java
@@ -119,8 +119,7 @@ public class RequestPoliciesApiTest extends ApiTests {
       assertThat(String.format("Failed to create request policy: %s", response2.getBody()),
         response2.getStatusCode(), is(HttpURLConnection.HTTP_INTERNAL_ERROR));
 
-      JsonObject error = extractErrorObject(response2);
-      assertThat("unexpected error message" , error.getString("message").contains("duplicate key value"));
+      assertThat("unexpected error message" , response2.getBody().contains("duplicate key value"));
   }
 
   @Test
@@ -149,8 +148,7 @@ public class RequestPoliciesApiTest extends ApiTests {
     JsonResponse response = createCompleted.get(CONNECTION_TIMEOUT, TimeUnit.SECONDS);
     assertThat(String.format("Failed to create request policy: %s", response.getBody()),
       response.getStatusCode(), is(HttpURLConnection.HTTP_INTERNAL_ERROR));
-    JsonObject error = extractErrorObject(response);
-    assertThat("unexpected error message" , error.getString("message").contains("invalid input syntax for type uuid"));
+    assertThat("unexpected error message" , response.getBody().contains("invalid input syntax for type uuid"));
   }
 
   @Test
@@ -224,12 +222,11 @@ public class RequestPoliciesApiTest extends ApiTests {
     JsonResponse responseGet = getCommpleted.get(CONNECTION_TIMEOUT, TimeUnit.SECONDS);
     assertThat("Failed to not get request-policy", responseGet.getStatusCode(), is(HttpURLConnection.HTTP_INTERNAL_ERROR));
 
-    JsonObject anError = extractErrorObject(responseGet);
-    assertThat("expected error message not found",anError.getString("message").contains("OFFSET must not be negative"));
+    assertThat("expected error message not found",responseGet.getBody().contains("OFFSET must not be negative"));
   }
 
   @Test
-  public void cannotGetRequestPoliciesByNonExistentName()
+  public void cannotGetRequestPolicyByNonExistentName()
     throws InterruptedException,
     MalformedURLException,
     TimeoutException,
@@ -251,7 +248,7 @@ public class RequestPoliciesApiTest extends ApiTests {
   }
 
   @Test
-  public void canGetRequestPoliciesByName()
+  public void canGetRequestPolicyByName()
     throws InterruptedException,
     MalformedURLException,
     TimeoutException,
@@ -279,7 +276,7 @@ public class RequestPoliciesApiTest extends ApiTests {
   }
 
   @Test
-  public void canGetRequestPoliciesById()
+  public void canGetRequestPolicyById()
     throws InterruptedException,
     MalformedURLException,
     TimeoutException,
@@ -321,8 +318,7 @@ public class RequestPoliciesApiTest extends ApiTests {
     JsonResponse responseGet = getCompleted.get(CONNECTION_TIMEOUT, TimeUnit.SECONDS);
     assertThat("Failed to not retrieve a request policy by non-existing ID", responseGet.getStatusCode(), is(HttpURLConnection.HTTP_NOT_FOUND));
 
-    JsonObject error = extractErrorObject(responseGet);
-    assertThat("Error message does not contain keyword 'already existed'", error.getString("message").contains("Not Found"));
+    assertThat("Error message does not contain keyword 'already existed'", responseGet.getBody().contains("Not Found"));
   }
 
   @Test
@@ -405,9 +401,7 @@ public class RequestPoliciesApiTest extends ApiTests {
 
     JsonResponse responseGetVerify = getCompletedVerify.get(CONNECTION_TIMEOUT, TimeUnit.SECONDS);
     assertThat("Failed to not get request-policy", responseGetVerify.getStatusCode(), is(HttpURLConnection.HTTP_NOT_FOUND));
-    JsonObject error = extractErrorObject(responseGetVerify);
-
-    assertThat("Error message does not contain keyword 'already existed'", error.getString("message").contains("Not Found"));
+    assertThat("Error message does not contain keyword 'already existed'", responseGetVerify.getBody().contains("Not Found"));
   }
 
   @Test
@@ -490,9 +484,8 @@ public class RequestPoliciesApiTest extends ApiTests {
     //Because of the unique name constraint, instead of getting an error message about a nonexistent object, the message
     //is about duplicate name. This happens because PUT can also be used to add a new record to the database.
     JsonResponse response = updateCompleted.get(CONNECTION_TIMEOUT, TimeUnit.SECONDS);
-    JsonObject anError = extractErrorObject(response);
     assertThat("Failed to update request-policy", response.getStatusCode(), is(HttpURLConnection.HTTP_INTERNAL_ERROR));
-    assertThat("Error message does not contain keyword 'already existed'", anError.getString("message").contains("already exists"));
+    assertThat("Error message does not contain keyword 'already existed'", response.getBody().contains("already exists"));
   }
 
   @Test
@@ -525,10 +518,7 @@ public class RequestPoliciesApiTest extends ApiTests {
 
     JsonResponse response = updateCompleted.get(CONNECTION_TIMEOUT, TimeUnit.SECONDS);
     assertThat("Failed to update request-policy", response.getStatusCode(), is(HttpURLConnection.HTTP_INTERNAL_ERROR));
-
-    JsonObject anError = extractErrorObject(response);
-
-    assertThat("Error message does not contain keyword 'already existed'", anError.getString("message").contains("already exists"));
+    assertThat("Error message does not contain keyword 'already existed'", response.getBody().contains("already exists"));
   }
 
   @Test


### PR DESCRIPTION
Addressed the mismatch between content-type and description in request-policy-storage.raml.
Also return a plain text error message for 500 error instead of a JSON. 