### PR TITLE
[CIRCSTORE-147, CIRCSTORE-148] Create CRUD API endpoints for patron action session

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -343,6 +343,33 @@
           "pathPattern": "/_/tenant"
         }
       ]
+    },
+    {
+      "id": "patron-action-session-storage",
+      "version": "1.0",
+      "handlers": [
+        {
+          "methods": ["GET"],
+          "pathPattern": "/patron-action-session-storage/patron-action-sessions",
+          "permissionsRequired": ["patron-action-session-storage.patron-action-sessions.collection.get"]
+        }, {
+          "methods": ["GET"],
+          "pathPattern": "/patron-action-session-storage/patron-action-sessions/{id}",
+          "permissionsRequired": ["patron-action-session-storage.patron-action-sessions.item.get"]
+        }, {
+          "methods": ["POST"],
+          "pathPattern": "/patron-action-session-storage/patron-action-sessions",
+          "permissionsRequired": ["patron-action-session-storage.patron-action-sessions.item.post"]
+        }, {
+          "methods": ["PUT"],
+          "pathPattern": "/patron-action-session-storage/patron-action-sessions/{id}",
+          "permissionsRequired": ["patron-action-session-storage.patron-action-sessions.item.put"]
+        }, {
+          "methods": ["DELETE"],
+          "pathPattern": "/patron-action-session-storage/patron-action-sessions/{id}",
+          "permissionsRequired": ["patron-action-session-storage.patron-action-sessions.item.delete"]
+        }
+      ]
     }
   ],
   "permissionSets": [
@@ -607,6 +634,31 @@
       "description": "Delete all scheduled notices from storage"
     },
     {
+      "permissionName": "patron-action-session-storage.patron-action-sessions.collection.get",
+      "displayName": "Circulation storage - get patron action session collection",
+      "description": "Get patron action session collection from storage"
+    },
+    {
+      "permissionName": "patron-action-session-storage.patron-action-sessions.item.get",
+      "displayName": "Circulation storage - get patron action session",
+      "description": "Get individual patron action session by id"
+    },
+    {
+      "permissionName": "patron-action-session-storage.patron-action-sessions.item.post",
+      "displayName": "Circulation storage - post patron action session",
+      "description": "Create individual patron action session"
+    },
+    {
+      "permissionName": "patron-action-session-storage.patron-action-sessions.item.put",
+      "displayName": "Circulation storage - put patron action session",
+      "description": "Put patron action session by id"
+    },
+    {
+      "permissionName": "patron-action-session-storage.patron-action-sessions.item.delete",
+      "displayName": "Circulation storage - delete patron action session",
+      "description": "Delete patron action session by id"
+    },
+    {
       "permissionName": "circulation-storage.all",
       "displayName": "Circulation storage module - all permissions",
       "description": "Entire set of permissions needed to use the circulation storage module",
@@ -668,7 +720,12 @@
         "scheduled-notice-storage.scheduled-notices.item.put",
         "scheduled-notice-storage.scheduled-notices.item.delete",
         "scheduled-notice-storage.scheduled-notices.collection.delete",
-        "anonymize-storage-loans.post"
+        "anonymize-storage-loans.post",
+        "patron-action-session-storage.patron-action-sessions.collection.get",
+        "patron-action-session-storage.patron-action-sessions.item.get",
+        "patron-action-session-storage.patron-action-sessions.item.post",
+        "patron-action-session-storage.patron-action-sessions.item.put",
+        "patron-action-session-storage.patron-action-sessions.item.delete"
       ]
     },
     {

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -346,7 +346,7 @@
     },
     {
       "id": "patron-action-session-storage",
-      "version": "1.0",
+      "version": "0.1",
       "handlers": [
         {
           "methods": ["GET"],

--- a/ramls/examples/patron-action-session.json
+++ b/ramls/examples/patron-action-session.json
@@ -2,6 +2,5 @@
   "id": "b86829e3-613d-47a6-9f71-d7fcc09c93a3",
   "patronId": "2d5f138f-e088-4dff-80f6-9830f13bcde7",
   "loanId": "718b576f-a6ca-4964-842e-63f79906bd32",
-  "actionType" : "Check-out",
-  "description": "description"
+  "actionType" : "Check-out"
 }

--- a/ramls/examples/patron-action-session.json
+++ b/ramls/examples/patron-action-session.json
@@ -1,0 +1,7 @@
+{
+  "id": "b86829e3-613d-47a6-9f71-d7fcc09c93a3",
+  "patronId": "2d5f138f-e088-4dff-80f6-9830f13bcde7",
+  "loanId": "718b576f-a6ca-4964-842e-63f79906bd32",
+  "actionType" : "Check-out",
+  "description": "description"
+}

--- a/ramls/examples/patron-action-sessions.json
+++ b/ramls/examples/patron-action-sessions.json
@@ -4,15 +4,13 @@
       "id": "b86829e3-613d-47a6-9f71-d7fcc09c93a3",
       "patronId": "2d5f138f-e088-4dff-80f6-9830f13bcde7",
       "loanId": "718b576f-a6ca-4964-842e-63f79906bd32",
-      "actionType" : "Check-out",
-      "description": "description"
+      "actionType" : "Check-out"
     },
     {
       "id": "5c1affcb-3c59-4e89-9223-c9f8850bf82c",
       "patronId": "ee6a2ac0-51c2-4c33-9e3e-d2effa63b9dd",
       "loanId": "12cf2185-e149-4430-af5e-52a6038a6cd6",
-      "actionType" : "Check-in",
-      "description": "description"
+      "actionType" : "Check-in"
     }
   ]
 }

