### PR TITLE
[Circstore-149] Create API endpoint to retrieve patron IDs with expired sessions

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -377,7 +377,7 @@
     },
     {
       "id": "patron-action-session-storage",
-      "version": "0.1",
+      "version": "0.2",
       "handlers": [
         {
           "methods": ["GET"],

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -368,6 +368,10 @@
           "methods": ["DELETE"],
           "pathPattern": "/patron-action-session-storage/patron-action-sessions/{id}",
           "permissionsRequired": ["patron-action-session-storage.patron-action-sessions.item.delete"]
+        }, {
+          "methods": ["GET"],
+          "pathPattern": "/patron-action-session-storage/expired-session-patron-ids",
+          "permissionsRequired": ["patron-action-session-storage.expired-session-patron-ids.collection.get"]
         }
       ]
     }
@@ -725,7 +729,8 @@
         "patron-action-session-storage.patron-action-sessions.item.get",
         "patron-action-session-storage.patron-action-sessions.item.post",
         "patron-action-session-storage.patron-action-sessions.item.put",
-        "patron-action-session-storage.patron-action-sessions.item.delete"
+        "patron-action-session-storage.patron-action-sessions.item.delete",
+        "patron-action-session-storage.expired-session-patron-ids.collection.get"
       ]
     },
     {

--- a/ramls/examples/patron-action-expired-session.json
+++ b/ramls/examples/patron-action-expired-session.json
@@ -1,0 +1,16 @@
+{
+  "expiredSessions": [
+    {
+      "patronId": "2d5f138f-e088-4dff-80f6-9830f13bcde7",
+      "actionType" : "Check-out"
+    },
+    {
+      "patronId": "2d5f138f-e088-4dff-80f6-9830f13bcde8",
+      "actionType" : "Check-in"
+    },
+    {
+      "patronId": "2d5f138f-e088-4dff-80f6-9830f13bcde9",
+      "actionType" : "Check-out"
+    }
+  ]
+}

--- a/ramls/patron-action-expired-ids-response.json
+++ b/ramls/patron-action-expired-ids-response.json
@@ -4,16 +4,32 @@
   "type": "object",
   "additionalProperties": false,
   "properties": {
-    "patronIds": {
-      "description": "List of patron ids",
-      "id": "patronIds",
+    "expiredSessions": {
+      "description": "List of expired sessions",
+      "id": "expiredSessions",
       "type": "array",
       "items": {
-        "type": "string"
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "patronId": {
+            "type": "string",
+            "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
+            "description": "Id of patron who has expired session"
+          },
+          "actionType": {
+            "type": "string",
+            "enum": [
+              "Check-out",
+              "Check-in"
+            ],
+            "description": "Type of expired session"
+          }
+        }
       }
     }
   },
   "required": [
-    "patronIds"
+    "expiredSessions"
   ]
 }

--- a/ramls/patron-action-expired-ids-response.json
+++ b/ramls/patron-action-expired-ids-response.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "description": "Collection of patron ids who has expired session",
+  "description": "Collection of expired sessions",
   "type": "object",
   "additionalProperties": false,
   "properties": {

--- a/ramls/patron-action-expired-ids-response.json
+++ b/ramls/patron-action-expired-ids-response.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "description": "Collection of patron ids who has expired session",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "patronIds": {
+      "description": "List of patron ids",
+      "id": "patronIds",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    }
+  },
+  "required": [
+    "patronIds"
+  ]
+}

--- a/ramls/patron-action-session.raml
+++ b/ramls/patron-action-session.raml
@@ -55,9 +55,10 @@ resourceTypes:
             description: Action type for patron notice session
             type: string
             enum: ["Check-in", "Check-out"]
-            required: true
-          max_session_change_time:
-            description: The maximum time of last session modification
+            required: false
+          session_inactivity_time_limit:
+            description: This parameter defines time in format up to which all sessions are considered as expired
+            example: 2018-11-29T13:23:36Z
             type: string
             required: true
           limit:

