### PR TITLE
increase default memory limits in MD

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -826,7 +826,7 @@
     }
   ],
   "metadata": {
-    "containerMemory": "256",
+    "containerMemory": "384",
     "databaseConnection": "true"
   },
   "launchDescriptor": {
@@ -834,7 +834,7 @@
     "dockerPull": false,
     "dockerArgs": {
       "HostConfig": {
-        "Memory": 357913941,
+        "Memory": 536870912,
         "PortBindings": { "8081/tcp": [ { "HostPort": "%p" } ] }
       }
     },


### PR DESCRIPTION
- increase JVM max heap default from 256mb to 384mb.  
- Increase container limit from 384mb to 512mb.  