### PR TITLE
Use install endpoint for running managed demo CIRCSTORE-131

### DIFF
--- a/descriptors/Activate-template.json
+++ b/descriptors/Activate-template.json
@@ -1,3 +1,0 @@
-{
-  "id": "${artifactId}-${version}"
-}

--- a/descriptors/Install-template.json
+++ b/descriptors/Install-template.json
@@ -1,0 +1,6 @@
+[
+  {
+    "id": "${artifactId}-${version}",
+    "action": "enable"
+  }
+]

--- a/okapi-registration/managed-deployment/register.sh
+++ b/okapi-registration/managed-deployment/register.sh
@@ -19,5 +19,5 @@ curl -w '\n' -D - -s \
 
 curl -w '\n' -X POST -D - \
      -H "Content-type: application/json" \
-     -d @./target/Activate.json \
-     "${okapi_proxy_address}/_/proxy/tenants/${tenant_id}/modules"
+     -d @./target/Install.json  \
+     "${okapi_proxy_address}/_/proxy/tenants/${tenant_id}/install?deploy=false&tenantParameters=loadSample%3Dtrue%2CloadReference%3Dtrue"

--- a/pom.xml
+++ b/pom.xml
@@ -310,8 +310,8 @@
                   <destinationFile>${project.build.directory}/DeploymentDescriptor-environment.json</destinationFile>
                 </fileSet>
                 <fileSet>
-                  <sourceFile>${project.build.directory}/Activate-template.json</sourceFile>
-                  <destinationFile>${project.build.directory}/Activate.json</destinationFile>
+                  <sourceFile>${project.build.directory}/Install-template.json</sourceFile>
+                  <destinationFile>${project.build.directory}/Install.json</destinationFile>
                 </fileSet>
               </fileSets>
             </configuration>


### PR DESCRIPTION
In order to improve local testing of reference and sample record loading, the managed demo script could use the install endpoint to trigger this each time the module is started.