### PR TITLE
CIRCSTORE-145 Increment version to 9.2.0-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <artifactId>mod-circulation-storage</artifactId>
   <groupId>org.folio</groupId>
-  <version>9.1.0-SNAPSHOT</version>
+  <version>9.2.0-SNAPSHOT</version>
   <licenses>
     <license>
       <name>Apache License 2.0</name>


### PR DESCRIPTION
9.1.0-SNAPSHOT was incorrect due to a mistake when entering the next
version during the last release