### PR TITLE
FOLIO-1853: tweak index so query open loan by item id can use.

### DIFF
--- a/src/main/resources/templates/db_scripts/schema.json
+++ b/src/main/resources/templates/db_scripts/schema.json
@@ -16,8 +16,9 @@
         {
           "fieldName": "itemId",
           "tOps": "ADD",
-          "caseSensitive": true,
-          "whereClause": "WHERE (jsonb->'status'->>'name') = 'Open'"
+          "caseSensitive": false,
+          "removeAccents": true,
+          "whereClause": "WHERE lower(f_unaccent((jsonb->'status'->>'name'))) LIKE 'open'"
         }
       ]
     },


### PR DESCRIPTION
Currently the SQL generated by cql2pgjson cannot use the index in the database. See below for the actual sql and index. The goal of this PR is to tweak the db index to match the SQL.
```
Query: SELECT COUNT(*) FROM supertenant_mod_circulation_storage.loan  WHERE (lower(f_unaccent(loan.jsonb->>'itemId')) LIKE lower(f_unaccent('00007443-1460-410e-bd22-305abf53ed6a'))) AND (lower(f_unaccent(loan.jsonb->'status'->>'name')) LIKE lower(f_unaccent('Open')))
Index: "loan_itemid_idx_unique" UNIQUE, btree (f_unaccent(jsonb ->> 'itemId'::text)) WHERE ((jsonb -> 'status'::text) ->> 'name'::text) = 'Open'::text
```