### PR TITLE
[CIRCSTORE-119] Not allow user to delete patron notice policy if currently in use

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -223,7 +223,7 @@
     },
     {
       "id": "patron-notice-policy-storage",
-      "version": "0.7",
+      "version": "0.8",
       "handlers": [
         {
           "methods": ["POST"],

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <artifactId>mod-circulation-storage</artifactId>
   <groupId>org.folio</groupId>
-  <version>7.1.0-SNAPSHOT</version>
+  <version>8.0.0-SNAPSHOT</version>
   <licenses>
     <license>
       <name>Apache License 2.0</name>

--- a/ramls/patron-notice-policy.raml
+++ b/ramls/patron-notice-policy.raml
@@ -82,11 +82,11 @@ traits:
         responses:
           204:
             description: "Source record deleted"
-          422:
-            description: "Unprocessable entity"
+          400:
+            description: "Bad request, e.g. malformed request body, query parameter or constraint violation."
             body:
-              application/json:
-                type: errors
+              text/plain:
+                example: "Cannot delete in use notice policy"
           404:
             description: "There is no source record for that patronNoticePolicyId"
             body:

--- a/ramls/patron-notice-policy.raml
+++ b/ramls/patron-notice-policy.raml
@@ -82,6 +82,11 @@ traits:
         responses:
           204:
             description: "Source record deleted"
+          422:
+            description: "Unprocessable entity"
+            body:
+              application/json:
+                type: errors
           404:
             description: "There is no source record for that patronNoticePolicyId"
             body:

--- a/ramls/patron-notice-policy.raml
+++ b/ramls/patron-notice-policy.raml
@@ -1,6 +1,6 @@
 #%RAML 1.0
 title: Patron Notice Policies
-version: v0.7
+version: v0.8
 protocols: [ HTTP, HTTPS ]
 baseUri: http://localhost:9130
 

--- a/src/main/java/org/folio/rest/impl/CirculationRulesAPI.java
+++ b/src/main/java/org/folio/rest/impl/CirculationRulesAPI.java
@@ -20,7 +20,7 @@ import java.util.Map;
 
 public class CirculationRulesAPI implements CirculationRulesStorage {
   private static final Logger log = LoggerFactory.getLogger(CirculationRulesStorage.class);
-  private static final String CIRCULATION_RULES_TABLE = "circulation_rules";
+  static final String CIRCULATION_RULES_TABLE = "circulation_rules";
 
   private void internalErrorGet(Handler<AsyncResult<Response>> asyncResultHandler, Throwable e) {
     log.error(e);

--- a/src/main/java/org/folio/rest/impl/PatronNoticePoliciesAPI.java
+++ b/src/main/java/org/folio/rest/impl/PatronNoticePoliciesAPI.java
@@ -163,8 +163,8 @@ public class PatronNoticePoliciesAPI implements PatronNoticePolicyStorage {
 
     findCirculationRules(pgClient)
       .map(CirculationRules::getRulesAsText)
-      .map(text -> text.indexOf(patronNoticePolicyId))
-      .compose(index -> index == -1 ? succeededFuture() : failedFuture(new NoticePolicyInUseException(IN_USE_POLICY_ERROR_MESSAGE)))
+      .map(text -> text.contains(patronNoticePolicyId))
+      .compose(contains -> contains ? failedFuture(new NoticePolicyInUseException(IN_USE_POLICY_ERROR_MESSAGE)) : succeededFuture())
       .compose(v -> deleteNoticePolicyById(pgClient, patronNoticePolicyId))
       .map(v -> DeletePatronNoticePolicyStoragePatronNoticePoliciesByPatronNoticePolicyIdResponse.respond204())
       .map(Response.class::cast)

--- a/src/main/java/org/folio/rest/impl/PatronNoticePoliciesAPI.java
+++ b/src/main/java/org/folio/rest/impl/PatronNoticePoliciesAPI.java
@@ -1,29 +1,49 @@
 package org.folio.rest.impl;
 
+import static io.vertx.core.Future.failedFuture;
+import static io.vertx.core.Future.succeededFuture;
+import static java.lang.String.format;
+import static java.util.Collections.singletonList;
+import static javax.ws.rs.core.HttpHeaders.CONTENT_TYPE;
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
+import static javax.ws.rs.core.MediaType.TEXT_PLAIN;
+
+import static org.folio.rest.impl.CirculationRulesAPI.CIRCULATION_RULES_TABLE;
+import static org.folio.rest.persist.Criteria.Criteria.OP_EQUAL;
+
+import java.util.Map;
+import java.util.UUID;
+
+import javax.ws.rs.NotFoundException;
+import javax.ws.rs.core.Response;
+
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Context;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
+import io.vertx.ext.sql.UpdateResult;
+
+import org.z3950.zing.cql.cql2pgjson.CQL2PgJSON;
+
 import org.folio.rest.RestVerticle;
+import org.folio.rest.jaxrs.model.CirculationRules;
 import org.folio.rest.jaxrs.model.Error;
 import org.folio.rest.jaxrs.model.Errors;
 import org.folio.rest.jaxrs.model.PatronNoticePolicies;
 import org.folio.rest.jaxrs.model.PatronNoticePolicy;
 import org.folio.rest.jaxrs.resource.PatronNoticePolicyStorage;
-import org.folio.rest.persist.Criteria.Limit;
-import org.folio.rest.persist.Criteria.Offset;
 import org.folio.rest.persist.PgUtil;
 import org.folio.rest.persist.PostgresClient;
+import org.folio.rest.persist.Criteria.Criteria;
+import org.folio.rest.persist.Criteria.Criterion;
+import org.folio.rest.persist.Criteria.Limit;
+import org.folio.rest.persist.Criteria.Offset;
 import org.folio.rest.persist.cql.CQLWrapper;
+import org.folio.rest.persist.interfaces.Results;
 import org.folio.rest.tools.utils.ValidationHelper;
-import org.z3950.zing.cql.cql2pgjson.CQL2PgJSON;
-
-import javax.ws.rs.core.Response;
-import java.util.Collections;
-import java.util.Map;
-import java.util.UUID;
+import org.folio.support.exception.NoticePolicyInUseException;
 
 public class PatronNoticePoliciesAPI implements PatronNoticePolicyStorage {
 
@@ -32,6 +52,8 @@ public class PatronNoticePoliciesAPI implements PatronNoticePolicyStorage {
   public static final String PATRON_NOTICE_POLICY_TABLE = "patron_notice_policy";
   public static final String STATUS_CODE_DUPLICATE_NAME = "duplicate.name";
   public static final String NOT_FOUND = "Not found";
+  private static final String INTERNAL_SERVER_ERROR = "Internal server error";
+  public static final String IN_USE_POLICY_ERROR_MESSAGE = "Cannot delete in use notice policy";
 
   @Override
   public void getPatronNoticePolicyStoragePatronNoticePolicies(
@@ -57,7 +79,7 @@ public class PatronNoticePoliciesAPI implements PatronNoticePolicyStorage {
         pgClient.get(PATRON_NOTICE_POLICY_TABLE, PatronNoticePolicy.class, fieldList, cql, true, false, get -> {
           if (get.failed()) {
             logger.error(get.cause());
-            asyncResultHandler.handle(Future.succeededFuture(
+            asyncResultHandler.handle(succeededFuture(
               GetPatronNoticePolicyStoragePatronNoticePoliciesResponse.respond500WithTextPlain(get.cause())));
             return;
           }
@@ -66,14 +88,14 @@ public class PatronNoticePoliciesAPI implements PatronNoticePolicyStorage {
             .withPatronNoticePolicies(get.result().getResults())
             .withTotalRecords(get.result().getResultInfo().getTotalRecords());
 
-          asyncResultHandler.handle(Future.succeededFuture(
+          asyncResultHandler.handle(succeededFuture(
             GetPatronNoticePolicyStoragePatronNoticePoliciesResponse
               .respond200WithApplicationJson(patronNoticePolicies)));
 
         });
       } catch (Exception e) {
         logger.error(e);
-        asyncResultHandler.handle(Future.succeededFuture(
+        asyncResultHandler.handle(succeededFuture(
           GetPatronNoticePolicyStoragePatronNoticePoliciesResponse.respond500WithTextPlain(e)));
       }
     });
@@ -99,20 +121,20 @@ public class PatronNoticePoliciesAPI implements PatronNoticePolicyStorage {
           if (save.failed()) {
             logger.error(save.cause());
             if (ValidationHelper.isDuplicate(save.cause().getMessage())) {
-              asyncResultHandler.handle(Future.succeededFuture(
+              asyncResultHandler.handle(succeededFuture(
                 PostPatronNoticePolicyStoragePatronNoticePoliciesResponse
                   .respond422WithApplicationJson(createNotUniqueNameErrors(entity.getName()))));
             }
-            asyncResultHandler.handle(Future.succeededFuture(
+            asyncResultHandler.handle(succeededFuture(
               PostPatronNoticePolicyStoragePatronNoticePoliciesResponse.respond500WithTextPlain(save.cause())));
             return;
           }
-          asyncResultHandler.handle(Future.succeededFuture(
+          asyncResultHandler.handle(succeededFuture(
             PostPatronNoticePolicyStoragePatronNoticePoliciesResponse.respond201WithApplicationJson(entity)));
         });
       } catch (Exception e) {
         logger.error(e);
-        asyncResultHandler.handle(Future.succeededFuture(
+        asyncResultHandler.handle(succeededFuture(
           PostPatronNoticePolicyStoragePatronNoticePoliciesResponse.respond500WithTextPlain(e)));
       }
     });
@@ -137,9 +159,17 @@ public class PatronNoticePoliciesAPI implements PatronNoticePolicyStorage {
     Handler<AsyncResult<Response>> asyncResultHandler,
     Context vertxContext) {
 
-    PgUtil.deleteById(PATRON_NOTICE_POLICY_TABLE, patronNoticePolicyId, okapiHeaders,
-      vertxContext, DeletePatronNoticePolicyStoragePatronNoticePoliciesByPatronNoticePolicyIdResponse.class,
-      asyncResultHandler);
+    PostgresClient pgClient = PgUtil.postgresClient(vertxContext, okapiHeaders);
+
+    findCirculationRules(pgClient)
+      .map(CirculationRules::getRulesAsText)
+      .map(text -> text.indexOf(patronNoticePolicyId))
+      .compose(index -> index == -1 ? succeededFuture() : failedFuture(new NoticePolicyInUseException(IN_USE_POLICY_ERROR_MESSAGE)))
+      .compose(v -> deleteNoticePolicyById(pgClient, patronNoticePolicyId))
+      .map(v -> DeletePatronNoticePolicyStoragePatronNoticePoliciesByPatronNoticePolicyIdResponse.respond204())
+      .map(Response.class::cast)
+      .otherwise(this::mapExceptionToResponse)
+      .setHandler(asyncResultHandler);
   }
 
   @Override
@@ -159,29 +189,29 @@ public class PatronNoticePoliciesAPI implements PatronNoticePolicyStorage {
           if (update.failed()) {
             logger.error(update.cause());
             if (ValidationHelper.isDuplicate(update.cause().getMessage())) {
-              asyncResultHandler.handle(Future.succeededFuture(
+              asyncResultHandler.handle(succeededFuture(
                 PutPatronNoticePolicyStoragePatronNoticePoliciesByPatronNoticePolicyIdResponse
                   .respond422WithApplicationJson(createNotUniqueNameErrors(entity.getName()))));
               return;
             }
-            asyncResultHandler.handle(Future.succeededFuture(
+            asyncResultHandler.handle(succeededFuture(
               PutPatronNoticePolicyStoragePatronNoticePoliciesByPatronNoticePolicyIdResponse
                 .respond500WithTextPlain(update.cause())));
             return;
           }
 
           if (update.result().getUpdated() == 0) {
-            asyncResultHandler.handle(Future.succeededFuture(
+            asyncResultHandler.handle(succeededFuture(
               PutPatronNoticePolicyStoragePatronNoticePoliciesByPatronNoticePolicyIdResponse
                 .respond404WithTextPlain(NOT_FOUND)));
             return;
           }
-          asyncResultHandler.handle(Future.succeededFuture(
+          asyncResultHandler.handle(succeededFuture(
             PutPatronNoticePolicyStoragePatronNoticePoliciesByPatronNoticePolicyIdResponse.respond204()));
         });
       } catch (Exception e) {
         logger.error(e);
-        asyncResultHandler.handle(Future.succeededFuture(
+        asyncResultHandler.handle(succeededFuture(
           PutPatronNoticePolicyStoragePatronNoticePoliciesByPatronNoticePolicyIdResponse.respond500WithTextPlain(e)));
       }
     });
@@ -189,8 +219,57 @@ public class PatronNoticePoliciesAPI implements PatronNoticePolicyStorage {
 
   private Errors createNotUniqueNameErrors(String name) {
     Error error = new Error();
-    error.setMessage(String.format("'%s' name in not unique", name));
+    error.setMessage(format("'%s' name in not unique", name));
     error.setCode(STATUS_CODE_DUPLICATE_NAME);
-    return new Errors().withErrors(Collections.singletonList(error));
+    return new Errors().withErrors(singletonList(error));
+  }
+
+  private Future<CirculationRules> findCirculationRules(PostgresClient pgClient) {
+
+    Future<Results<CirculationRules>> future = Future.future();
+    pgClient.get(CIRCULATION_RULES_TABLE, CirculationRules.class, new Criterion(), false, false, future.completer());
+    return future.map(Results::getResults)
+      .compose(list -> list.size() == 1 ? succeededFuture(list) :
+        failedFuture(new IllegalStateException("Number of records in circulation_rules table is " + list.size())))
+      .map(list -> list.get(0));
+  }
+
+  private Future<Void> deleteNoticePolicyById(PostgresClient pgClient, String id) {
+
+    Criteria criteria = new Criteria()
+      .addField("'id'")
+      .setOperation(OP_EQUAL)
+      .setValue("'" + id + "'");
+
+    Future<UpdateResult> future = Future.future();
+    pgClient.delete(PATRON_NOTICE_POLICY_TABLE, new Criterion(criteria), future.completer());
+
+    return future.map(UpdateResult::getUpdated)
+      .compose(updated -> updated > 0 ? succeededFuture() : failedFuture(new NotFoundException(NOT_FOUND)));
+  }
+
+  private Response mapExceptionToResponse(Throwable t) {
+
+    if (t.getClass() == NotFoundException.class) {
+      return Response.status(404)
+        .header(CONTENT_TYPE, TEXT_PLAIN)
+        .entity(t.getMessage())
+        .build();
+    }
+
+    if (t.getClass() == NoticePolicyInUseException.class) {
+      Error error = new Error().withMessage(t.getMessage());
+      Errors errors = new Errors().withErrors(singletonList(error));
+
+      return Response.status(422)
+        .header(CONTENT_TYPE, APPLICATION_JSON)
+        .entity(errors)
+        .build();
+    }
+
+    return Response.status(500)
+      .header(CONTENT_TYPE, TEXT_PLAIN)
+      .entity(INTERNAL_SERVER_ERROR)
+      .build();
   }
 }

--- a/src/main/java/org/folio/rest/impl/PatronNoticePoliciesAPI.java
+++ b/src/main/java/org/folio/rest/impl/PatronNoticePoliciesAPI.java
@@ -5,7 +5,6 @@ import static io.vertx.core.Future.succeededFuture;
 import static java.lang.String.format;
 import static java.util.Collections.singletonList;
 import static javax.ws.rs.core.HttpHeaders.CONTENT_TYPE;
-import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 import static javax.ws.rs.core.MediaType.TEXT_PLAIN;
 
 import static org.folio.rest.impl.CirculationRulesAPI.CIRCULATION_RULES_TABLE;
@@ -258,12 +257,9 @@ public class PatronNoticePoliciesAPI implements PatronNoticePolicyStorage {
     }
 
     if (t.getClass() == NoticePolicyInUseException.class) {
-      Error error = new Error().withMessage(t.getMessage());
-      Errors errors = new Errors().withErrors(singletonList(error));
-
-      return Response.status(422)
-        .header(CONTENT_TYPE, APPLICATION_JSON)
-        .entity(errors)
+      return Response.status(400)
+        .header(CONTENT_TYPE, TEXT_PLAIN)
+        .entity(t.getMessage())
         .build();
     }
 

--- a/src/main/java/org/folio/rest/impl/PatronNoticePoliciesAPI.java
+++ b/src/main/java/org/folio/rest/impl/PatronNoticePoliciesAPI.java
@@ -53,7 +53,7 @@ public class PatronNoticePoliciesAPI implements PatronNoticePolicyStorage {
   public static final String STATUS_CODE_DUPLICATE_NAME = "duplicate.name";
   public static final String NOT_FOUND = "Not found";
   private static final String INTERNAL_SERVER_ERROR = "Internal server error";
-  public static final String IN_USE_POLICY_ERROR_MESSAGE = "Cannot delete in use notice policy";
+  private static final String IN_USE_POLICY_ERROR_MESSAGE = "Cannot delete in use notice policy";
 
   @Override
   public void getPatronNoticePolicyStoragePatronNoticePolicies(

--- a/src/main/java/org/folio/support/exception/NoticePolicyInUseException.java
+++ b/src/main/java/org/folio/support/exception/NoticePolicyInUseException.java
@@ -1,0 +1,8 @@
+package org.folio.support.exception;
+
+public class NoticePolicyInUseException extends RuntimeException {
+
+  public NoticePolicyInUseException(String message) {
+    super(message);
+  }
+}

--- a/src/test/java/org/folio/rest/api/CirculationRulesApiTest.java
+++ b/src/test/java/org/folio/rest/api/CirculationRulesApiTest.java
@@ -24,7 +24,7 @@ public class CirculationRulesApiTest extends ApiTests {
   private static final int HTTP_VALIDATION_ERROR = 422;
   private String uuid;
 
-  private static URL rulesStorageUrl() throws MalformedURLException {
+  public static URL rulesStorageUrl() throws MalformedURLException {
     return rulesStorageUrl("");
   }
 

--- a/src/test/java/org/folio/rest/api/PatronNoticePoliciesApiTest.java
+++ b/src/test/java/org/folio/rest/api/PatronNoticePoliciesApiTest.java
@@ -6,7 +6,6 @@ import static org.hamcrest.junit.MatcherAssert.assertThat;
 
 import static org.folio.rest.api.CirculationRulesApiTest.rulesStorageUrl;
 import static org.folio.rest.api.StorageTestSuite.TENANT_ID;
-import static org.folio.rest.impl.PatronNoticePoliciesAPI.IN_USE_POLICY_ERROR_MESSAGE;
 import static org.folio.rest.impl.PatronNoticePoliciesAPI.NOT_FOUND;
 import static org.folio.rest.impl.PatronNoticePoliciesAPI.PATRON_NOTICE_POLICY_TABLE;
 import static org.folio.rest.impl.PatronNoticePoliciesAPI.STATUS_CODE_DUPLICATE_NAME;
@@ -240,7 +239,7 @@ public class PatronNoticePoliciesApiTest extends ApiTests {
     String message = response.getJson().getJsonArray("errors").getJsonObject(0).getString("message");
 
     assertThat(response.getStatusCode(), is(422));
-    assertThat(message, is(IN_USE_POLICY_ERROR_MESSAGE));
+    assertThat(message, is("Cannot delete in use notice policy"));
   }
 
   private JsonResponse createPatronNoticePolicy(PatronNoticePolicy entity) throws MalformedURLException,

--- a/src/test/java/org/folio/rest/api/PatronNoticePoliciesApiTest.java
+++ b/src/test/java/org/folio/rest/api/PatronNoticePoliciesApiTest.java
@@ -53,8 +53,6 @@ public class PatronNoticePoliciesApiTest extends ApiTests {
     .withId("0f612a84-dc0f-4670-9017-62981ba63644")
     .withName("nonexistentPolicy");
 
-  private static final String IN_USE_NOTICE_POLICY_ID = "16b88363-0d93-464a-967a-ad5ad0f9187c";
-
   @After
   public void cleanUp() {
     CompletableFuture<UpdateResult> future = new CompletableFuture<>();
@@ -224,14 +222,21 @@ public class PatronNoticePoliciesApiTest extends ApiTests {
   public void cannotDeleteInUsePatronNoticePolicy() throws InterruptedException, MalformedURLException,
     TimeoutException, ExecutionException {
 
+    String inUsePolicyId = "16b88363-0d93-464a-967a-ad5ad0f9187c";
+
+    String rulesAsText = "priority: t, s, c, b, a, m, g" +
+      "fallback-policy: l 43198de5-f56a-4a53-a0bd-5a324418967a r 4c6e1fb0-2ef1-4666-bd15-f9190ff89060 " +
+      "n 122b3d2b-4788-4f1e-9117-56daa91cb75c m 1a54b431-2e4f-452d-9cae-9cee66c9a892: " +
+      "l d9cd0bed-1b49-4b5e-a7bd-064b8d177231 r 334e5a9e-94f9-4673-8d1d-ab552863886b n " + inUsePolicyId;
+
     CirculationRules circulationRules = new CirculationRules()
-      .withRulesAsText(IN_USE_NOTICE_POLICY_ID);
+      .withRulesAsText(rulesAsText);
 
     CompletableFuture<JsonResponse> putCompleted = new CompletableFuture<>();
     client.put(rulesStorageUrl(), circulationRules, TENANT_ID, ResponseHandler.json(putCompleted));
     putCompleted.join();
 
-    JsonResponse response = deletePatronNoticePolicy(IN_USE_NOTICE_POLICY_ID);
+    JsonResponse response = deletePatronNoticePolicy(inUsePolicyId);
     String message = response.getJson().getJsonArray("errors").getJsonObject(0).getString("message");
 
     assertThat(response.getStatusCode(), is(422));

--- a/src/test/java/org/folio/rest/api/PatronNoticePoliciesApiTest.java
+++ b/src/test/java/org/folio/rest/api/PatronNoticePoliciesApiTest.java
@@ -233,7 +233,7 @@ public class PatronNoticePoliciesApiTest extends ApiTests {
 
     CompletableFuture<JsonResponse> putCompleted = new CompletableFuture<>();
     client.put(rulesStorageUrl(), circulationRules, TENANT_ID, ResponseHandler.json(putCompleted));
-    putCompleted.join();
+    putCompleted.get(5, TimeUnit.SECONDS);
 
     JsonResponse response = deletePatronNoticePolicy(inUsePolicyId);
     String message = response.getJson().getJsonArray("errors").getJsonObject(0).getString("message");

--- a/src/test/java/org/folio/rest/api/PatronNoticePoliciesApiTest.java
+++ b/src/test/java/org/folio/rest/api/PatronNoticePoliciesApiTest.java
@@ -4,6 +4,8 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.collection.IsArrayContainingInAnyOrder.arrayContainingInAnyOrder;
 import static org.hamcrest.junit.MatcherAssert.assertThat;
 
+import static org.folio.rest.api.CirculationRulesApiTest.rulesStorageUrl;
+import static org.folio.rest.api.StorageTestSuite.TENANT_ID;
 import static org.folio.rest.impl.PatronNoticePoliciesAPI.IN_USE_POLICY_ERROR_MESSAGE;
 import static org.folio.rest.impl.PatronNoticePoliciesAPI.NOT_FOUND;
 import static org.folio.rest.impl.PatronNoticePoliciesAPI.PATRON_NOTICE_POLICY_TABLE;
@@ -26,6 +28,7 @@ import io.vertx.ext.sql.UpdateResult;
 import org.junit.After;
 import org.junit.Test;
 
+import org.folio.rest.jaxrs.model.CirculationRules;
 import org.folio.rest.jaxrs.model.LoanNotice;
 import org.folio.rest.jaxrs.model.PatronNoticePolicy;
 import org.folio.rest.jaxrs.model.RequestNotice;
@@ -56,7 +59,7 @@ public class PatronNoticePoliciesApiTest extends ApiTests {
   public void cleanUp() {
     CompletableFuture<UpdateResult> future = new CompletableFuture<>();
     PostgresClient
-      .getInstance(StorageTestSuite.getVertx(), StorageTestSuite.TENANT_ID)
+      .getInstance(StorageTestSuite.getVertx(), TENANT_ID)
       .delete(PATRON_NOTICE_POLICY_TABLE, new Criterion(), del -> future.complete(del.result()));
     future.join();
   }
@@ -145,7 +148,7 @@ public class PatronNoticePoliciesApiTest extends ApiTests {
 
     CompletableFuture<JsonResponse> getAllCompleted = new CompletableFuture<>();
 
-    client.get(patronNoticePoliciesStorageUrl(), StorageTestSuite.TENANT_ID, ResponseHandler.json(getAllCompleted));
+    client.get(patronNoticePoliciesStorageUrl(), TENANT_ID, ResponseHandler.json(getAllCompleted));
 
     JsonResponse response = getAllCompleted.get(5, TimeUnit.SECONDS);
 
@@ -172,7 +175,7 @@ public class PatronNoticePoliciesApiTest extends ApiTests {
 
     CompletableFuture<JsonResponse> getCompleted = new CompletableFuture<>();
 
-    client.get(patronNoticePoliciesStorageUrl("/" + id), StorageTestSuite.TENANT_ID, ResponseHandler.json(getCompleted));
+    client.get(patronNoticePoliciesStorageUrl("/" + id), TENANT_ID, ResponseHandler.json(getCompleted));
 
     JsonResponse response = getCompleted.get(5, TimeUnit.SECONDS);
 
@@ -188,7 +191,7 @@ public class PatronNoticePoliciesApiTest extends ApiTests {
     CompletableFuture<JsonResponse> getCompleted = new CompletableFuture<>();
 
     client.get(patronNoticePoliciesStorageUrl("/" + nonexistentPolicy.getId()),
-      StorageTestSuite.TENANT_ID, ResponseHandler.json(getCompleted));
+      TENANT_ID, ResponseHandler.json(getCompleted));
 
     JsonResponse response = getCompleted.get(5, TimeUnit.SECONDS);
 
@@ -221,6 +224,13 @@ public class PatronNoticePoliciesApiTest extends ApiTests {
   public void cannotDeleteInUsePatronNoticePolicy() throws InterruptedException, MalformedURLException,
     TimeoutException, ExecutionException {
 
+    CirculationRules circulationRules = new CirculationRules()
+      .withRulesAsText(IN_USE_NOTICE_POLICY_ID);
+
+    CompletableFuture<JsonResponse> putCompleted = new CompletableFuture<>();
+    client.put(rulesStorageUrl(), circulationRules, TENANT_ID, ResponseHandler.json(putCompleted));
+    putCompleted.join();
+
     JsonResponse response = deletePatronNoticePolicy(IN_USE_NOTICE_POLICY_ID);
     String message = response.getJson().getJsonArray("errors").getJsonObject(0).getString("message");
 
@@ -233,7 +243,7 @@ public class PatronNoticePoliciesApiTest extends ApiTests {
 
     CompletableFuture<JsonResponse> createCompleted = new CompletableFuture<>();
 
-    client.post(patronNoticePoliciesStorageUrl(), entity, StorageTestSuite.TENANT_ID,
+    client.post(patronNoticePoliciesStorageUrl(), entity, TENANT_ID,
       ResponseHandler.json(createCompleted));
 
     return createCompleted.get(5, TimeUnit.SECONDS);
@@ -244,7 +254,7 @@ public class PatronNoticePoliciesApiTest extends ApiTests {
 
     CompletableFuture<JsonResponse> updateCompleted = new CompletableFuture<>();
 
-    client.put(patronNoticePoliciesStorageUrl("/" + entity.getId()), entity, StorageTestSuite.TENANT_ID,
+    client.put(patronNoticePoliciesStorageUrl("/" + entity.getId()), entity, TENANT_ID,
       ResponseHandler.json(updateCompleted));
 
     return updateCompleted.get(5, TimeUnit.SECONDS);
@@ -255,7 +265,7 @@ public class PatronNoticePoliciesApiTest extends ApiTests {
 
     CompletableFuture<JsonResponse> deleteCompleted = new CompletableFuture<>();
 
-    client.delete(patronNoticePoliciesStorageUrl("/" + patronNoticePolicyId), StorageTestSuite.TENANT_ID,
+    client.delete(patronNoticePoliciesStorageUrl("/" + patronNoticePolicyId), TENANT_ID,
       ResponseHandler.json(deleteCompleted));
 
     return deleteCompleted.get(5, TimeUnit.SECONDS);

--- a/src/test/java/org/folio/rest/api/PatronNoticePoliciesApiTest.java
+++ b/src/test/java/org/folio/rest/api/PatronNoticePoliciesApiTest.java
@@ -39,6 +39,7 @@ import org.folio.rest.support.ApiTests;
 import org.folio.rest.support.JsonResponse;
 import org.folio.rest.support.Response;
 import org.folio.rest.support.ResponseHandler;
+import org.folio.rest.support.TextResponse;
 
 public class PatronNoticePoliciesApiTest extends ApiTests {
 
@@ -231,14 +232,14 @@ public class PatronNoticePoliciesApiTest extends ApiTests {
     CirculationRules circulationRules = new CirculationRules()
       .withRulesAsText(rulesAsText);
 
-    CompletableFuture<JsonResponse> putCompleted = new CompletableFuture<>();
-    client.put(rulesStorageUrl(), circulationRules, TENANT_ID, ResponseHandler.json(putCompleted));
+    CompletableFuture<TextResponse> putCompleted = new CompletableFuture<>();
+    client.put(rulesStorageUrl(), circulationRules, TENANT_ID, ResponseHandler.text(putCompleted));
     putCompleted.get(5, TimeUnit.SECONDS);
 
     JsonResponse response = deletePatronNoticePolicy(inUsePolicyId);
-    String message = response.getJson().getJsonArray("errors").getJsonObject(0).getString("message");
+    String message = response.getBody();
 
-    assertThat(response.getStatusCode(), is(422));
+    assertThat(response.getStatusCode(), is(400));
     assertThat(message, is("Cannot delete in use notice policy"));
   }
 


### PR DESCRIPTION
## Purpose
Resolves: CIRCSTORE-119
Not allow user to delete patron notice policy if currently in use
## Links
https://issues.folio.org/browse/CIRCSTORE-119