--- a/ramls/patron-action-session.raml
+++ b/ramls/patron-action-session.raml
@@ -47,3 +47,33 @@ resourceTypes:
           exampleItem: !include examples/patron-action-session.json
       put:
         is: [validate]
+  /expired-session-patron-ids:
+      get:
+        queryParameters:
+          action_type:
+            description: Action type for patron notice session
+            type: string
+            required: true
+          last_time_action_limit:
+            description: Period of time for before that a session will be expired
+            type: string
+            required: true
+          limit:
+            description: Limit the number of sessions returned in the response
+            type: integer
+            required: false
+            example: 10
+            default: 10
+            minimum: 0
+            maximum: 2147483647
+        responses:
+          200:
+            description: "Return list of notice groups"
+            body:
+              application/json:
+                type: string[]
+          500:
+            description: "Internal server error"
+            body:
+              text/plain:
+                example: "Internal server error"

--- a/ramls/patron-action-session.raml
+++ b/ramls/patron-action-session.raml
@@ -56,8 +56,8 @@ resourceTypes:
             type: string
             enum: ["Check-in", "Check-out"]
             required: true
-          last_time_action_limit:
-            description: Period of time for before that a session will be expired
+          max_session_change_time:
+            description: The maximum time of last session modification
             type: string
             required: true
           limit:

--- a/ramls/patron-action-session.raml
+++ b/ramls/patron-action-session.raml
@@ -12,6 +12,7 @@ types:
   patron-action-session: !include patron-action-session.json
   patron-action-sessions: !include patron-action-sessions.json
   errors: !include raml-util/schemas/errors.schema
+  patron-action-expired-ids-response: !include patron-action-expired-ids-response.json
 
 traits:
   pageable: !include raml-util/traits/pageable.raml
@@ -53,6 +54,7 @@ resourceTypes:
           action_type:
             description: Action type for patron notice session
             type: string
+            enum: ["Check-in", "Check-out"]
             required: true
           last_time_action_limit:
             description: Period of time for before that a session will be expired
@@ -71,9 +73,14 @@ resourceTypes:
             description: "Return list of notice groups"
             body:
               application/json:
-                type: string[]
+                type: patron-action-expired-ids-response
           500:
             description: "Internal server error"
             body:
               text/plain:
                 example: "Internal server error"
+          422:
+            description: "Validation error"
+            body:
+              application/json:
+                type: errors

--- a/ramls/patron-action-session.raml
+++ b/ramls/patron-action-session.raml
@@ -53,11 +53,11 @@ resourceTypes:
         is: [validate]
         queryParameters:
           action_type:
-            description: Action type for patron notice session
+            description: Parameter to filter expired sessions by patron action type
             type: string
             required: false
           session_inactivity_time_limit:
-            description: This parameter defines time in format up to which all sessions are considered as expired
+            description: This parameter defines time up to which all sessions are considered as expired. Conforms to the ISO 8601 date and time format
             example: 2018-11-29T13:23:36Z
             type: string
             required: true

--- a/ramls/patron-action-session.raml
+++ b/ramls/patron-action-session.raml
@@ -50,11 +50,11 @@ resourceTypes:
         is: [validate]
   /expired-session-patron-ids:
       get:
+        is: [validate]
         queryParameters:
           action_type:
             description: Action type for patron notice session
             type: string
-            enum: ["Check-in", "Check-out"]
             required: false
           session_inactivity_time_limit:
             description: This parameter defines time in format up to which all sessions are considered as expired
@@ -80,8 +80,3 @@ resourceTypes:
             body:
               text/plain:
                 example: "Internal server error"
-          422:
-            description: "Validation error"
-            body:
-              application/json:
-                type: errors