--- a/ramls/examples/patron-action-sessions.json
+++ b/ramls/examples/patron-action-sessions.json
@@ -1,0 +1,18 @@
+{
+  "patronActionSessions": [
+    {
+      "id": "b86829e3-613d-47a6-9f71-d7fcc09c93a3",
+      "patronId": "2d5f138f-e088-4dff-80f6-9830f13bcde7",
+      "loanId": "718b576f-a6ca-4964-842e-63f79906bd32",
+      "actionType" : "Check-out",
+      "description": "description"
+    },
+    {
+      "id": "5c1affcb-3c59-4e89-9223-c9f8850bf82c",
+      "patronId": "ee6a2ac0-51c2-4c33-9e3e-d2effa63b9dd",
+      "loanId": "12cf2185-e149-4430-af5e-52a6038a6cd6",
+      "actionType" : "Check-in",
+      "description": "description"
+    }
+  ]
+}

--- a/ramls/patron-action-session.json
+++ b/ramls/patron-action-session.json
@@ -1,0 +1,41 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "additionalProperties": false,
+  "description": "Patron action session",
+  "properties": {
+    "id": {
+      "type": "string",
+      "description": "Patron action session id, UUID",
+      "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$"
+    },
+    "patronId": {
+      "type": "string",
+      "description": "Patron id",
+      "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$"
+    },
+    "loanId": {
+      "type": "string",
+      "description": "Loan id",
+      "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$"
+    },
+    "actionType": {
+      "type": "string",
+      "description": "Defines action type",
+      "enum": [
+        "Check-out",
+        "Check-in"
+      ]
+    },
+    "metadata": {
+      "description": "Metadata about creation and changes to patron action session, provided by the server (client should not provide)",
+      "type": "object",
+      "$ref": "raml-util/schemas/metadata.schema"
+    }
+  },
+  "required": [
+    "patronId",
+    "loanId",
+    "actionType"
+  ]
+}

