### PR TITLE
FOLIO-2256 deploy image to ci k8s cluster on snapshot/release build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,6 +5,7 @@ buildMvn {
   publishAPI = 'yes'
   mvnDeploy = 'yes'
   runLintRamlCop = 'yes'
+  doKubeDeploy = true
 
   doDocker = {
     buildJavaDocker {


### PR DESCRIPTION
enables kubeDeploy step on buildMvn pipeline to deploy images to ci kubernetes cluster on release/snapshot builds.