### PR TITLE
CIRCSTORE-107 - request and pick up expiration to include time

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -89,7 +89,7 @@
     },
     {
       "id": "request-storage",
-      "version": "2.6",
+      "version": "3.0",
       "handlers": [
         {
           "methods": ["GET"],

--- a/ramls/examples/request.json
+++ b/ramls/examples/request.json
@@ -5,6 +5,6 @@
   "requesterId": "21932a85-bd00-446b-9565-46e0c1a5490b",
   "itemId": "195efae1-588f-47bd-a181-13a2eb437701",
   "fulfilmentPreference": "Hold Shelf",
-  "requestExpirationDate": "2017-07-25",
+  "requestExpirationDate": "2017-07-25T22:25:37Z",
   "position": 1
 }

--- a/ramls/examples/requests.json
+++ b/ramls/examples/requests.json
@@ -16,8 +16,8 @@
       "itemId": "3e5d5433-a271-499c-94f4-5f3e4652e537",
       "fulfilmentPreference": "Delivery",
       "position": 1,
-      "requestExpirationDate": "2017-08-31",
-      "holdShelfExpirationDate": "2017-09-01",
+      "requestExpirationDate": "2017-08-31T22:25:37Z",
+      "holdShelfExpirationDate": "2017-09-01T22:25:37Z",
       "item": {
         "title": "Interesting Times",
         "barcode": "269394016504"

--- a/ramls/request-storage.raml
+++ b/ramls/request-storage.raml
@@ -1,6 +1,6 @@
 #%RAML 1.0
 title: Request Storage
-version: v2.6
+version: v3.0
 protocols: [ HTTP, HTTPS ]
 baseUri: http://localhost:9130
 

--- a/ramls/request.json
+++ b/ramls/request.json
@@ -149,12 +149,12 @@
     "requestExpirationDate": {
       "description": "Date when the request expires",
       "type": "string",
-      "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$"
+      "format": "date-time"
     },
     "holdShelfExpirationDate": {
       "description": "Date when an item returned to the hold shelf expires",
       "type": "string",
-      "pattern": "[0-9]{4}-[0-9]{2}-[0-9]{2}"
+      "format": "date-time"
     },
     "pickupServicePointId": {
       "description": "The ID of the Service Point where this request can be picked up",

--- a/sample-data/requests/interesting-times.json
+++ b/sample-data/requests/interesting-times.json
@@ -5,7 +5,7 @@
   "requesterId": "9a6ed769-15b4-4555-bbe1-2987c1e6e014",
   "itemId": "bb5a6689-c008-4c96-8f8f-b666850ee12d",
   "fulfilmentPreference": "Hold Shelf",
-  "holdShelfExpirationDate": "2017-01-20",
+  "holdShelfExpirationDate": "2017-01-20T22:25:37Z",
   "status": "Open - Not yet filled",
   "position": 1,
   "item": {

--- a/sample-data/requests/nod.json
+++ b/sample-data/requests/nod.json
@@ -5,7 +5,7 @@
   "requesterId": "2420929e-c41d-4e87-8310-22b7ba2b251e",
   "itemId": "23f2c8e1-bd5d-4f27-9398-a688c998808a",
   "fulfilmentPreference": "Delivery",
-  "requestExpirationDate": "2017-03-22",
+  "requestExpirationDate": "2017-03-22T11:14:21Z",
   "status": "Open - Not yet filled",
   "position": 1,
   "item": {

--- a/sample-data/requests/temeraire.json
+++ b/sample-data/requests/temeraire.json
@@ -5,7 +5,7 @@
   "requesterId": "9a6ed769-15b4-4555-bbe1-2987c1e6e014",
   "itemId": "23fdb0bc-ab58-442a-b326-577a96204487",
   "fulfilmentPreference": "Hold Shelf",
-  "holdShelfExpirationDate": "2018-09-10",
+  "holdShelfExpirationDate": "2018-09-10T10:43:16Z",
   "status": "Open - Awaiting pickup",
   "position": 1,
   "item": {

--- a/src/test/java/org/folio/rest/api/CancellationReasonsApiTest.java
+++ b/src/test/java/org/folio/rest/api/CancellationReasonsApiTest.java
@@ -6,7 +6,6 @@ import org.folio.rest.support.builders.RequestRequestBuilder;
 import org.hamcrest.junit.MatcherAssert;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
-import org.joda.time.LocalDate;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -289,6 +288,8 @@ public class CancellationReasonsApiTest extends ApiTests {
     UUID requesterId = UUID.randomUUID();
     UUID proxyId = UUID.randomUUID();
     DateTime requestDate = new DateTime(2017, 7, 22, 10, 22, 54, DateTimeZone.UTC);
+    DateTime requestExpirationDate = new DateTime(2017, 7, 30, 0, 0, DateTimeZone.UTC);
+    DateTime holdShelfExpirationDate = new DateTime(2017, 8, 31, 0, 0, DateTimeZone.UTC);
 
     JsonObject reasonRequest = new JsonObject()
         .put("name", "worms").put("description", "Item Eaten by space worms.")
@@ -302,8 +303,8 @@ public class CancellationReasonsApiTest extends ApiTests {
       .withItemId(itemId)
       .withRequesterId(requesterId)
       .withProxyId(proxyId)
-      .withRequestExpiration(new LocalDate(2017, 7, 30))
-      .withHoldShelfExpiration(new LocalDate(2017, 8, 31))
+      .withRequestExpiration(requestExpirationDate)
+      .withHoldShelfExpiration(holdShelfExpirationDate)
       .withItem("Nod", "565578437802")
       .withRequester("Jones", "Stuart", "Anthony", "6837502674015")
       .withProxy("Stuart", "Rebecca", "6059539205")

--- a/src/test/java/org/folio/rest/api/RequestsApiTest.java
+++ b/src/test/java/org/folio/rest/api/RequestsApiTest.java
@@ -13,7 +13,8 @@ import static org.folio.rest.support.matchers.TextDateTimeMatcher.equivalentTo;
 import static org.folio.rest.support.matchers.TextDateTimeMatcher.withinSecondsAfter;
 import static org.folio.rest.support.matchers.ValidationErrorMatchers.hasMessage;
 import static org.folio.rest.support.matchers.ValidationResponseMatchers.isValidationResponseWhich;
-import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.collection.IsIterableContainingInOrder.contains;
 import static org.hamcrest.core.Is.is;
@@ -44,8 +45,8 @@ import org.folio.rest.support.builders.RequestRequestBuilder;
 import org.hamcrest.junit.MatcherAssert;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
-import org.joda.time.LocalDate;
 import org.joda.time.Seconds;
+import org.joda.time.format.ISODateTimeFormat;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -88,6 +89,8 @@ public class RequestsApiTest extends ApiTests {
     UUID proxyId = UUID.randomUUID();
     UUID pickupServicePointId = UUID.randomUUID();
     DateTime requestDate = new DateTime(2017, 7, 22, 10, 22, 54, DateTimeZone.UTC);
+    DateTime requestExpirationDate = new DateTime(2017, 7, 30, 0, 0, DateTimeZone.UTC);
+    DateTime holdShelfExpirationDate = new DateTime(2017, 8, 31, 0, 0, DateTimeZone.UTC);
 
     JsonObject requestRequest = new RequestRequestBuilder()
       .recall()
@@ -97,8 +100,8 @@ public class RequestsApiTest extends ApiTests {
       .withItemId(itemId)
       .withRequesterId(requesterId)
       .withProxyId(proxyId)
-      .withRequestExpiration(new LocalDate(2017, 7, 30))
-      .withHoldShelfExpiration(new LocalDate(2017, 8, 31))
+      .withRequestExpiration(requestExpirationDate)
+      .withHoldShelfExpiration(holdShelfExpirationDate)
       .withItem("Nod", "565578437802")
       .withRequester("Jones", "Stuart", "Anthony", "6837502674015")
       .withProxy("Stuart", "Rebecca", "6059539205")
@@ -126,8 +129,8 @@ public class RequestsApiTest extends ApiTests {
     assertThat(representation.getString("requesterId"), is(requesterId.toString()));
     assertThat(representation.getString("proxyUserId"), is(proxyId.toString()));
     assertThat(representation.getString("fulfilmentPreference"), is("Hold Shelf"));
-    assertThat(representation.getString("requestExpirationDate"), is("2017-07-30"));
-    assertThat(representation.getString("holdShelfExpirationDate"), is("2017-08-31"));
+    assertThat(representation.getString("requestExpirationDate"), is(equivalentTo(requestExpirationDate)));
+    assertThat(representation.getString("holdShelfExpirationDate"), is(equivalentTo(holdShelfExpirationDate)));
     assertThat(representation.getString("status"), is(OPEN_NOT_YET_FILLED));
     assertThat(representation.getInteger("position"), is(1));
     assertThat(representation.getString("pickupServicePointId"), is(pickupServicePointId.toString()));
@@ -564,6 +567,8 @@ public class RequestsApiTest extends ApiTests {
     UUID itemId = UUID.randomUUID();
     UUID requesterId = UUID.randomUUID();
     DateTime requestDate = new DateTime(2017, 7, 22, 10, 22, 54, DateTimeZone.UTC);
+    DateTime requestExpirationDate = new DateTime(2017, 7, 30, 0, 0, DateTimeZone.UTC);
+    DateTime holdShelfExpirationDate = new DateTime(2017, 8, 31, 0, 0, DateTimeZone.UTC);
 
     JsonObject requestRequest = new RequestRequestBuilder()
       .recall()
@@ -572,8 +577,8 @@ public class RequestsApiTest extends ApiTests {
       .withItemId(itemId)
       .withRequesterId(requesterId)
       .toHoldShelf()
-      .withRequestExpiration(new LocalDate(2017, 7, 30))
-      .withHoldShelfExpiration(new LocalDate(2017, 8, 31))
+      .withRequestExpiration(requestExpirationDate)
+      .withHoldShelfExpiration(holdShelfExpirationDate)
       .withItem("Nod", "565578437802")
       .withRequester("Smith", "Jessica", "721076398251")
       .create();
@@ -602,8 +607,8 @@ public class RequestsApiTest extends ApiTests {
     assertThat(representation.getString("itemId"), is(itemId.toString()));
     assertThat(representation.getString("requesterId"), is(requesterId.toString()));
     assertThat(representation.getString("fulfilmentPreference"), is("Hold Shelf"));
-    assertThat(representation.getString("requestExpirationDate"), is("2017-07-30"));
-    assertThat(representation.getString("holdShelfExpirationDate"), is("2017-08-31"));
+    assertThat(representation.getString("requestExpirationDate"), is(equivalentTo(requestExpirationDate)));
+    assertThat(representation.getString("holdShelfExpirationDate"), is(equivalentTo(holdShelfExpirationDate)));
 
     assertThat(representation.containsKey("item"), is(true));
     assertThat(representation.getJsonObject("item").getString("title"), is("Nod"));
@@ -661,6 +666,8 @@ public class RequestsApiTest extends ApiTests {
     UUID itemId = UUID.randomUUID();
     UUID requesterId = UUID.randomUUID();
     DateTime requestDate = new DateTime(2017, 7, 22, 10, 22, 54, DateTimeZone.UTC);
+    DateTime requestExpirationDate = new DateTime(2017, 7, 30, 0, 0, DateTimeZone.UTC);
+    DateTime holdShelfExpirationDate = new DateTime(2017, 8, 31, 0, 0, DateTimeZone.UTC);
 
     JsonObject createRequestRequest = new RequestRequestBuilder()
       .recall()
@@ -699,10 +706,8 @@ public class RequestsApiTest extends ApiTests {
         .put("lastName", "Stuart")
         .put("firstName", "Rebecca")
         .put("barcode", "6059539205"))
-      .put("requestExpirationDate", new LocalDate(2017, 7, 30)
-        .toString("yyyy-MM-dd"))
-      .put("holdShelfExpirationDate", new LocalDate(2017, 8, 31)
-        .toString("yyyy-MM-dd"));
+      .put("requestExpirationDate", requestExpirationDate.toString(ISODateTimeFormat.dateTime()))
+      .put("holdShelfExpirationDate", holdShelfExpirationDate.toString(ISODateTimeFormat.dateTime()));
 
     client.put(requestStorageUrl(String.format("/%s", id)),
       updateRequestRequest, StorageTestSuite.TENANT_ID,
@@ -724,8 +729,8 @@ public class RequestsApiTest extends ApiTests {
     assertThat(representation.getString("requesterId"), is(newRequesterId.toString()));
     assertThat(representation.getString("proxyUserId"), is(proxyId.toString()));
     assertThat(representation.getString("fulfilmentPreference"), is("Hold Shelf"));
-    assertThat(representation.getString("requestExpirationDate"), is("2017-07-30"));
-    assertThat(representation.getString("holdShelfExpirationDate"), is("2017-08-31"));
+    assertThat(representation.getString("requestExpirationDate"), is(equivalentTo(requestExpirationDate)));
+    assertThat(representation.getString("holdShelfExpirationDate"), is(equivalentTo(holdShelfExpirationDate)));
     assertThat(representation.getInteger("position"), is(2));
 
     assertThat(representation.containsKey("item"), is(true));
@@ -1003,6 +1008,8 @@ public class RequestsApiTest extends ApiTests {
     UUID itemId = UUID.randomUUID();
     UUID requesterId = UUID.randomUUID();
     DateTime requestDate = new DateTime(2017, 7, 22, 10, 22, 54, DateTimeZone.UTC);
+    DateTime requestExpirationDate = new DateTime(2017, 7, 30, 0, 0, DateTimeZone.UTC);
+    DateTime holdShelfExpirationDate = new DateTime(2017, 8, 31, 0, 0, DateTimeZone.UTC);
 
     JsonObject requestRequest = new RequestRequestBuilder()
       .recall()
@@ -1011,8 +1018,8 @@ public class RequestsApiTest extends ApiTests {
       .withItemId(itemId)
       .withRequesterId(requesterId)
       .toHoldShelf()
-      .withRequestExpiration(new LocalDate(2017, 7, 30))
-      .withHoldShelfExpiration(new LocalDate(2017, 8, 31))
+      .withRequestExpiration(requestExpirationDate)
+      .withHoldShelfExpiration(holdShelfExpirationDate)
       .withItem("Nod", "565578437802")
       .withRequester("Jones", "Stuart", "Anthony", "6837502674015")
       .withPosition(3)
@@ -1033,8 +1040,8 @@ public class RequestsApiTest extends ApiTests {
     assertThat(representation.getString("itemId"), is(itemId.toString()));
     assertThat(representation.getString("requesterId"), is(requesterId.toString()));
     assertThat(representation.getString("fulfilmentPreference"), is("Hold Shelf"));
-    assertThat(representation.getString("requestExpirationDate"), is("2017-07-30"));
-    assertThat(representation.getString("holdShelfExpirationDate"), is("2017-08-31"));
+    assertThat(representation.getString("requestExpirationDate"), is(equivalentTo(requestExpirationDate)));
+    assertThat(representation.getString("holdShelfExpirationDate"), is(equivalentTo(holdShelfExpirationDate)));
     assertThat(representation.getInteger("position"), is(3));
 
     assertThat(representation.containsKey("item"), is(true));

--- a/src/test/java/org/folio/rest/support/builders/RequestRequestBuilder.java
+++ b/src/test/java/org/folio/rest/support/builders/RequestRequestBuilder.java
@@ -4,7 +4,6 @@ import io.vertx.core.json.JsonObject;
 import org.folio.rest.jaxrs.model.Tags;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
-import org.joda.time.LocalDate;
 
 import java.util.UUID;
 
@@ -25,8 +24,8 @@ public class RequestRequestBuilder extends JsonBuilder {
   private final UUID proxyId;
   private final String fulfilmentPreference;
   private final UUID deliveryAddressTypeId;
-  private final LocalDate requestExpirationDate;
-  private final LocalDate holdShelfExpirationDate;
+  private final DateTime requestExpirationDate;
+  private final DateTime holdShelfExpirationDate;
   private final ItemSummary itemSummary;
   private final PatronSummary requesterSummary;
   private final PatronSummary proxySummary;
@@ -72,8 +71,8 @@ public class RequestRequestBuilder extends JsonBuilder {
     UUID proxyId,
     String fulfilmentPreference,
     UUID deliveryAddressTypeId,
-    LocalDate requestExpirationDate,
-    LocalDate holdShelfExpirationDate,
+    DateTime requestExpirationDate,
+    DateTime holdShelfExpirationDate,
     ItemSummary itemSummary,
     PatronSummary requesterSummary,
     PatronSummary proxySummary,
@@ -365,7 +364,7 @@ public class RequestRequestBuilder extends JsonBuilder {
       this.tags);
   }
 
-  public RequestRequestBuilder withRequestExpiration(LocalDate requestExpiration) {
+  public RequestRequestBuilder withRequestExpiration(DateTime requestExpiration) {
     return new RequestRequestBuilder(
       this.id,
       this.requestType,
@@ -390,7 +389,7 @@ public class RequestRequestBuilder extends JsonBuilder {
       this.tags);
   }
 
-  public RequestRequestBuilder withHoldShelfExpiration(LocalDate holdShelfExpiration) {
+  public RequestRequestBuilder withHoldShelfExpiration(DateTime holdShelfExpiration) {
     return new RequestRequestBuilder(
       this.id,
       this.requestType,


### PR DESCRIPTION
In order to provide a finer grained expiration period for `holdShelfExpirationDate`, we need to include a time component to the field. We are also doing this for `requestExpirationDate` as well.

Since this is a breaking change the major version of the `request-storage` interface has been bumped.