--- a/ramls/patron-action-session.raml
+++ b/ramls/patron-action-session.raml
@@ -1,0 +1,49 @@
+#%RAML 1.0
+title: Patron Action Session
+version: v1.0
+protocols: [ HTTP, HTTPS ]
+baseUri: http://localhost:9130
+
+documentation:
+  - title: Patron Action Session API
+    content: <b>Storage for patron action sessions</b>
+
+types:
+  patron-action-session: !include patron-action-session.json
+  patron-action-sessions: !include patron-action-sessions.json
+  errors: !include raml-util/schemas/errors.schema
+
+traits:
+  pageable: !include raml-util/traits/pageable.raml
+  searchable: !include raml-util/traits/searchable.raml
+  language: !include raml-util/traits/language.raml
+  validate: !include raml-util/traits/validation.raml
+
+resourceTypes:
+  collection: !include raml-util/rtypes/collection.raml
+  collection-item: !include raml-util/rtypes/item-collection.raml
+
+/patron-action-session-storage:
+  /patron-action-sessions:
+    displayName: Patron Action Session
+    type:
+      collection:
+        schemaItem: patron-action-session
+        schemaCollection: patron-action-sessions
+        exampleItem: !include examples/patron-action-session.json
+        exampleCollection: !include examples/patron-action-sessions.json
+
+    get:
+      is: [
+        pageable,
+        searchable: {description: "searchable using CQL", example: "name=\"undergrad*\""}
+        ]
+    post:
+      is: [validate]
+    /{patronSessionId}:
+      type:
+        collection-item:
+          schema: patron-action-session
+          exampleItem: !include examples/patron-action-session.json
+      put:
+        is: [validate]

--- a/ramls/patron-action-session.raml
+++ b/ramls/patron-action-session.raml
@@ -1,6 +1,6 @@
 #%RAML 1.0
 title: Patron Action Session
-version: v1.0
+version: v0.1
 protocols: [ HTTP, HTTPS ]
 baseUri: http://localhost:9130
 

--- a/ramls/patron-action-sessions.json
+++ b/ramls/patron-action-sessions.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "description": "Collection of patron action sessions",
+  "type": "object",
+  "properties": {
+    "patronActionSessions": {
+      "description": "List of patron action sessions",
+      "id": "patronActionSessions",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "$ref": "patron-action-session.json"
+      }
+    },
+    "totalRecords": {
+      "type": "integer"
+    }
+  },
+  "required": [
+    "patron-action-sessions",
+    "totalRecords"
+  ]
+}

