### PR TITLE
Define initial set of code owners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+*  @marcjohnson-kint @kostyantyn-kh @mrdpopov @OleksiiKuzminov @opochepam @mtraneis


### PR DESCRIPTION
To help broaden the collective ownership of this module and expand the set of folks who can review changes to this module we are introducing an initial set of code owners.

This initial set is made up of the active contributors to this module over the last year and the Tech Leads from teams actively working in this area.