--- a/ramls/patron-action-session.raml
+++ b/ramls/patron-action-session.raml
@@ -1,6 +1,6 @@
 #%RAML 1.0
 title: Patron Action Session
-version: v0.1
+version: v0.2
 protocols: [ HTTP, HTTPS ]
 baseUri: http://localhost:9130
 

--- a/ramls/patron-action-sessions.json
+++ b/ramls/patron-action-sessions.json
@@ -17,7 +17,7 @@
     }
   },
   "required": [
-    "patron-action-sessions",
+    "patronActionSessions",
     "totalRecords"
   ]
 }

--- a/src/main/java/org/folio/rest/impl/PatronActionSessionAPI.java
+++ b/src/main/java/org/folio/rest/impl/PatronActionSessionAPI.java
@@ -6,6 +6,7 @@ import static javax.ws.rs.core.MediaType.TEXT_PLAIN;
 
 import static org.folio.rest.persist.PostgresClient.convertToPsqlStandard;
 
+import java.util.EnumMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -37,7 +38,16 @@ public class PatronActionSessionAPI implements PatronActionSessionStorage {
 
   private static final String PATRON_ACTION_SESSION_TABLE = "patron_action_session";
   private static final String INTERNAL_SERVER_ERROR = "Internal Server Error";
-  private static final Logger LOGGER = LoggerFactory.getLogger(PatronActionSessionStorage.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(PatronActionSessionAPI.class);
+  private static final EnumMap<PatronActionSessionStorageExpiredSessionPatronIdsGetActionType,
+    PatronActionSession.ActionType> ACTION_TYPE_MAP = new EnumMap<>(
+      PatronActionSessionStorageExpiredSessionPatronIdsGetActionType.class);
+
+  static {
+    ACTION_TYPE_MAP.put(PatronActionSessionStorageExpiredSessionPatronIdsGetActionType.CHECKIN, PatronActionSession.ActionType.CHECK_IN);
+    ACTION_TYPE_MAP.put(PatronActionSessionStorageExpiredSessionPatronIdsGetActionType.CHECKOUT, PatronActionSession.ActionType.CHECK_OUT);
+  }
+
 
   @Override
   public void getPatronActionSessionStoragePatronActionSessions(int offset,
@@ -97,7 +107,7 @@ public class PatronActionSessionAPI implements PatronActionSessionStorage {
       return;
     }
 
-    String sql = toSelectExpiredSessionsQuery(tenantId, PatronActionSession.ActionType.valueOf(actionType.name()),
+    String sql = toSelectExpiredSessionsQuery(tenantId, ACTION_TYPE_MAP.get(actionType),
       limit, dateTimeLimit);
 
     pgClient.select(sql)

--- a/src/main/java/org/folio/rest/impl/PatronActionSessionAPI.java
+++ b/src/main/java/org/folio/rest/impl/PatronActionSessionAPI.java
@@ -1,21 +1,39 @@
 package org.folio.rest.impl;
 
+import static javax.ws.rs.core.HttpHeaders.CONTENT_TYPE;
+import static javax.ws.rs.core.MediaType.TEXT_PLAIN;
+
+import static org.folio.rest.persist.PostgresClient.convertToPsqlStandard;
+
+import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import javax.ws.rs.core.Response;
 
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Context;
 import io.vertx.core.Handler;
+import io.vertx.core.logging.Logger;
+import io.vertx.core.logging.LoggerFactory;
+import io.vertx.ext.sql.ResultSet;
 
+import org.joda.time.DateTime;
+import org.joda.time.format.ISODateTimeFormat;
+
+import org.folio.cql2pgjson.exception.QueryValidationException;
+import org.folio.rest.RestVerticle;
 import org.folio.rest.jaxrs.model.PatronActionSession;
 import org.folio.rest.jaxrs.model.PatronActionSessions;
 import org.folio.rest.jaxrs.resource.PatronActionSessionStorage;
 import org.folio.rest.persist.PgUtil;
+import org.folio.support.PgClientFutureAdapter;
 
 public class PatronActionSessionAPI implements PatronActionSessionStorage {
 
   private static final String PATRON_ACTION_SESSION_TABLE = "patron_action_session";
+  private static final String INTERNAL_SERVER_ERROR = "Internal Server Error";
+  private static final Logger LOGGER = LoggerFactory.getLogger(PatronActionSessionStorage.class);
 
   @Override
   public void getPatronActionSessionStoragePatronActionSessions(int offset,
@@ -56,11 +74,68 @@ public class PatronActionSessionAPI implements PatronActionSessionStorage {
   }
 
   @Override
+  public void getPatronActionSessionStorageExpiredSessionPatronIds(
+    String actionType, String lastTimeActionLimit, int limit, Map<String,
+    String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
+
+    String tenantId = okapiHeaders.get(RestVerticle.OKAPI_HEADER_TENANT);
+    PgClientFutureAdapter pgClient = PgClientFutureAdapter.create(vertxContext, okapiHeaders);
+
+    String sql = toSelectExpiredSessionsQuery(tenantId, PatronActionSession.ActionType.fromValue(actionType),
+      limit, DateTime.parse(lastTimeActionLimit));
+
+    pgClient.select(sql)
+      .map(this::mapPatronIdResponse)
+      .map(GetPatronActionSessionStorageExpiredSessionPatronIdsResponse::respond200WithApplicationJson)
+      .map(Response.class::cast)
+      .otherwise(this::mapExceptionToResponse)
+      .setHandler(asyncResultHandler);
+  }
+
+  private List<String> mapPatronIdResponse(ResultSet resultSet) {
+    return resultSet.getRows()
+      .stream()
+      .map(json -> json.getString("patron_id"))
+      .collect(Collectors.toList());
+  }
+
+  @Override
   public void putPatronActionSessionStoragePatronActionSessionsByPatronSessionId(
     String patronSessionId, String lang, PatronActionSession entity, Map<String, String> okapiHeaders,
     Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
 
     PgUtil.put(PATRON_ACTION_SESSION_TABLE, entity, patronSessionId, okapiHeaders, vertxContext,
       PutPatronActionSessionStoragePatronActionSessionsByPatronSessionIdResponse.class, asyncResultHandler);
+  }
+
+  private String toSelectExpiredSessionsQuery(String tenant, PatronActionSession.ActionType actionType,
+                                                      int limit, DateTime lastActionDateLimit){
+
+    String tableName = String.format("%s.%s", convertToPsqlStandard(tenant), PATRON_ACTION_SESSION_TABLE);
+    String limitDate = lastActionDateLimit.toString(ISODateTimeFormat.dateTime());
+
+    return String.format("SELECT jsonb ->> 'patronId' AS \"patron_id\" " +
+      "FROM %s " +
+      "WHERE jsonb ->> 'actionType' = '%s' " +
+      "GROUP BY jsonb ->> 'patronId' " +
+      "HAVING max(jsonb #>> '{metadata,createdDate}') < '%s' " +
+      "LIMIT '%d'", tableName, actionType, limitDate, limit);
+  }
+
+  private Response mapExceptionToResponse(Throwable t) {
+
+    LOGGER.error(t.getMessage(), t);
+
+    if (t.getClass() == QueryValidationException.class) {
+      return Response.status(400)
+        .header(CONTENT_TYPE, TEXT_PLAIN)
+        .entity(t.getMessage())
+        .build();
+    }
+
+    return Response.status(500)
+      .header(CONTENT_TYPE, TEXT_PLAIN)
+      .entity(INTERNAL_SERVER_ERROR)
+      .build();
   }
 }

--- a/src/main/java/org/folio/rest/impl/PatronActionSessionAPI.java
+++ b/src/main/java/org/folio/rest/impl/PatronActionSessionAPI.java
@@ -97,8 +97,7 @@ public class PatronActionSessionAPI implements PatronActionSessionStorage {
     DateTime dateTimeLimit;
     try {
       dateTimeLimit = DateTime.parse(lastTimeActionLimit);
-    }
-    catch (Exception e){
+    } catch (Exception e) {
       Errors errors = ValidationHelper.createValidationErrorMessage("last_time_action_limit",
         lastTimeActionLimit, "cannot be parsed");
       asyncResultHandler.handle(succeededFuture(
@@ -121,7 +120,7 @@ public class PatronActionSessionAPI implements PatronActionSessionStorage {
   private PatronActionExpiredIdsResponse mapPatronIdResponse(ResultSet resultSet) {
     List<String> patronIds = resultSet.getRows()
       .stream()
-      .map(json -> json.getString("patron_id"))
+      .map(json -> json.getString("patronId"))
       .collect(Collectors.toList());
     return new PatronActionExpiredIdsResponse().withPatronIds(patronIds);
   }
@@ -141,7 +140,7 @@ public class PatronActionSessionAPI implements PatronActionSessionStorage {
     String tableName = String.format("%s.%s", convertToPsqlStandard(tenant), PATRON_ACTION_SESSION_TABLE);
     String limitDate = lastActionDateLimit.toString(ISODateTimeFormat.dateTime());
 
-    return String.format("SELECT jsonb ->> 'patronId' AS \"patron_id\" " +
+    return String.format("SELECT jsonb ->> 'patronId' AS \"patronId\" " +
       "FROM %s " +
       "WHERE jsonb ->> 'actionType' = '%s' " +
       "GROUP BY jsonb ->> 'patronId' " +

--- a/src/main/java/org/folio/support/PgClientFutureAdapter.java
+++ b/src/main/java/org/folio/support/PgClientFutureAdapter.java
@@ -1,0 +1,36 @@
+package org.folio.support;
+
+import java.util.Map;
+
+import org.folio.rest.persist.PgUtil;
+import org.folio.rest.persist.PostgresClient;
+
+import io.vertx.core.Context;
+import io.vertx.core.Future;
+import io.vertx.ext.sql.ResultSet;
+import io.vertx.ext.sql.UpdateResult;
+
+public class PgClientFutureAdapter {
+
+  public static PgClientFutureAdapter create(Context vertxContext, Map<String, String> okapiHeaders) {
+    return new PgClientFutureAdapter(PgUtil.postgresClient(vertxContext, okapiHeaders));
+  }
+
+  private final PostgresClient client;
+
+  public PgClientFutureAdapter(PostgresClient client) {
+    this.client = client;
+  }
+
+  public Future<ResultSet> select(String sql) {
+    Future<ResultSet> future = Future.future();
+    client.select(sql, future);
+    return future;
+  }
+
+  public Future<UpdateResult> execute(String sql) {
+    Future<UpdateResult> future = Future.future();
+    client.execute(sql, future);
+    return future;
+  }
+}

--- a/src/test/java/org/folio/rest/api/PatronActionSessionAPITest.java
+++ b/src/test/java/org/folio/rest/api/PatronActionSessionAPITest.java
@@ -254,7 +254,6 @@ public class PatronActionSessionAPITest extends ApiTests {
     final JsonResponse response = getCompleted.get(5, TimeUnit.SECONDS);
 
     assertThat(response, isOk());
-
     return response.getJson().getJsonArray("patronIds").getList();
   }
 }

--- a/src/test/java/org/folio/rest/api/PatronActionSessionAPITest.java
+++ b/src/test/java/org/folio/rest/api/PatronActionSessionAPITest.java
@@ -197,18 +197,18 @@ public class PatronActionSessionAPITest extends ApiTests {
     createPatronActionSessionRecords(secondPatronId, "Check-in", DateTime.now().minus(1));
     createPatronActionSessionRecords(secondPatronId, "Check-out", DateTime.now().minus(1));
 
-    assertThat(getExpiredSessionPatronIds("Check-out", 10, DateTime.now()).size(), is(2));
+    assertThat(getExpiredPatronSessions("Check-out", 10, DateTime.now()).size(), is(2));
 
-    JsonArray checkInJsonArray = getExpiredSessionPatronIds("Check-in", 10, DateTime.now().minusDays(2));
+    JsonArray checkInJsonArray = getExpiredPatronSessions("Check-in", 10, DateTime.now().minusDays(2));
     assertThat(checkInJsonArray.size(), is(1));
     assertThat(checkInJsonArray.getJsonObject(0).getString("patronId"), is(firstPatronId));
     assertThat(checkInJsonArray.getJsonObject(0).getString("actionType"), is("Check-in"));
 
-    JsonArray checkOutJsonArray = getExpiredSessionPatronIds("Check-out", 10, DateTime.now().minusDays(2));
+    JsonArray checkOutJsonArray = getExpiredPatronSessions("Check-out", 10, DateTime.now().minusDays(2));
     assertThat(checkOutJsonArray.getJsonObject(0).getString("patronId"), is(firstPatronId));
     assertThat(checkOutJsonArray.getJsonObject(0).getString("actionType"), is("Check-out"));
 
-    assertThat(getExpiredSessionPatronIds("Check-out", 1, DateTime.now()).size(), is(1));
+    assertThat(getExpiredPatronSessions("Check-out", 1, DateTime.now()).size(), is(1));
   }
 
   @Test
@@ -220,7 +220,7 @@ public class PatronActionSessionAPITest extends ApiTests {
     String secondPatronId = UUID.randomUUID().toString();
     createPatronActionSessionRecords(secondPatronId, "Check-out", DateTime.now().minusDays(1));
 
-    JsonArray jsonArray = getExpiredSessionPatronIds(10, DateTime.now());
+    JsonArray jsonArray = getExpiredPatronSessions(10, DateTime.now());
 
     assertThat(jsonArray.size(), is(2));
     assertThat(jsonArray.getJsonObject(0).getString("patronId"), is(firstPatronId));
@@ -292,7 +292,7 @@ public class PatronActionSessionAPITest extends ApiTests {
     return session;
   }
 
-  private JsonArray getExpiredSessionPatronIds(String actionType, int limit, DateTime lastActionDateLimit)
+  private JsonArray getExpiredPatronSessions(String actionType, int limit, DateTime lastActionDateLimit)
     throws InterruptedException, ExecutionException, TimeoutException, MalformedURLException {
 
     String actionTypeFilter = actionType != null ? actionType : "";
@@ -305,10 +305,10 @@ public class PatronActionSessionAPITest extends ApiTests {
     return response.getJson().getJsonArray("expiredSessions");
   }
 
-  private JsonArray getExpiredSessionPatronIds(int limit, DateTime lastActionDateLimit)
+  private JsonArray getExpiredPatronSessions(int limit, DateTime lastActionDateLimit)
     throws InterruptedException, ExecutionException, TimeoutException, MalformedURLException {
 
-    return getExpiredSessionPatronIds(null, limit, lastActionDateLimit);
+    return getExpiredPatronSessions(null, limit, lastActionDateLimit);
   }
 
   private JsonResponse get(URL url)


### PR DESCRIPTION
## Purpose
Add API endpoint to retrieve all patrons Ids from patron_action_session table where last record's createdDate has expired according to configured timeout

Resolves story: https://issues.folio.org/browse/CIRCSTORE-149
## Approach
- update patron-action-session.raml to support retrieving patron IDs with expired sessions
- implement `getPatronActionSessionStorageExpiredSessionPatronIds `method in `PatronActionSessionAPI`
- create tests to `PatronActionSessionAPITest`
## Links
https://issues.folio.org/browse/CIRCSTORE-149 

 