--- a/src/main/java/org/folio/rest/impl/PatronActionSessionAPI.java
+++ b/src/main/java/org/folio/rest/impl/PatronActionSessionAPI.java
@@ -1,0 +1,66 @@
+package org.folio.rest.impl;
+
+import java.util.Map;
+
+import javax.ws.rs.core.Response;
+
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Context;
+import io.vertx.core.Handler;
+
+import org.folio.rest.jaxrs.model.PatronActionSession;
+import org.folio.rest.jaxrs.model.PatronActionSessions;
+import org.folio.rest.jaxrs.resource.PatronActionSessionStorage;
+import org.folio.rest.persist.PgUtil;
+
+public class PatronActionSessionAPI implements PatronActionSessionStorage {
+
+  private static final String PATRON_ACTION_SESSION_TABLE = "patron_action_session";
+
+  @Override
+  public void getPatronActionSessionStoragePatronActionSessions(int offset,
+    int limit, String query, String lang, Map<String, String> okapiHeaders,
+    Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
+
+    PgUtil.get(PATRON_ACTION_SESSION_TABLE, PatronActionSession.class, PatronActionSessions.class,
+      query, offset, limit, okapiHeaders, vertxContext,
+      GetPatronActionSessionStoragePatronActionSessionsResponse.class, asyncResultHandler);
+  }
+
+  @Override
+  public void postPatronActionSessionStoragePatronActionSessions(
+    String lang, PatronActionSession entity, Map<String, String> okapiHeaders,
+    Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
+
+    PgUtil.post(PATRON_ACTION_SESSION_TABLE, entity, okapiHeaders, vertxContext,
+      PostPatronActionSessionStoragePatronActionSessionsResponse.class, asyncResultHandler);
+  }
+
+  @Override
+  public void getPatronActionSessionStoragePatronActionSessionsByPatronSessionId(
+    String patronSessionId, String lang, Map<String, String> okapiHeaders,
+    Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
+
+    PgUtil.getById(PATRON_ACTION_SESSION_TABLE, PatronActionSession.class, patronSessionId,
+      okapiHeaders, vertxContext, GetPatronActionSessionStoragePatronActionSessionsByPatronSessionIdResponse.class,
+      asyncResultHandler);
+  }
+
+  @Override
+  public void deletePatronActionSessionStoragePatronActionSessionsByPatronSessionId(
+    String patronSessionId, String lang, Map<String, String> okapiHeaders,
+    Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
+
+    PgUtil.deleteById(PATRON_ACTION_SESSION_TABLE, patronSessionId, okapiHeaders, vertxContext,
+      DeletePatronActionSessionStoragePatronActionSessionsByPatronSessionIdResponse.class, asyncResultHandler);
+  }
+
+  @Override
+  public void putPatronActionSessionStoragePatronActionSessionsByPatronSessionId(
+    String patronSessionId, String lang, PatronActionSession entity, Map<String, String> okapiHeaders,
+    Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
+
+    PgUtil.put(PATRON_ACTION_SESSION_TABLE, entity, patronSessionId, okapiHeaders, vertxContext,
+      PutPatronActionSessionStoragePatronActionSessionsByPatronSessionIdResponse.class, asyncResultHandler);
+  }
+}

--- a/src/main/resources/templates/db_scripts/schema.json
+++ b/src/main/resources/templates/db_scripts/schema.json
@@ -183,6 +183,11 @@
       "tableName": "scheduled_notice",
       "withMetadata": true,
       "withAuditing": false
+    },
+    {
+      "tableName": "patron_action_session",
+      "withMetadata": true,
+      "withAuditing": false
     }
   ]
 }

--- a/src/test/java/org/folio/rest/api/AnonymizeLoansApiTest.java
+++ b/src/test/java/org/folio/rest/api/AnonymizeLoansApiTest.java
@@ -25,7 +25,7 @@ import io.vertx.core.json.JsonObject;
 
 public class AnonymizeLoansApiTest extends ApiTests {
   private final AssertingRecordClient loansClient = new AssertingRecordClient(
-    client, StorageTestSuite.TENANT_ID, InterfaceUrls::loanStorageUrl);
+    client, StorageTestSuite.TENANT_ID, InterfaceUrls::loanStorageUrl, "loans");
 
   private JsonArray loanIds;
   private int REQUEST_TIMEOUT = 500;

--- a/src/test/java/org/folio/rest/api/LoansApiTest.java
+++ b/src/test/java/org/folio/rest/api/LoansApiTest.java
@@ -51,7 +51,7 @@ import io.vertx.core.json.JsonObject;
 
 public class LoansApiTest extends ApiTests {
   private final AssertingRecordClient loansClient = new AssertingRecordClient(
-    client, StorageTestSuite.TENANT_ID, InterfaceUrls::loanStorageUrl);
+    client, StorageTestSuite.TENANT_ID, InterfaceUrls::loanStorageUrl, "loans");
 
   @Before
   public void beforeEach()

