### PR TITLE
[CIRCSTORE-155] Change patron notice policy schema 

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -234,7 +234,7 @@
     },
     {
       "id": "patron-notice-policy-storage",
-      "version": "0.10",
+      "version": "1.0",
       "handlers": [
         {
           "methods": ["POST"],

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -234,7 +234,7 @@
     },
     {
       "id": "patron-notice-policy-storage",
-      "version": "1.0",
+      "version": "0.11",
       "handlers": [
         {
           "methods": ["POST"],

--- a/ramls/patron-notice-policy.json
+++ b/ramls/patron-notice-policy.json
@@ -87,7 +87,8 @@
                   "Renewed",
                   "Check in",
                   "Check out",
-                  "Manual due date change"
+                  "Manual due date change",
+                  "Item recalled"
                 ]
               },
               "sendBy": {
@@ -343,7 +344,6 @@
                 "description": "User initiated and time driven events for request related notices",
                 "enum": [
                   "Recall request",
-                  "Recall loanee",
                   "Hold request",
                   "Request expiration",
                   "Paging request",

--- a/ramls/patron-notice-policy.json
+++ b/ramls/patron-notice-policy.json
@@ -83,7 +83,6 @@
                 "description": "Triggering event",
                 "enum": [
                   "Due date",
-                  "Overdue",
                   "Renewed",
                   "Check in",
                   "Check out",
@@ -348,7 +347,7 @@
                   "Request expiration",
                   "Paging request",
                   "Available",
-                  "Hold Expiration",
+                  "Hold expiration",
                   "Request cancellation"
                 ]
               },

--- a/ramls/patron-notice-policy.raml
+++ b/ramls/patron-notice-policy.raml
@@ -1,6 +1,6 @@
 #%RAML 1.0
 title: Patron Notice Policies
-version: v1.0
+version: v0.11
 protocols: [ HTTP, HTTPS ]
 baseUri: http://localhost:9130
 

--- a/ramls/patron-notice-policy.raml
+++ b/ramls/patron-notice-policy.raml
@@ -1,6 +1,6 @@
 #%RAML 1.0
 title: Patron Notice Policies
-version: v0.10
+version: v1.0
 protocols: [ HTTP, HTTPS ]
 baseUri: http://localhost:9130
 

--- a/src/test/java/org/folio/rest/api/PatronNoticePoliciesApiTest.java
+++ b/src/test/java/org/folio/rest/api/PatronNoticePoliciesApiTest.java
@@ -61,10 +61,19 @@ public class PatronNoticePoliciesApiTest extends ApiTests {
       .put("sendOptions", new JsonObject()
         .put("sendWhen", "Manual due date change"));
 
+    JsonObject itemRecalledNotice = new JsonObject()
+      .put("templateId", UUID.randomUUID().toString())
+      .put("format", "Email")
+      .put("realTime", "true")
+      .put("sendOptions", new JsonObject()
+        .put("sendWhen", "Item recalled"));
+
     JsonObject noticePolicy = new JsonObject()
       .put("name", "sample policy")
       .put("requestNotices", new JsonArray().add(requestNotice))
-      .put("loanNotices", new JsonArray().add(manualDueDateChangeNotice));
+      .put("loanNotices", new JsonArray()
+        .add(manualDueDateChangeNotice)
+        .add(itemRecalledNotice));
 
     JsonResponse response = postPatronNoticePolicy(noticePolicy);
 

--- a/src/test/java/org/folio/rest/api/PatronNoticePoliciesApiTest.java
+++ b/src/test/java/org/folio/rest/api/PatronNoticePoliciesApiTest.java
@@ -68,9 +68,18 @@ public class PatronNoticePoliciesApiTest extends ApiTests {
       .put("sendOptions", new JsonObject()
         .put("sendWhen", "Item recalled"));
 
+    JsonObject holdExpirationChangeNotice = new JsonObject()
+      .put("templateId", UUID.randomUUID().toString())
+      .put("format", "Email")
+      .put("realTime", "true")
+      .put("sendOptions", new JsonObject()
+        .put("sendWhen", "Hold expiration"));
+
     JsonObject noticePolicy = new JsonObject()
       .put("name", "sample policy")
-      .put("requestNotices", new JsonArray().add(requestNotice))
+      .put("requestNotices", new JsonArray()
+        .add(requestNotice)
+        .add(holdExpirationChangeNotice))
       .put("loanNotices", new JsonArray()
         .add(manualDueDateChangeNotice)
         .add(itemRecalledNotice));


### PR DESCRIPTION
## Purpose 
Move "Recall loanee" triggering event option from request notices to loan notices and rename it to "Item recalled". 
Resolves story: [CIRCSTORE-155](https://issues.folio.org/browse/CIRCSTORE-155)
It is needed for: [UICIRC-279](https://issues.folio.org/browse/UICIRC-279)

## Approach
- Changed patron notice policy schema due to requirements
- Given PR already introduces breaking change, removed "Overdue" option from loan notices as not used and renamed "Hold Expiration" to "Hold expiration" to follow convention
- Updated tests according to schema changes

## Notes 
This PR should be merged together with mod-circulation PR and ui-circulation PR (not ready yet)