### PR TITLE
[CIRCSTORE-133] Request Expiration Job Takes Too Long for Short Term Expiry Periods

### DIFF
--- a/src/main/java/org/folio/rest/impl/RequestExpiryImpl.java
+++ b/src/main/java/org/folio/rest/impl/RequestExpiryImpl.java
@@ -13,7 +13,7 @@ public class RequestExpiryImpl implements PeriodicAPI {
   @Override
   public long runEvery() {
     String intervalString = MODULE_SPECIFIC_ARGS.getOrDefault("request.expire.interval",
-      "3600000");
+      "120000");
     return Long.parseLong(intervalString);
   }
 

--- a/src/main/java/org/folio/support/ExpirationTool.java
+++ b/src/main/java/org/folio/support/ExpirationTool.java
@@ -88,7 +88,8 @@ public class ExpirationTool {
 
     String where = format("WHERE " +
         "(jsonb->>'status' = '%1$s' AND jsonb->>'requestExpirationDate' < '%3$s') OR " +
-        "(jsonb->>'status' = '%2$s' AND jsonb->>'holdShelfExpirationDate' < '%3$s')",
+        "(jsonb->>'status' = '%2$s' AND jsonb->>'holdShelfExpirationDate' < '%3$s') " +
+        "LIMIT 150",
 
       OPEN_NOT_YET_FILLED.value(),
       OPEN_AWAITING_PICKUP.value(),


### PR DESCRIPTION
reduce run period to "every 2 minutes" and process up to 150 expired requests