--- a/src/test/java/org/folio/rest/api/PatronActionSessionAPITest.java
+++ b/src/test/java/org/folio/rest/api/PatronActionSessionAPITest.java
@@ -1,0 +1,224 @@
+package org.folio.rest.api;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.collection.IsArrayContainingInAnyOrder.arrayContainingInAnyOrder;
+import static org.hamcrest.junit.MatcherAssert.assertThat;
+
+import static org.folio.rest.api.StorageTestSuite.TENANT_ID;
+
+import java.net.MalformedURLException;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.sql.UpdateResult;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import org.folio.rest.persist.PostgresClient;
+import org.folio.rest.persist.Criteria.Criterion;
+import org.folio.rest.support.ApiTests;
+import org.folio.rest.support.JsonResponse;
+import org.folio.rest.support.ResponseHandler;
+
+public class PatronActionSessionAPITest extends ApiTests {
+
+  private static final String PATRON_ACTION_SESSION = "patron_action_session";
+  private static final String PATRON_ACTION_SESSION_URL = "/patron-action-session-storage/patron-action-sessions";
+
+  @Before
+  public void cleanUp() {
+    CompletableFuture<UpdateResult> future = new CompletableFuture<>();
+    PostgresClient
+      .getInstance(StorageTestSuite.getVertx(), TENANT_ID)
+      .delete(PATRON_ACTION_SESSION, new Criterion(), del -> future.complete(del.result()));
+    future.join();
+  }
+
+  @Test
+  public void canGetAllPatronActionSessions() throws InterruptedException, MalformedURLException,
+    TimeoutException, ExecutionException {
+
+    JsonObject firstSession = new JsonObject()
+      .put("id", UUID.randomUUID().toString())
+      .put("patronId", UUID.randomUUID().toString())
+      .put("loanId", UUID.randomUUID().toString())
+      .put("actionType", "Check-out");
+
+    JsonObject secondSession = new JsonObject()
+      .put("id", UUID.randomUUID().toString())
+      .put("patronId", UUID.randomUUID().toString())
+      .put("loanId", UUID.randomUUID().toString())
+      .put("actionType", "Check-out");
+
+    postPatronActionSession(firstSession);
+    postPatronActionSession(secondSession);
+
+    CompletableFuture<JsonResponse> getAllCompleted = new CompletableFuture<>();
+
+    client.get(StorageTestSuite.storageUrl(PATRON_ACTION_SESSION_URL), TENANT_ID,
+      ResponseHandler.json(getAllCompleted));
+    JsonResponse response = getAllCompleted.get(5, TimeUnit.SECONDS);
+
+    assertThat("Failed to get all patron notice policies", response.getStatusCode(), is(200));
+
+    JsonArray sessions = response.getJson().getJsonArray("patronActionSessions");
+
+    assertThat(sessions.size(), is(2));
+    assertThat(response.getJson().getInteger("totalRecords"), is(2));
+
+    String[] patronIdArray = sessions.stream()
+      .map(JsonObject.class :: cast)
+      .map(json -> json.getString("patronId"))
+      .toArray(String[] :: new);
+
+    assertThat(patronIdArray,
+      arrayContainingInAnyOrder(firstSession.getString("patronId"), secondSession.getString("patronId")));
+  }
+
+  @Test
+  public void canCreatePatronActionSession() throws InterruptedException,
+    MalformedURLException, TimeoutException, ExecutionException {
+
+    JsonObject request = new JsonObject()
+      .put("id", UUID.randomUUID().toString())
+      .put("patronId", UUID.randomUUID().toString())
+      .put("loanId", UUID.randomUUID().toString())
+      .put("actionType", "Check-out");
+    JsonResponse response = postPatronActionSession(request);
+    assertThat("Failed to create patron active session", response.getStatusCode(), is(201));
+  }
+
+  @Test
+  public void canGetPatronActionSession() throws InterruptedException, MalformedURLException,
+    TimeoutException, ExecutionException {
+
+    JsonObject session = new JsonObject()
+      .put("id", UUID.randomUUID().toString())
+      .put("patronId", UUID.randomUUID().toString())
+      .put("loanId", UUID.randomUUID().toString())
+      .put("actionType", "Check-out");
+    String id = postPatronActionSession(session).getJson().getString("id");
+
+    CompletableFuture<JsonResponse> getCompleted = new CompletableFuture<>();
+    client.get(StorageTestSuite.storageUrl(PATRON_ACTION_SESSION_URL + "/" + id),
+      TENANT_ID, ResponseHandler.json(getCompleted));
+
+    JsonResponse response = getCompleted.get(5, TimeUnit.SECONDS);
+
+    assertThat(response.getStatusCode(), is(200));
+    assertThat(response.getJson().getString("id"), is(id));
+    assertThat(response.getJson().getString("patronId"), is(session.getString("patronId")));
+
+  }
+
+  @Test
+  public void canDeletePatronActionSession() throws InterruptedException, MalformedURLException,
+    TimeoutException, ExecutionException {
+
+    JsonObject request = new JsonObject()
+      .put("id", UUID.randomUUID().toString())
+      .put("patronId", UUID.randomUUID().toString())
+      .put("loanId", UUID.randomUUID().toString())
+      .put("actionType", "Check-out");
+    String id = postPatronActionSession(request).getJson().getString("id");
+    JsonResponse response = deletePatronActionSession(id);
+
+    assertThat(response.getStatusCode(), is(204));
+  }
+
+  @Test
+  public void cannotDeleteNonExistPatronActionSessionId() throws MalformedURLException,
+    InterruptedException, ExecutionException, TimeoutException {
+
+    String id = UUID.randomUUID().toString();
+    JsonResponse response = deletePatronActionSession(id);
+
+    assertThat(response.getStatusCode(), is(404));
+    assertThat(response.getBody(), is("Not found"));
+  }
+
+  @Test
+  public void canUpdatePatronActiveSession() throws InterruptedException, MalformedURLException,
+    TimeoutException, ExecutionException {
+
+    JsonObject request = new JsonObject()
+      .put("id", UUID.randomUUID().toString())
+      .put("patronId", UUID.randomUUID().toString())
+      .put("loanId", UUID.randomUUID().toString())
+      .put("actionType", "Check-out");
+
+    String id = postPatronActionSession(request).getJson().getString("id");
+    String newLoanId = UUID.randomUUID().toString();
+    request
+      .put("loanId", newLoanId)
+      .put("actionType", "Check-in");
+    JsonResponse response = putPatronActionSession(request);
+
+    assertThat("Failed to update patron active session", response.getStatusCode(), is(204));
+
+    JsonObject updatedPolicy = getPatronActionSessionById(id).getJson();
+    assertThat(updatedPolicy.getString("loanId"), is(newLoanId));
+    assertThat(updatedPolicy.getString("actionType"), is ("Check-in"));
+  }
+
+  @Test
+  public void cannotUpdateNonExistActionSession() throws InterruptedException, MalformedURLException,
+    TimeoutException, ExecutionException {
+
+    JsonObject nonExistPatronActionSession = new JsonObject()
+      .put("id", UUID.randomUUID().toString())
+      .put("patronId", UUID.randomUUID().toString())
+      .put("loanId", UUID.randomUUID().toString())
+      .put("actionType", "Check-out");
+    JsonResponse response = putPatronActionSession(nonExistPatronActionSession);
+
+    assertThat(response.getStatusCode(), is(404));
+  }
+
+
+  private JsonResponse postPatronActionSession(JsonObject entity) throws MalformedURLException,
+    InterruptedException, ExecutionException, TimeoutException {
+
+    CompletableFuture<JsonResponse> createCompleted = new CompletableFuture<>();
+    client.post(StorageTestSuite.storageUrl(PATRON_ACTION_SESSION_URL),
+      entity, TENANT_ID, ResponseHandler.json(createCompleted));
+
+    return createCompleted.get(5, TimeUnit.SECONDS);
+  }
+
+  private JsonResponse putPatronActionSession(JsonObject entity) throws MalformedURLException,
+    InterruptedException, ExecutionException, TimeoutException {
+
+    CompletableFuture<JsonResponse> updateCompleted = new CompletableFuture<>();
+    client.put(StorageTestSuite.storageUrl(PATRON_ACTION_SESSION_URL + "/" + entity.getString("id")),
+      entity, TENANT_ID, ResponseHandler.json(updateCompleted));
+
+    return updateCompleted.get(5, TimeUnit.SECONDS);
+  }
+
+  private JsonResponse getPatronActionSessionById(String id)
+    throws MalformedURLException, InterruptedException, ExecutionException, TimeoutException {
+
+    CompletableFuture<JsonResponse> getCompleted = new CompletableFuture<>();
+    client.get(StorageTestSuite.storageUrl(PATRON_ACTION_SESSION_URL + "/" + id),
+      TENANT_ID, ResponseHandler.json(getCompleted));
+
+    return getCompleted.get(5, TimeUnit.SECONDS);
+  }
+
+  private JsonResponse deletePatronActionSession(String id) throws MalformedURLException,
+    InterruptedException, ExecutionException, TimeoutException {
+
+    CompletableFuture<JsonResponse> deleteCompleted = new CompletableFuture<>();
+    client.delete(StorageTestSuite.storageUrl(PATRON_ACTION_SESSION_URL + "/" + id),
+      TENANT_ID, ResponseHandler.json(deleteCompleted));
+
+    return deleteCompleted.get(5, TimeUnit.SECONDS);
+  }
+}

