### PR TITLE
[CIRCSTORE-120] Change sample loan policy records to expected values

### DIFF
--- a/ramls/examples/loan-policies.json
+++ b/ramls/examples/loan-policies.json
@@ -11,7 +11,7 @@
           "duration": 1,
           "intervalId": "Months"
         },
-        "closedLibraryDueDateManagementId": "KEEP_CURRENT_DATE",
+        "closedLibraryDueDateManagementId": "CURRENT_DUE_DATE",
         "gracePeriod": {
           "duration": 7,
           "intervalId": "Days"

--- a/ramls/examples/loan-policy.json
+++ b/ramls/examples/loan-policy.json
@@ -9,7 +9,7 @@
       "duration": 1,
       "intervalId": "Months"
     },
-    "closedLibraryDueDateManagementId": "KEEP_CURRENT_DATE",
+    "closedLibraryDueDateManagementId": "CURRENT_DUE_DATE",
     "gracePeriod": {
       "duration": 7,
       "intervalId": "Days"

--- a/reference-data/loan-policy-storage/loan-policies/one-hour.json
+++ b/reference-data/loan-policy-storage/loan-policies/one-hour.json
@@ -8,7 +8,7 @@
       "duration" : 1,
       "intervalId" : "Hours"
     },
-    "closedLibraryDueDateManagementId" : "KEEP_CURRENT_DATE"
+    "closedLibraryDueDateManagementId" : "CURRENT_DUE_DATE"
   },
   "renewable" : true,
   "renewalsPolicy" : {

--- a/reference-data/loan-policy-storage/loan-policies/rolling.json
+++ b/reference-data/loan-policy-storage/loan-policies/rolling.json
@@ -9,7 +9,7 @@
       "duration" : 1,
       "intervalId" : "Months"
     },
-    "closedLibraryDueDateManagementId" : "KEEP_CURRENT_DATE",
+    "closedLibraryDueDateManagementId" : "CURRENT_DUE_DATE",
     "gracePeriod" : {
       "duration" : 7,
       "intervalId" : "Days"

--- a/src/test/java/org/folio/rest/api/LoanPoliciesApiTest.java
+++ b/src/test/java/org/folio/rest/api/LoanPoliciesApiTest.java
@@ -267,7 +267,7 @@ public class LoanPoliciesApiTest extends ApiTests {
 
     assertThat(loansPolicy.getString("profileId"), is("Rolling"));
     assertThat(loansPolicy.getJsonObject("period"), matchesPeriod(1, "Months"));
-    assertThat(loansPolicy.getString("closedLibraryDueDateManagementId"), is("KEEP_CURRENT_DATE"));
+    assertThat(loansPolicy.getString("closedLibraryDueDateManagementId"), is("CURRENT_DUE_DATE"));
     assertThat(loansPolicy.getJsonObject("gracePeriod"), matchesPeriod(7, "Days"));
 
     checkRequestManagementSection(representation);
@@ -421,7 +421,7 @@ public class LoanPoliciesApiTest extends ApiTests {
 
     assertThat(loansPolicy.getString("profileId"), is("Rolling"));
     assertThat(loansPolicy.getJsonObject("period"), matchesPeriod(1, "Months"));
-    assertThat(loansPolicy.getString("closedLibraryDueDateManagementId"), is("KEEP_CURRENT_DATE"));
+    assertThat(loansPolicy.getString("closedLibraryDueDateManagementId"), is("CURRENT_DUE_DATE"));
     assertThat(loansPolicy.getJsonObject("gracePeriod"), matchesPeriod(7, "Days"));
 
     checkRequestManagementSection(representation);
@@ -466,7 +466,7 @@ public class LoanPoliciesApiTest extends ApiTests {
 
     assertThat(loansPolicy.getString("profileId"), is("Rolling"));
     assertThat(loansPolicy.getJsonObject("period"), matchesPeriod(1, "Months"));
-    assertThat(loansPolicy.getString("closedLibraryDueDateManagementId"), is("KEEP_CURRENT_DATE"));
+    assertThat(loansPolicy.getString("closedLibraryDueDateManagementId"), is("CURRENT_DUE_DATE"));
     assertThat(loansPolicy.getJsonObject("gracePeriod"), matchesPeriod(7, "Days"));
     assertThat(loansPolicy.getJsonObject("openingTimeOffset"), matchesPeriod(3, "Hours"));
 
@@ -684,7 +684,7 @@ public class LoanPoliciesApiTest extends ApiTests {
 
     assertThat(loansPolicy.getString("profileId"), is("Rolling"));
     assertThat(loansPolicy.getJsonObject("period"), matchesPeriod(1, "Months"));
-    assertThat(loansPolicy.getString("closedLibraryDueDateManagementId"), is("KEEP_CURRENT_DATE"));
+    assertThat(loansPolicy.getString("closedLibraryDueDateManagementId"), is("CURRENT_DUE_DATE"));
     assertThat(loansPolicy.getJsonObject("gracePeriod"), matchesPeriod(7, "Days"));
     assertThat(loansPolicy.getJsonObject("openingTimeOffset"), matchesPeriod(3, "Hours"));
 

--- a/src/test/java/org/folio/rest/support/builders/LoanPolicyRequestBuilder.java
+++ b/src/test/java/org/folio/rest/support/builders/LoanPolicyRequestBuilder.java
@@ -34,7 +34,7 @@ public class LoanPolicyRequestBuilder {
 
     loansPolicy.put("profileId", "Rolling");
     loansPolicy.put("period", createPeriod(1, "Months"));
-    loansPolicy.put("closedLibraryDueDateManagementId", "KEEP_CURRENT_DATE");
+    loansPolicy.put("closedLibraryDueDateManagementId", "CURRENT_DUE_DATE");
     loansPolicy.put("gracePeriod", createPeriod(7, "Days"));
     loansPolicy.put("openingTimeOffset", createPeriod(3, "Hours"));
 


### PR DESCRIPTION
## Purpose
Resolves: CIRCSTORE-120
Change sample loan policy records to correspond with what is expected in **mod-circulation** and **ui-circulation**.
Change _closedLibraryDueDateManagementId_ property of loan policy from "KEEP_CURRENT_DATE" to "CURRENT_DUE_DATE"
## Links
https://issues.folio.org/browse/CIRCSTORE-120