### PR TITLE
[CIRCSTORE-151] Add "Manual due date change" as a triggering event

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -234,7 +234,7 @@
     },
     {
       "id": "patron-notice-policy-storage",
-      "version": "0.9",
+      "version": "0.10",
       "handlers": [
         {
           "methods": ["POST"],

--- a/ramls/patron-notice-policy.json
+++ b/ramls/patron-notice-policy.json
@@ -86,7 +86,8 @@
                   "Overdue",
                   "Renewed",
                   "Check in",
-                  "Check out"
+                  "Check out",
+                  "Manual due date change"
                 ]
               },
               "sendBy": {

--- a/ramls/patron-notice-policy.raml
+++ b/ramls/patron-notice-policy.raml
@@ -1,6 +1,6 @@
 #%RAML 1.0
 title: Patron Notice Policies
-version: v0.9
+version: v0.10
 protocols: [ HTTP, HTTPS ]
 baseUri: http://localhost:9130
 

--- a/src/test/java/org/folio/rest/api/PatronNoticePoliciesApiTest.java
+++ b/src/test/java/org/folio/rest/api/PatronNoticePoliciesApiTest.java
@@ -54,9 +54,17 @@ public class PatronNoticePoliciesApiTest extends ApiTests {
       .put("realTime", "true")
       .put("sendOptions", sendOptions);
 
+    JsonObject manualDueDateChangeNotice = new JsonObject()
+      .put("templateId", UUID.randomUUID().toString())
+      .put("format", "Email")
+      .put("realTime", "true")
+      .put("sendOptions", new JsonObject()
+        .put("sendWhen", "Manual due date change"));
+
     JsonObject noticePolicy = new JsonObject()
       .put("name", "sample policy")
-      .put("requestNotices", new JsonArray().add(requestNotice));
+      .put("requestNotices", new JsonArray().add(requestNotice))
+      .put("loanNotices", new JsonArray().add(manualDueDateChangeNotice));
 
     JsonResponse response = postPatronNoticePolicy(noticePolicy);
 


### PR DESCRIPTION
## Purpose
Add "Manual due date change" as a triggering event to loan notices in patron notice policy
Resolves: [CIRCSTORE-151](https://issues.folio.org/browse/CIRCSTORE-151)
 ## Approach

- Add "Manual due date change" option to `sendWhen` enum in **patron notice policy** JSON schema
- Increase minor version of `patron-notice-policy-storage` interface
- Change the test to demonstrate that "Manual due date change" is an allowed option