### PR TITLE
[CIRCSTORE-141] Extend patron notice policy and scheduled notice schemas

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -223,7 +223,7 @@
     },
     {
       "id": "patron-notice-policy-storage",
-      "version": "2.0",
+      "version": "0.9",
       "handlers": [
         {
           "methods": ["POST"],

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -223,7 +223,7 @@
     },
     {
       "id": "patron-notice-policy-storage",
-      "version": "0.9",
+      "version": "2.0",
       "handlers": [
         {
           "methods": ["POST"],

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -223,7 +223,7 @@
     },
     {
       "id": "patron-notice-policy-storage",
-      "version": "0.8",
+      "version": "0.9",
       "handlers": [
         {
           "methods": ["POST"],
@@ -285,7 +285,7 @@
     },
     {
       "id": "scheduled-notice-storage",
-      "version": "0.1",
+      "version": "0.2",
       "handlers": [
         {
           "methods": ["GET"],

--- a/ramls/patron-notice-policy.json
+++ b/ramls/patron-notice-policy.json
@@ -344,6 +344,7 @@
                   "Recall request",
                   "Recall loanee",
                   "Hold request",
+                  "Request Expiration",
                   "Paging request",
                   "Available",
                   "Hold Expiration",

--- a/ramls/patron-notice-policy.json
+++ b/ramls/patron-notice-policy.json
@@ -344,7 +344,7 @@
                   "Recall request",
                   "Recall loanee",
                   "Hold request",
-                  "Request Expiration",
+                  "Request expiration",
                   "Paging request",
                   "Available",
                   "Hold Expiration",

--- a/ramls/patron-notice-policy.raml
+++ b/ramls/patron-notice-policy.raml
@@ -1,6 +1,6 @@
 #%RAML 1.0
 title: Patron Notice Policies
-version: v0.8
+version: v0.9
 protocols: [ HTTP, HTTPS ]
 baseUri: http://localhost:9130
 

--- a/ramls/patron-notice-policy.raml
+++ b/ramls/patron-notice-policy.raml
@@ -1,6 +1,6 @@
 #%RAML 1.0
 title: Patron Notice Policies
-version: v0.9
+version: v2.0
 protocols: [ HTTP, HTTPS ]
 baseUri: http://localhost:9130
 

--- a/ramls/patron-notice-policy.raml
+++ b/ramls/patron-notice-policy.raml
@@ -1,6 +1,6 @@
 #%RAML 1.0
 title: Patron Notice Policies
-version: v2.0
+version: v0.9
 protocols: [ HTTP, HTTPS ]
 baseUri: http://localhost:9130
 

--- a/ramls/scheduled-notice-storage.raml
+++ b/ramls/scheduled-notice-storage.raml
@@ -1,6 +1,6 @@
 #%RAML 1.0
 title: Scheduled Notice Storage
-version: v0.1
+version: v0.2
 protocols: [ HTTP, HTTPS ]
 baseUri: http://localhost:9130
 

--- a/ramls/scheduled-notice.json
+++ b/ramls/scheduled-notice.json
@@ -22,6 +22,11 @@
       "format": "date-time",
       "description": "Next run time"
     },
+    "triggeringEvent": {
+      "type": "string",
+      "description": "Scheduled notice triggering event",
+      "enum": ["Hold Expiration", "Request Expiration"]
+    },
     "noticeConfig": {
       "type": "object",
       "properties": {

--- a/ramls/scheduled-notice.json
+++ b/ramls/scheduled-notice.json
@@ -25,7 +25,7 @@
     "triggeringEvent": {
       "type": "string",
       "description": "Scheduled notice triggering event",
-      "enum": ["Hold Expiration", "Request Expiration"]
+      "enum": ["Hold Expiration", "Request expiration"]
     },
     "noticeConfig": {
       "type": "object",

--- a/ramls/scheduled-notice.json
+++ b/ramls/scheduled-notice.json
@@ -25,7 +25,11 @@
     "triggeringEvent": {
       "type": "string",
       "description": "Scheduled notice triggering event",
-      "enum": ["Hold expiration", "Request expiration"]
+      "enum": [
+        "Hold expiration",
+        "Request expiration",
+        "Due date"
+      ]
     },
     "noticeConfig": {
       "type": "object",

--- a/ramls/scheduled-notice.json
+++ b/ramls/scheduled-notice.json
@@ -25,7 +25,7 @@
     "triggeringEvent": {
       "type": "string",
       "description": "Scheduled notice triggering event",
-      "enum": ["Hold Expiration", "Request expiration"]
+      "enum": ["Hold expiration", "Request expiration"]
     },
     "noticeConfig": {
       "type": "object",


### PR DESCRIPTION
## Purpose
Resolves: CIRCSTORE-141
1. Add `Request Expiriation` event to patron notice policy by the following path
patron-notice-policy.json -> requestNotices -> sendOptions -> sendWhen

2. Add `triggeringEvent` property to scheduled-notice json, values: Hold Expiration, Request Expiration
## Links
https://issues.folio.org/browse/CIRCSTORE-141
https://issues.folio.org/browse/CIRC-387