### PR TITLE
CIRCSTORE-150 - Delivery requests: add new staff slip - "Request deli…

### DIFF
--- a/reference-data/staff-slips-storage/staff-slips/requestDelivery.json
+++ b/reference-data/staff-slips-storage/staff-slips/requestDelivery.json
@@ -1,6 +1,6 @@
 {
   "id": "1ed55c5c-64d9-40eb-8b80-7438a262288b",
-  "name": "Request Delivery",
+  "name": "Request delivery",
   "active": true,
   "template": "<p></p>"
 }

--- a/reference-data/staff-slips-storage/staff-slips/requestDelivery.json
+++ b/reference-data/staff-slips-storage/staff-slips/requestDelivery.json
@@ -1,0 +1,6 @@
+{
+  "id": "1ed55c5c-64d9-40eb-8b80-7438a262288b",
+  "name": "Request Delivery",
+  "active": true,
+  "template": "<p></p>"
+}

--- a/src/test/java/org/folio/rest/api/StaffSlipsApiTest.java
+++ b/src/test/java/org/folio/rest/api/StaffSlipsApiTest.java
@@ -66,7 +66,7 @@ public class StaffSlipsApiTest extends ApiTests {
 
     JsonArray slipsJsonArray = getResponse.getJson().getJsonArray("staffSlips");
     Object [] names = slipsJsonArray.stream().map(o -> ((JsonObject) o).getString(NAME_KEY)).toArray();
-    assertThat(names, arrayContainingInAnyOrder("Hold", "Transit", "Request Delivery"));
+    assertThat(names, arrayContainingInAnyOrder("Hold", "Transit", "Request delivery"));
   }
 
   /* Begin Tests */

--- a/src/test/java/org/folio/rest/api/StaffSlipsApiTest.java
+++ b/src/test/java/org/folio/rest/api/StaffSlipsApiTest.java
@@ -66,7 +66,7 @@ public class StaffSlipsApiTest extends ApiTests {
 
     JsonArray slipsJsonArray = getResponse.getJson().getJsonArray("staffSlips");
     Object [] names = slipsJsonArray.stream().map(o -> ((JsonObject) o).getString(NAME_KEY)).toArray();
-    assertThat(names, arrayContainingInAnyOrder("Hold", "Transit"));
+    assertThat(names, arrayContainingInAnyOrder("Hold", "Transit", "Request Delivery"));
   }
 
   /* Begin Tests */


### PR DESCRIPTION
## Purpose
Due to https://issues.folio.org/browse/CIRCSTORE-150 we want to add an additional staff slip entry.

## Approach
* added new staff slip entry with name "Request delivery" as a separate file.