### PR TITLE
Increment major version to reflect breaking compatibility change CIRCSTORE-134

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <artifactId>mod-circulation-storage</artifactId>
   <groupId>org.folio</groupId>
-  <version>8.2.0-SNAPSHOT</version>
+  <version>9.0.0-SNAPSHOT</version>
   <licenses>
     <license>
       <name>Apache License 2.0</name>


### PR DESCRIPTION
In order to have at least one snapshot version of the correct version published prior to formal release.

[CIRCSTORE-134](https://github.com/folio-org/mod-circulation-storage/commit/cf452b7bc62ffc94d6e6a5e5402c1abacb1d4eea) introduced compatibility breaking changes, which were correctly reflected in the interface version.

This change means that it will also be reflected in the implementation version, prior to the upcoming formal release.