### PR TITLE
CIRCSTORE-158 add BE validation for update patron notice policies

### DIFF
--- a/src/main/java/org/folio/rest/impl/PatronNoticePoliciesAPI.java
+++ b/src/main/java/org/folio/rest/impl/PatronNoticePoliciesAPI.java
@@ -58,6 +58,7 @@ public class PatronNoticePoliciesAPI implements PatronNoticePolicyStorage {
   public static final String NOT_FOUND = "Not found";
   private static final String INTERNAL_SERVER_ERROR = "Internal server error";
   private static final String IN_USE_POLICY_ERROR_MESSAGE = "Cannot delete in use notice policy";
+  private static final String VALIDATION_ERROR_MESSAGE = "This option is not valid for selected";
 
   @Override
   public void getPatronNoticePolicyStoragePatronNoticePolicies(
@@ -310,7 +311,7 @@ public class PatronNoticePoliciesAPI implements PatronNoticePolicyStorage {
       && sendOptions.getSendHow() != SendOptions.SendHow.AFTER && loanNotice.getFrequency() != null) {
 
       return ValidationHelper.createValidationErrorMessage("frequency",
-        loanNotice.getFrequency().toString(), "frequency should not be present");
+        loanNotice.getFrequency().toString(), VALIDATION_ERROR_MESSAGE + " Send");
     }
     return new Errors().withErrors(Collections.emptyList());
   }
@@ -319,7 +320,7 @@ public class PatronNoticePoliciesAPI implements PatronNoticePolicyStorage {
     if (loanNotice.getFrequency() != null && loanNotice.getFrequency() == LoanNotice.Frequency.ONE_TIME
       && loanNotice.getSendOptions().getSendEvery() != null) {
       return ValidationHelper.createValidationErrorMessage("sendEvery",
-        loanNotice.getSendOptions().getSendEvery().toString(), "sendEvery should not be present");
+        loanNotice.getSendOptions().getSendEvery().toString(), VALIDATION_ERROR_MESSAGE + " Frequency");
     }
     return new Errors().withErrors(Collections.emptyList());
   }
@@ -327,15 +328,15 @@ public class PatronNoticePoliciesAPI implements PatronNoticePolicyStorage {
   private Errors validateSendOptionsForNotDueDate(SendOptions sendOptions) {
     if (sendOptions.getSendHow() != null) {
        return ValidationHelper.createValidationErrorMessage("sendHow",
-        sendOptions.getSendHow().toString(), "sendHow should not be present");
+        sendOptions.getSendHow().toString(), VALIDATION_ERROR_MESSAGE + " Triggering event");
     }
     if (sendOptions.getSendBy() != null) {
       return ValidationHelper.createValidationErrorMessage("sendBy",
-        sendOptions.getSendBy().toString(), "sendBy should not be present");
+        sendOptions.getSendBy().toString(), VALIDATION_ERROR_MESSAGE + " Triggering event");
     }
     if (sendOptions.getSendEvery() != null) {
       return ValidationHelper.createValidationErrorMessage("sendEvery",
-        sendOptions.getSendEvery().toString(), "sendEvery should not be present");
+        sendOptions.getSendEvery().toString(), VALIDATION_ERROR_MESSAGE + " Triggering event");
     }
     return new Errors().withErrors(Collections.emptyList());
   }

--- a/src/test/java/org/folio/rest/api/PatronNoticePoliciesApiTest.java
+++ b/src/test/java/org/folio/rest/api/PatronNoticePoliciesApiTest.java
@@ -296,6 +296,144 @@ public class PatronNoticePoliciesApiTest extends ApiTests {
     assertThat(message, is("Cannot delete in use notice policy"));
   }
 