--- a/src/test/java/org/folio/rest/api/StorageTestSuite.java
+++ b/src/test/java/org/folio/rest/api/StorageTestSuite.java
@@ -53,7 +53,8 @@ import io.vertx.ext.sql.ResultSet;
   PatronNoticePoliciesApiTest.class,
   RequestPoliciesApiTest.class,
   RequestExpirationApiTest.class,
-  ScheduledNoticesAPITest.class
+  ScheduledNoticesAPITest.class,
+  PatronActionSessionAPITest.class
 })
 
 public class StorageTestSuite {

--- a/src/test/java/org/folio/rest/api/loans/LoansAnonymizationApiTest.java
+++ b/src/test/java/org/folio/rest/api/loans/LoansAnonymizationApiTest.java
@@ -40,7 +40,7 @@ import io.vertx.core.json.JsonObject;
 
 public class LoansAnonymizationApiTest extends ApiTests {
   private final AssertingRecordClient loansClient = new AssertingRecordClient(
-    client, StorageTestSuite.TENANT_ID, InterfaceUrls::loanStorageUrl);
+    client, StorageTestSuite.TENANT_ID, InterfaceUrls::loanStorageUrl, "loans");
 
   @Before
   public void beforeEach()

--- a/src/test/java/org/folio/rest/support/http/InterfaceUrls.java
+++ b/src/test/java/org/folio/rest/support/http/InterfaceUrls.java
@@ -18,6 +18,12 @@ public class InterfaceUrls {
     return StorageTestSuite.storageUrl("/loan-storage/loans" + subPath);
   }
 
+  public static URL patronActionSessionStorageUrl(String subPath)
+    throws MalformedURLException {
+
+    return StorageTestSuite.storageUrl("/patron-action-session-storage/patron-action-sessions" + subPath);
+  }
+
   public static URL anonymizeLoansURL() throws MalformedURLException {
     return StorageTestSuite.storageUrl("/anonymize-storage-loans");
   }


### PR DESCRIPTION
## Purpose

Resolves: CIRCSTORE-147, CIRCSTORE-148

1. Create DB table to store check-in/check-out session information 
2. Create CRUD API endpoints for patron action session

## Approach
1. Update `AssertingRecordClient` with new field `String collectionPropertyName`
2. Add `attemptDeleteById(UUID id)` and `attemptPutById(JsonObject updateObject)` methods to `AssertingRecordClient` 

## TODOS and Open Questions
1. The name of the table and API endpoints are under discussion

## Links 
1. https://issues.folio.org/browse/CIRCSTORE-147
2. https://issues.folio.org/browse/CIRCSTORE-148