+  @Test
+  public void cannotUpdatePatronNoticePolicyWithNotValidSendHow() throws InterruptedException,
+    MalformedURLException, TimeoutException, ExecutionException {
+
+    JsonObject sendOptions = new JsonObject()
+      .put("sendWhen", "Renewed")
+      .put("sendHow", "Before");
+
+    JsonObject loanNotice = new JsonObject()
+      .put("templateId", UUID.randomUUID().toString())
+      .put("format", "Email")
+      .put("realTime", "true")
+      .put("sendOptions", sendOptions);
+
+    JsonObject noticePolicy = createNoticePolicyWithLoanNotice(loanNotice);
+    JsonResponse response = putPatronNoticePolicy(noticePolicy);
+    assertThat(response.getStatusCode(), is(422));
+    assertThat(response.getJson().getJsonArray("errors").getJsonObject(0).getString("message"),
+      is("sendHow should not be present"));
+  }
+
+  @Test
+  public void cannotUpdatePatronNoticePolicyWithNotValidSendBy() throws InterruptedException,
+    MalformedURLException, TimeoutException, ExecutionException {
+
+    JsonObject sendBy = new JsonObject()
+      .put("duration", "1")
+      .put("intervalId", "Days");
+
+    JsonObject sendOptions = new JsonObject()
+      .put("sendWhen", "Renewed")
+      .put("sendBy", sendBy);
+
+    JsonObject noticePolicy = createNoticePolicyWithSendOptions(sendOptions);
+    JsonResponse response = putPatronNoticePolicy(noticePolicy);
+    assertThat(response.getStatusCode(), is(422));
+    assertThat(response.getJson().getJsonArray("errors").getJsonObject(0).getString("message"),
+      is("sendBy should not be present"));
+  }
+
+  @Test
+  public void cannotUpdatePatronNoticePolicyWithNotValidSendEvery() throws InterruptedException,
+    MalformedURLException, TimeoutException, ExecutionException {
+
+    JsonObject sendEvery = new JsonObject()
+      .put("duration", "2")
+      .put("intervalId", "Hours");
+
+    JsonObject sendOptions = new JsonObject()
+      .put("sendWhen", "Renewed")
+      .put("sendEvery", sendEvery);
+
+    JsonObject noticePolicy = createNoticePolicyWithSendOptions(sendOptions);
+    JsonResponse response = putPatronNoticePolicy(noticePolicy);
+    assertThat(response.getStatusCode(), is(422));
+    assertThat(response.getJson().getJsonArray("errors").getJsonObject(0).getString("message"),
+      is("sendEvery should not be present"));
+  }
+
+  @Test
+  public void cannotUpdatePatronNoticePolicyWithWrongSendHow() throws InterruptedException,
+    MalformedURLException, TimeoutException, ExecutionException {
+
+    JsonObject sendOptions = new JsonObject()
+      .put("sendWhen", "Due date")
+      .put("sendHow", "Upon At");
+
+    JsonObject loanNotice = new JsonObject()
+      .put("templateId", UUID.randomUUID().toString())
+      .put("format", "Email")
+      .put("realTime", "true")
+      .put("frequency", "Recurring")
+      .put("sendOptions", sendOptions);
+
+    JsonObject noticePolicy = createNoticePolicyWithLoanNotice(loanNotice);
+    JsonResponse response = putPatronNoticePolicy(noticePolicy);
+    assertThat(response.getStatusCode(), is(422));
+    assertThat(response.getJson().getJsonArray("errors").getJsonObject(0).getString("message"),
+      is("frequency should not be present"));
+  }
+
+  @Test
+  public void cannotUpdatePatronNoticePolicyWithWrongFrequency() throws InterruptedException,
+    MalformedURLException, TimeoutException, ExecutionException {
+
+    JsonObject sendEvery = new JsonObject()
+      .put("duration", "10")
+      .put("intervalId", "Minutes");
+
+    JsonObject sendOptions = new JsonObject()
+      .put("sendWhen", "Due date")
+      .put("sendHow", "Before")
+      .put("sendEvery", sendEvery);
+
+    JsonObject loanNotice = new JsonObject()
+      .put("templateId", UUID.randomUUID().toString())
+      .put("format", "Email")
+      .put("realTime", "true")
+      .put("frequency", "One time")
+      .put("sendOptions", sendOptions);
+
+    JsonObject noticePolicy = createNoticePolicyWithLoanNotice(loanNotice);
+    JsonResponse response = putPatronNoticePolicy(noticePolicy);
+    assertThat(response.getStatusCode(), is(422));
+    assertThat(response.getJson().getJsonArray("errors").getJsonObject(0).getString("message"),
+      is("sendEvery should not be present"));
+  }
+
+  private JsonObject createNoticePolicyWithSendOptions(JsonObject sendOptions) {
+
+    JsonObject noticePolicy = new JsonObject()
+      .put("name", "sample policy");
+
+    JsonObject loanNotice = new JsonObject()
+      .put("templateId", UUID.randomUUID().toString())
+      .put("format", "Email")
+      .put("realTime", "true")
+      .put("sendOptions", sendOptions);
+
+    noticePolicy
+      .put("id", UUID.randomUUID().toString())
+      .put("description", "new description")
+      .put("loanNotices", new JsonArray().add(loanNotice));
+
+    return noticePolicy;
+  }
+
+  private JsonObject createNoticePolicyWithLoanNotice(JsonObject loanNotice) {
+
+    JsonObject noticePolicy = new JsonObject()
+      .put("name", "sample policy")
+      .put("id", UUID.randomUUID().toString())
+      .put("description", "new description")
+      .put("loanNotices", new JsonArray().add(loanNotice));
+
+    return noticePolicy;
+  }
+
   private JsonResponse getPatronNoticePolicyById(String id)
     throws MalformedURLException, InterruptedException, ExecutionException, TimeoutException {
 

--- a/src/test/java/org/folio/rest/api/PatronNoticePoliciesApiTest.java
+++ b/src/test/java/org/folio/rest/api/PatronNoticePoliciesApiTest.java
@@ -314,7 +314,7 @@ public class PatronNoticePoliciesApiTest extends ApiTests {
     JsonResponse response = putPatronNoticePolicy(noticePolicy);
     assertThat(response.getStatusCode(), is(422));
     assertThat(response.getJson().getJsonArray("errors").getJsonObject(0).getString("message"),
-      is("sendHow should not be present"));
+      is("This option is not valid for selected Triggering event"));
   }
 
   @Test
@@ -333,7 +333,7 @@ public class PatronNoticePoliciesApiTest extends ApiTests {
     JsonResponse response = putPatronNoticePolicy(noticePolicy);
     assertThat(response.getStatusCode(), is(422));
     assertThat(response.getJson().getJsonArray("errors").getJsonObject(0).getString("message"),
-      is("sendBy should not be present"));
+      is("This option is not valid for selected Triggering event"));
   }
 
   @Test
@@ -352,7 +352,7 @@ public class PatronNoticePoliciesApiTest extends ApiTests {
     JsonResponse response = putPatronNoticePolicy(noticePolicy);
     assertThat(response.getStatusCode(), is(422));
     assertThat(response.getJson().getJsonArray("errors").getJsonObject(0).getString("message"),
-      is("sendEvery should not be present"));
+      is("This option is not valid for selected Triggering event"));
   }
 
   @Test
@@ -374,7 +374,7 @@ public class PatronNoticePoliciesApiTest extends ApiTests {
     JsonResponse response = putPatronNoticePolicy(noticePolicy);
     assertThat(response.getStatusCode(), is(422));
     assertThat(response.getJson().getJsonArray("errors").getJsonObject(0).getString("message"),
-      is("frequency should not be present"));
+      is("This option is not valid for selected Send"));
   }
 
   @Test
@@ -401,7 +401,7 @@ public class PatronNoticePoliciesApiTest extends ApiTests {
     JsonResponse response = putPatronNoticePolicy(noticePolicy);
     assertThat(response.getStatusCode(), is(422));
     assertThat(response.getJson().getJsonArray("errors").getJsonObject(0).getString("message"),
-      is("sendEvery should not be present"));
+      is("This option is not valid for selected Frequency"));
   }
 
   private JsonObject createNoticePolicyWithSendOptions(JsonObject sendOptions) {


### PR DESCRIPTION
## Purpose
Resolves: CIRCSTORE-158

1. Create BE validation for update patron notice policies
2. Create tests to test validation

## Approach
1. Update `PatronNoticePoliciesAPI` with new validation for `putPatronNoticePolicyStoragePatronNoticePoliciesByPatronNoticePolicyId`
2. Update `PatronNoticePoliciesApiTest` to test validation changes

## Links
https://issues.folio.org/browse/CIRCSTORE-158
