### PR TITLE
CIRCSTORE-164: Implement request batch update API.

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -152,3 +152,19 @@ Then an update trigger adds the property 'awaitingPickupRequestClosedDate' to th
 Such behavior is required by Expired Holds Report CSV functionality in mod-circulation<br/>
 See [CIRC-320](https://issues.folio.org/browse/CIRC-320)
 
+### Requests Batch API
+
+In order to go through `itemId`-`position` constraint for **request** table we're removing all positions 
+for requests as the first operation of batch, before executing the updates.
+
+Let's say we have following requests in batch package:
+* *Request A*;
+* *Request B*;
+* *Request C*.
+
+Then, in order to execute them successfully and do not get constraint violation we're 
+removing positions for these request, so we will do:
+1. `UPDATE requests SET jsonb = jsonb - 'position' WHERE id IN (A, B, C)`;
+1. `UPDATE requests SET jsonb = A WHERE id = A`;
+1. `UPDATE requests SET jsonb = B WHERE id = B`;
+1. `UPDATE requests SET jsonb = C WHERE id = C`;

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -7,9 +7,9 @@
       "version": "0.1",
       "handlers": [
         {
-          "methods": ["PUT"],
+          "methods": ["POST"],
           "pathPattern": "/request-storage-batch/requests",
-          "permissionsRequired": ["circulation-storage-batch.requests.item.put"]
+          "permissionsRequired": ["circulation-storage-batch.requests.item.post"]
         }
       ]
     },
@@ -530,7 +530,7 @@
       "description": "Modify request in storage"
     },
     {
-      "permissionName": "circulation-storage-batch.requests.item.put",
+      "permissionName": "circulation-storage-batch.requests.item.post",
       "displayName": "Circulation storage batch - modify requests",
       "description": "Modify requests in storage"
     },
@@ -795,7 +795,7 @@
         "circulation-storage.request-policies.item.delete",
         "circulation-storage.request-policies.item.post",
         "circulation-storage.request-policies.item.put",
-        "circulation-storage-batch.requests.item.put",
+        "circulation-storage-batch.requests.item.post",
         "scheduled-notice-storage.scheduled-notices.collection.get",
         "scheduled-notice-storage.scheduled-notices.item.get",
         "scheduled-notice-storage.scheduled-notices.item.post",

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -3,13 +3,13 @@
   "name": "Circulation Storage Module",
   "provides": [
     {
-      "id": "requests-storage-batch",
+      "id": "request-storage-batch",
       "version": "0.1",
       "handlers": [
         {
           "methods": ["POST"],
           "pathPattern": "/request-storage-batch/requests",
-          "permissionsRequired": ["circulation-storage-batch.requests.item.post"]
+          "permissionsRequired": ["circulation-storage.request-batch.item.post"]
         }
       ]
     },
@@ -530,7 +530,7 @@
       "description": "Modify request in storage"
     },
     {
-      "permissionName": "circulation-storage-batch.requests.item.post",
+      "permissionName": "circulation-storage.request-batch.item.post",
       "displayName": "Circulation storage batch - modify requests",
       "description": "Modify requests in storage"
     },
@@ -795,7 +795,7 @@
         "circulation-storage.request-policies.item.delete",
         "circulation-storage.request-policies.item.post",
         "circulation-storage.request-policies.item.put",
-        "circulation-storage-batch.requests.item.post",
+        "circulation-storage.request-batch.item.post",
         "scheduled-notice-storage.scheduled-notices.collection.get",
         "scheduled-notice-storage.scheduled-notices.item.get",
         "scheduled-notice-storage.scheduled-notices.item.post",

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -3,6 +3,17 @@
   "name": "Circulation Storage Module",
   "provides": [
     {
+      "id": "requests-storage-batch",
+      "version": "0.1",
+      "handlers": [
+        {
+          "methods": ["PUT"],
+          "pathPattern": "/request-storage-batch/requests",
+          "permissionsRequired": ["circulation-storage-batch.requests.item.put"]
+        }
+      ]
+    },
+    {
       "id": "loan-storage",
       "version": "6.2",
       "handlers": [
@@ -519,6 +530,11 @@
       "description": "Modify request in storage"
     },
     {
+      "permissionName": "circulation-storage-batch.requests.item.put",
+      "displayName": "Circulation storage batch - modify requests",
+      "description": "Modify requests in storage"
+    },
+    {
       "permissionName": "circulation-storage.requests.item.delete",
       "displayName": "Circulation storage - delete individual request",
       "description": "Delete individual request from storage"
@@ -779,6 +795,7 @@
         "circulation-storage.request-policies.item.delete",
         "circulation-storage.request-policies.item.post",
         "circulation-storage.request-policies.item.put",
+        "circulation-storage-batch.requests.item.put",
         "scheduled-notice-storage.scheduled-notices.collection.get",
         "scheduled-notice-storage.scheduled-notices.item.get",
         "scheduled-notice-storage.scheduled-notices.item.post",

--- a/pom.xml
+++ b/pom.xml
@@ -52,11 +52,6 @@
       <version>5.4.2</version>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>uk.com.robust-it</groupId>
-      <artifactId>cloning</artifactId>
-      <version>1.9.11</version>
-    </dependency>
   </dependencies>
 
   <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -52,6 +52,11 @@
       <version>5.4.2</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>uk.com.robust-it</groupId>
+      <artifactId>cloning</artifactId>
+      <version>1.9.11</version>
+    </dependency>
   </dependencies>
 
   <properties>

--- a/ramls/request-storage-batch.raml
+++ b/ramls/request-storage-batch.raml
@@ -1,0 +1,32 @@
+#%RAML 1.0
+title: Request Storage Batch
+version: v0.1
+protocols: [ HTTP, HTTPS ]
+baseUri: http://localhost:9130
+
+documentation:
+  - title: Batch Request Storage API
+    content: <b>Batch request operations</b>
+
+types:
+  requests-batch: !include requests-batch.json
+  errors: !include raml-util/schemas/errors.schema
+
+traits:
+  validate: !include raml-util/traits/validation.raml
+
+/request-storage-batch:
+  /requests:
+    put:
+      is: [validate]
+      body:
+        application/json:
+          type: requests-batch
+      responses:
+        204:
+          description: "Update executed successfully"
+        500:
+          description: "Internal server error, e.g. due to misconfiguration"
+          body:
+            text/plain:
+              example: "Internal server error, contact administrator"

--- a/ramls/request-storage-batch.raml
+++ b/ramls/request-storage-batch.raml
@@ -17,13 +17,13 @@ traits:
 
 /request-storage-batch:
   /requests:
-    put:
+    post:
       is: [validate]
       body:
         application/json:
           type: requests-batch
       responses:
-        204:
+        201:
           description: "Update executed successfully"
         500:
           description: "Internal server error, e.g. due to misconfiguration"

--- a/ramls/requests-batch.json
+++ b/ramls/requests-batch.json
@@ -11,19 +11,10 @@
         "type": "object",
         "$ref": "request.json"
       }
-    },
-    "transactionMode": {
-      "type": "string",
-      "description": "Transaction mode to use for update operation: Same - execute all updates sequentially within the same transaction",
-      "enum": [
-        "Same"
-      ],
-      "default": "Same"
     }
   },
   "additionalProperties": false,
   "required": [
-    "requests",
-    "transactionMode"
+    "requests"
   ]
 }

--- a/ramls/requests-batch.json
+++ b/ramls/requests-batch.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "description": "Collection of requests",
+  "type": "object",
+  "properties": {
+    "requests": {
+      "description": "List of request items to update",
+      "id": "requests",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "$ref": "request.json"
+      }
+    },
+    "transactionMode": {
+      "type": "string",
+      "description": "Transaction mode to use for update operation: Same - execute all updates sequentially within the same transaction",
+      "enum": [
+        "Same"
+      ],
+      "default": "Same"
+    }
+  },
+  "additionalProperties": false,
+  "required": [
+    "requests",
+    "transactionMode"
+  ]
+}

--- a/src/main/java/org/folio/rest/impl/RequestsBatchAPI.java
+++ b/src/main/java/org/folio/rest/impl/RequestsBatchAPI.java
@@ -1,0 +1,58 @@
+package org.folio.rest.impl;
+
+import static io.vertx.core.Future.succeededFuture;
+import static org.folio.rest.impl.RequestsAPI.REQUEST_TABLE;
+import static org.folio.rest.impl.util.RequestsApiUtil.hasSamePositionConstraintViolated;
+import static org.folio.rest.impl.util.RequestsApiUtil.samePositionInQueueError;
+import static org.folio.rest.jaxrs.resource.RequestStorageBatch.PutRequestStorageBatchRequestsResponse.respond204;
+import static org.folio.rest.jaxrs.resource.RequestStorageBatch.PutRequestStorageBatchRequestsResponse.respond422WithApplicationJson;
+import static org.folio.rest.jaxrs.resource.RequestStorageBatch.PutRequestStorageBatchRequestsResponse.respond500WithTextPlain;
+
+import java.util.Map;
+
+import javax.ws.rs.core.Response;
+
+import org.folio.rest.jaxrs.model.Request;
+import org.folio.rest.jaxrs.model.RequestsBatch;
+import org.folio.rest.jaxrs.resource.RequestStorageBatch;
+import org.folio.rest.persist.PgUtil;
+import org.folio.service.BatchResourceService;
+
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Context;
+import io.vertx.core.Handler;
+
+public class RequestsBatchAPI implements RequestStorageBatch {
+
+  @Override
+  public void putRequestStorageBatchRequests(
+    RequestsBatch entity, Map<String, String> okapiHeaders,
+    Handler<AsyncResult<Response>> asyncResultHandler, Context context) {
+
+    BatchResourceService updateService = new BatchResourceService(
+      PgUtil.postgresClient(context, okapiHeaders),
+      REQUEST_TABLE
+    );
+
+    updateService.executeBatchUpdate(entity.getTransactionMode(), entity.getRequests(), Request::getId,
+      updateResult -> {
+        // Successfully updated
+        if (updateResult.succeeded()) {
+          asyncResultHandler.handle(succeededFuture(respond204()));
+          return;
+        }
+
+        // Update failed due to can not have more then one request in the same position
+        if (hasSamePositionConstraintViolated(updateResult.cause())) {
+          asyncResultHandler.handle(succeededFuture(
+            respond422WithApplicationJson(samePositionInQueueError(null, null))
+          ));
+        } else {
+          // Other failure occurred
+          asyncResultHandler.handle(succeededFuture(
+            respond500WithTextPlain(updateResult.cause().getMessage())
+          ));
+        }
+      });
+  }
+}

--- a/src/main/java/org/folio/rest/impl/RequestsBatchAPI.java
+++ b/src/main/java/org/folio/rest/impl/RequestsBatchAPI.java
@@ -12,11 +12,11 @@ import java.util.Map;
 
 import javax.ws.rs.core.Response;
 
-import org.folio.rest.jaxrs.model.Request;
 import org.folio.rest.jaxrs.model.RequestsBatch;
 import org.folio.rest.jaxrs.resource.RequestStorageBatch;
 import org.folio.rest.persist.PgUtil;
 import org.folio.service.BatchResourceService;
+import org.folio.service.request.RequestBatchResourceService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -32,12 +32,15 @@ public class RequestsBatchAPI implements RequestStorageBatch {
     RequestsBatch entity, Map<String, String> okapiHeaders,
     Handler<AsyncResult<Response>> asyncResultHandler, Context context) {
 
-    BatchResourceService updateService = new BatchResourceService(
+    BatchResourceService batchUpdateService = new BatchResourceService(
       PgUtil.postgresClient(context, okapiHeaders),
       REQUEST_TABLE
     );
 
-    updateService.executeBatchUpdate(entity.getRequests(), Request::getId,
+    RequestBatchResourceService requestBatchUpdateService =
+      new RequestBatchResourceService(batchUpdateService);
+
+    requestBatchUpdateService.executeRequestBatchUpdate(entity.getRequests(),
       updateResult -> {
         // Successfully updated
         if (updateResult.succeeded()) {

--- a/src/main/java/org/folio/rest/impl/RequestsBatchAPI.java
+++ b/src/main/java/org/folio/rest/impl/RequestsBatchAPI.java
@@ -1,12 +1,12 @@
 package org.folio.rest.impl;
 
 import static io.vertx.core.Future.succeededFuture;
-import static org.folio.rest.impl.RequestsAPI.REQUEST_TABLE;
 import static org.folio.rest.impl.util.RequestsApiUtil.hasSamePositionConstraintViolated;
 import static org.folio.rest.impl.util.RequestsApiUtil.samePositionInQueueError;
 import static org.folio.rest.jaxrs.resource.RequestStorageBatch.PostRequestStorageBatchRequestsResponse.respond201;
 import static org.folio.rest.jaxrs.resource.RequestStorageBatch.PostRequestStorageBatchRequestsResponse.respond422WithApplicationJson;
 import static org.folio.rest.jaxrs.resource.RequestStorageBatch.PostRequestStorageBatchRequestsResponse.respond500WithTextPlain;
+import static org.folio.rest.tools.utils.TenantTool.tenantId;
 
 import java.util.Map;
 
@@ -33,12 +33,11 @@ public class RequestsBatchAPI implements RequestStorageBatch {
     Handler<AsyncResult<Response>> asyncResultHandler, Context context) {
 
     BatchResourceService batchUpdateService = new BatchResourceService(
-      PgUtil.postgresClient(context, okapiHeaders),
-      REQUEST_TABLE
+      PgUtil.postgresClient(context, okapiHeaders)
     );
 
     RequestBatchResourceService requestBatchUpdateService =
-      new RequestBatchResourceService(batchUpdateService);
+      new RequestBatchResourceService(tenantId(okapiHeaders), batchUpdateService);
 
     requestBatchUpdateService.executeRequestBatchUpdate(entity.getRequests(),
       updateResult -> {

--- a/src/main/java/org/folio/rest/impl/util/RequestsApiUtil.java
+++ b/src/main/java/org/folio/rest/impl/util/RequestsApiUtil.java
@@ -1,0 +1,41 @@
+package org.folio.rest.impl.util;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.folio.rest.jaxrs.model.Error;
+import org.folio.rest.jaxrs.model.Errors;
+
+/**
+ * Utility methods for Requests resource.
+ */
+public class RequestsApiUtil {
+
+  private RequestsApiUtil() {
+    throw new UnsupportedOperationException("Do not instantiate");
+  }
+
+  public static boolean hasSamePositionConstraintViolated(Throwable cause) {
+    return cause != null && hasSamePositionConstraintViolated(cause.getMessage());
+  }
+
+  public static boolean hasSamePositionConstraintViolated(String errorMessage) {
+    return errorMessage != null && errorMessage.contains("request_itemid_position_idx_unique");
+  }
+
+  public static Errors samePositionInQueueError(String item, Integer position) {
+    Error error = new Error();
+
+    error.withMessage("Cannot have more than one request with the same position in the queue")
+      .withAdditionalProperty("itemId", item)
+      .withAdditionalProperty("position", position);
+
+    List<Error> errorList = new ArrayList<>();
+    errorList.add(error);
+
+    Errors errors = new Errors();
+    errors.setErrors(errorList);
+
+    return errors;
+  }
+}

--- a/src/main/java/org/folio/service/BatchResourceService.java
+++ b/src/main/java/org/folio/service/BatchResourceService.java
@@ -1,0 +1,109 @@
+package org.folio.service;
+
+import static org.folio.rest.jaxrs.model.RequestsBatch.TransactionMode;
+
+import java.util.List;
+import java.util.function.Function;
+
+import org.folio.rest.persist.PostgresClient;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.ext.sql.SQLConnection;
+import io.vertx.ext.sql.UpdateResult;
+
+public class BatchResourceService {
+  private static final Logger LOG = LoggerFactory.getLogger(BatchResourceService.class);
+  private static final String WHERE_CLAUSE = "WHERE id = '%s'";
+
+  private final PostgresClient postgresClient;
+  private final String tableName;
+
+  public BatchResourceService(PostgresClient postgresClient, String tableName) {
+    this.postgresClient = postgresClient;
+    this.tableName = tableName;
+  }
+
+  /**
+   * Execute batch update.
+   *
+   * @param transactionMode - Transaction mode for update:
+   *                        Same - use one transaction for all entities
+   * @param entities        - Entities to update
+   * @param getId           - Function to get ID from an entity.
+   * @param onFinishHandler - Callback.
+   * @param <T>             - Entity type.
+   * @throws UnsupportedOperationException if transaction mode is not supported.
+   */
+  public <T> void executeBatchUpdate(
+    TransactionMode transactionMode, List<T> entities, Function<T, String> getId,
+    Handler<AsyncResult<Void>> onFinishHandler) {
+
+    // Currently only one mode supported
+    if (transactionMode == TransactionMode.SAME) {
+      executeBatchUpdateInSameTransaction(entities, getId, onFinishHandler);
+    } else {
+      throw new UnsupportedOperationException(
+        "Transaction mode: [" + transactionMode + "] is not supported now");
+    }
+  }
+
+  private <T> void executeBatchUpdateInSameTransaction(
+    List<T> entities, Function<T, String> getId, Handler<AsyncResult<Void>> onFinishHandler) {
+
+    postgresClient.startTx(connectionResult -> {
+      if (connectionResult.failed()) {
+        LOG.warn("Can not start transaction", connectionResult.cause());
+        onFinishHandler.handle(Future.failedFuture(connectionResult.cause()));
+        return;
+      }
+
+      // Using this future for chaining updates
+      Future<UpdateResult> lastUpdate = Future.succeededFuture();
+      for (T entity : entities) {
+        String id = getId.apply(entity);
+        lastUpdate = lastUpdate
+          .compose(prev -> updateSingleEntity(connectionResult, id, entity));
+      }
+
+      // Handle overall update result and decide on whether to commit or rollback transaction
+      lastUpdate.setHandler(updateResult -> {
+        if (updateResult.failed()) {
+          LOG.warn("Batch update rejected", updateResult.cause());
+
+          // Rollback transaction and keep original cause.
+          postgresClient.rollbackTx(connectionResult,
+            rollback -> onFinishHandler.handle(Future.failedFuture(updateResult.cause()))
+          );
+        } else {
+          LOG.debug("Update successful, committing transaction");
+
+          postgresClient.endTx(connectionResult, onFinishHandler);
+        }
+      });
+    });
+  }
+
+  /**
+   * Executes an update for a single entity on given DB connection.
+   *
+   * @param connection - DB connection.
+   * @param id         - Entity ID to update.
+   * @param entity     - New entity state.
+   * @param <T>        - Entity type.
+   * @return Callback.
+   */
+  private <T> Future<UpdateResult> updateSingleEntity(
+    AsyncResult<SQLConnection> connection, String id, T entity) {
+
+    Future<UpdateResult> updateResultFuture = Future.future();
+
+    postgresClient.update(connection, tableName, entity, "jsonb",
+      String.format(WHERE_CLAUSE, id), false, updateResultFuture);
+
+    return updateResultFuture;
+  }
+}

--- a/src/main/java/org/folio/service/BatchResourceService.java
+++ b/src/main/java/org/folio/service/BatchResourceService.java
@@ -1,7 +1,5 @@
 package org.folio.service;
 
-import static org.folio.rest.jaxrs.model.RequestsBatch.TransactionMode;
-
 import java.util.List;
 import java.util.function.Function;
 
@@ -28,31 +26,16 @@ public class BatchResourceService {
   }
 
   /**
-   * Execute batch update.
+   * Execute batch update in a single transaction, subsequently.
    *
-   * @param transactionMode - Transaction mode for update:
-   *                        Same - use one transaction for all entities
    * @param entities        - Entities to update
    * @param getId           - Function to get ID from an entity.
    * @param onFinishHandler - Callback.
    * @param <T>             - Entity type.
-   * @throws UnsupportedOperationException if transaction mode is not supported.
    */
   public <T> void executeBatchUpdate(
-    TransactionMode transactionMode, List<T> entities, Function<T, String> getId,
+    List<T> entities, Function<T, String> getId,
     Handler<AsyncResult<Void>> onFinishHandler) {
-
-    // Currently only one mode supported
-    if (transactionMode == TransactionMode.SAME) {
-      executeBatchUpdateInSameTransaction(entities, getId, onFinishHandler);
-    } else {
-      throw new UnsupportedOperationException(
-        "Transaction mode: [" + transactionMode + "] is not supported now");
-    }
-  }
-
-  private <T> void executeBatchUpdateInSameTransaction(
-    List<T> entities, Function<T, String> getId, Handler<AsyncResult<Void>> onFinishHandler) {
 
     postgresClient.startTx(connectionResult -> {
       if (connectionResult.failed()) {

--- a/src/main/java/org/folio/service/request/RequestBatchResourceService.java
+++ b/src/main/java/org/folio/service/request/RequestBatchResourceService.java
@@ -61,7 +61,8 @@ public class RequestBatchResourceService {
     List<Request> requests, Handler<AsyncResult<Void>> onFinishHandler) {
 
     LOG.debug("Removing positions for all request to go through positions constraint");
-    List<Function<SQLConnection, Future<UpdateResult>>> allBatches = new ArrayList<>();
+    List<Function<SQLConnection, Future<UpdateResult>>> allDatabaseOperations =
+      new ArrayList<>();
 
     // Remove positions for the requests before updating them
     // in order to go through item position constraint.
@@ -71,14 +72,14 @@ public class RequestBatchResourceService {
     List<Function<SQLConnection, Future<UpdateResult>>> updateRequestsBatch =
       updateRequestsBatch(requests);
 
-    allBatches.add(removePositionBatch);
-    allBatches.addAll(updateRequestsBatch);
+    allDatabaseOperations.add(removePositionBatch);
+    allDatabaseOperations.addAll(updateRequestsBatch);
 
     LOG.info("Executing batch update, total records to update [{}] (including remove positions)",
-      allBatches.size()
+      allDatabaseOperations.size()
     );
 
-    batchResourceService.executeBatchUpdate(allBatches, onFinishHandler);
+    batchResourceService.executeBatchUpdate(allDatabaseOperations, onFinishHandler);
   }
 
   private Function<SQLConnection, Future<UpdateResult>> removePositionsForRequestsBatch(

--- a/src/main/java/org/folio/service/request/RequestBatchResourceService.java
+++ b/src/main/java/org/folio/service/request/RequestBatchResourceService.java
@@ -1,0 +1,91 @@
+package org.folio.service.request;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.folio.rest.jaxrs.model.Request;
+import org.folio.service.BatchResourceService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.rits.cloning.Cloner;
+
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Handler;
+
+public class RequestBatchResourceService {
+  private static final Logger LOG = LoggerFactory.getLogger(RequestBatchResourceService.class);
+
+  private final BatchResourceService batchResourceService;
+  private final Cloner cloner;
+
+
+  public RequestBatchResourceService(BatchResourceService batchResourceService) {
+    this.batchResourceService = batchResourceService;
+    this.cloner = new Cloner();
+  }
+
+  /**
+   * This method executes batch update for the request table.
+   * The batch package must include request copies with removed positions
+   * as a first part of transaction in order to pass 'itemId - position' constraint.
+   * <p>
+   * Example:
+   * Let's say we have following requests in the batch:
+   * 1. Request A.
+   * 2. Request B.
+   * 3. Request C.
+   * <p>
+   * Then actual batch package, that will be executed, is following:
+   * 1. Copy of Request A with position = null.
+   * 1. Copy of Request B with position = null.
+   * 1. Copy of Request C with position = null.
+   * 4. Request A.
+   * 5. Request B.
+   * 6. Request C.
+   *
+   * @param requests        - List of requests to execute in batch.
+   * @param onFinishHandler - Callback function.
+   */
+  public void executeRequestBatchUpdate(
+    List<Request> requests, Handler<AsyncResult<Void>> onFinishHandler) {
+
+    LOG.debug("Removing positions for all request to go through positions constraint");
+    // We have to include requests with positions removed to the batch package
+    // to go through itemId-position unique constraint.
+    List<Request> requestsWithRemovedPositions = removePositionsForRequests(requests);
+
+    List<Request> allRequestsToUpdate = new ArrayList<>(requestsWithRemovedPositions);
+    allRequestsToUpdate.addAll(requests);
+
+    LOG.info("Executing batch update, total records to update [{}] (including remove positions)",
+      allRequestsToUpdate.size()
+    );
+
+    batchResourceService.executeBatchUpdate(allRequestsToUpdate,
+      Request::getId, onFinishHandler);
+  }
+
+  private List<Request> removePositionsForRequests(List<Request> requests) {
+    List<Request> allRequests = new ArrayList<>();
+
+    for (Request request : requests) {
+      Request requestCopyWithNoPosition = cloneRequest(request)
+        .withPosition(null);
+
+      allRequests.add(requestCopyWithNoPosition);
+    }
+
+    return allRequests;
+  }
+
+  /**
+   * Makes a copy of a request object.
+   *
+   * @param requestToCopy - Request object to make a copy.
+   * @return Copy of a request object.
+   */
+  private Request cloneRequest(Request requestToCopy) {
+    return cloner.deepClone(requestToCopy);
+  }
+}

--- a/src/test/java/org/folio/rest/api/RequestBatchAPITest.java
+++ b/src/test/java/org/folio/rest/api/RequestBatchAPITest.java
@@ -1,0 +1,192 @@
+package org.folio.rest.api;
+
+import static org.folio.rest.api.RequestsApiTest.requestStorageUrl;
+import static org.folio.rest.api.StorageTestSuite.TENANT_ID;
+import static org.folio.rest.api.StorageTestSuite.storageUrl;
+import static org.folio.rest.support.ResponseHandler.empty;
+import static org.folio.rest.support.ResponseHandler.json;
+import static org.folio.rest.support.builders.RequestRequestBuilder.OPEN_AWAITING_PICKUP;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+
+import java.net.URL;
+import java.util.Arrays;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+
+import org.folio.rest.support.ApiTests;
+import org.folio.rest.support.JsonResponse;
+import org.folio.rest.support.Response;
+import org.folio.rest.support.builders.RequestRequestBuilder;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+
+public class RequestBatchAPITest extends ApiTests {
+
+  @Before
+  public void beforeEach() throws Exception {
+    StorageTestSuite.deleteAll(requestStorageUrl());
+  }
+
+  @After
+  public void checkIdsAfterEach() {
+    StorageTestSuite.checkForMismatchedIDs("request");
+  }
+
+  @Test
+  public void canUpdateRequestPositionsInBatch() throws Exception {
+    UUID itemId = UUID.randomUUID();
+
+    // 1st create some sample requests for an item
+    JsonObject firstRequest = createRequestForItemAtPosition(itemId, 1);
+    JsonObject secondRequest = createRequestForItemAtPosition(itemId, 2);
+
+    // 2nd: Swap positions for these requests
+    JsonObject firstRequestWithNoPosition = firstRequest.copy();
+    JsonObject secondRequestWithNoPosition = secondRequest.copy();
+
+    // 2.1 - release previous positions
+    secondRequestWithNoPosition.remove("position");
+    firstRequestWithNoPosition.remove("position");
+
+    // 2.2 - set new positions
+    firstRequest.put("position", 2);
+    secondRequest.put("position", 1);
+
+    CompletableFuture<Response> putCompleted = new CompletableFuture<>();
+    JsonObject allRequests = buildBatchUpdateRequest(firstRequestWithNoPosition,
+      secondRequestWithNoPosition, firstRequest, secondRequest);
+
+    client.put(batchRequestStorageUrl(), allRequests, TENANT_ID, empty(putCompleted));
+
+    Response response = putCompleted.get(5, TimeUnit.SECONDS);
+    assertThat(response.getStatusCode(), is(204));
+
+    // 3rd: Retrieve requests from DB and assert changes.
+    JsonObject requestsFromDb = getAllRequestsForItem(itemId);
+
+    JsonObject firstRequestFromDb = requestsFromDb.getJsonArray("requests").getJsonObject(0);
+    JsonObject secondRequestFromDb = requestsFromDb.getJsonArray("requests").getJsonObject(1);
+
+    assertThat(requestsFromDb.getInteger("totalRecords"), is(2));
+    assertThat(firstRequestFromDb, is(firstRequest));
+    assertThat(secondRequestFromDb, is(secondRequest));
+  }
+
+  @Test
+  public void canRollbackTransactionOnSamePositionConstraintViolation() throws Exception {
+    UUID itemId = UUID.randomUUID();
+
+    // 1st create some sample requests for an item
+    JsonObject firstRequest = createRequestForItemAtPosition(itemId, 1);
+    JsonObject secondRequest = createRequestForItemAtPosition(itemId, 2);
+
+    // 2nd: Specify same positions for the requests, so constraint violation happens
+    firstRequest.put("position", 1);
+    secondRequest.put("position", 1);
+
+    CompletableFuture<JsonResponse> putCompleted = new CompletableFuture<>();
+    client.put(batchRequestStorageUrl(),
+      buildBatchUpdateRequest(firstRequest, secondRequest),
+      TENANT_ID,
+      json(putCompleted)
+    );
+
+    JsonResponse response = putCompleted.get(5, TimeUnit.SECONDS);
+    assertThat(response.getStatusCode(), is(422));
+
+    JsonArray errors = response.getJson().getJsonArray("errors");
+    assertThat(errors.size(), is(1));
+    assertThat(errors.getJsonObject(0).getString("message"),
+      is("Cannot have more than one request with the same position in the queue"));
+
+    // 3rd: Retrieve requests from DB and assert that changes have not been applied.
+    JsonObject requestsFromDb = getAllRequestsForItem(itemId);
+
+    JsonObject firstRequestFromDb = requestsFromDb.getJsonArray("requests").getJsonObject(0);
+    JsonObject secondRequestFromDb = requestsFromDb.getJsonArray("requests").getJsonObject(1);
+
+    assertThat(requestsFromDb.getInteger("totalRecords"), is(2));
+    assertThat(firstRequestFromDb, is(firstRequest));
+    // 2nd RQ must have it's initial position - 2nd
+    assertThat(secondRequestFromDb, is(secondRequest.put("position", 2)));
+  }
+
+  @Test
+  public void canRollbackTransactionServerError() throws Exception {
+    UUID itemId = UUID.randomUUID();
+
+    // 1st create some sample requests for an item
+    JsonObject firstRequest = createRequestForItemAtPosition(itemId, 1);
+    JsonObject secondRequest = createRequestForItemAtPosition(itemId, 2);
+
+    // 2nd: Remove ID for the request, which causes an exception and transaction to be reverted
+    JsonObject firstRequestCopy = firstRequest.copy();
+
+    firstRequestCopy.remove("id");
+    secondRequest.put("position", 10);
+
+    CompletableFuture<Response> putCompleted = new CompletableFuture<>();
+    client.put(batchRequestStorageUrl(),
+      buildBatchUpdateRequest(firstRequestCopy, secondRequest),
+      TENANT_ID,
+      empty(putCompleted)
+    );
+
+    // Expect server error due to Exception
+    Response response = putCompleted.get(5, TimeUnit.SECONDS);
+    assertThat(response.getStatusCode(), is(500));
+
+    // 3rd: Retrieve requests from DB and assert that changes have not been applied.
+    JsonObject requestsFromDb = getAllRequestsForItem(itemId);
+
+    JsonObject firstRequestFromDb = requestsFromDb.getJsonArray("requests").getJsonObject(0);
+    JsonObject secondRequestFromDb = requestsFromDb.getJsonArray("requests").getJsonObject(1);
+
+    assertThat(requestsFromDb.getInteger("totalRecords"), is(2));
+    assertThat(firstRequestFromDb, is(firstRequest));
+    // 2nd RQ must have it's initial position - 2nd
+    assertThat(secondRequestFromDb, is(secondRequest.put("position", 2)));
+  }
+
+  private JsonObject getAllRequestsForItem(UUID itemId) throws Exception {
+    CompletableFuture<JsonResponse> getRequestsCompleted = new CompletableFuture<>();
+
+    client.get(requestStorageUrl() + String.format("?query=itemId==%s", itemId),
+      TENANT_ID, json(getRequestsCompleted));
+
+    return getRequestsCompleted.get(5, TimeUnit.SECONDS).getJson();
+  }
+
+  private JsonObject createRequestForItemAtPosition(UUID itemId, int position) throws Exception {
+    JsonObject request = createEntity(
+      new RequestRequestBuilder()
+        .withItemId(itemId)
+        .withPosition(position)
+        .recall()
+        .toHoldShelf()
+        .withStatus(OPEN_AWAITING_PICKUP)
+        .create(),
+      requestStorageUrl()
+    ).getJson();
+
+    assertThat(request.getString("itemId"), is(itemId.toString()));
+    assertThat(request.getInteger("position"), is(position));
+
+    return request;
+  }
+
+  private JsonObject buildBatchUpdateRequest(JsonObject... requestsToUpdate) {
+    return new JsonObject()
+      .put("requests", new JsonArray(Arrays.asList(requestsToUpdate)));
+  }
+
+  private URL batchRequestStorageUrl() throws Exception {
+    return storageUrl("/request-storage-batch/requests");
+  }
+}

--- a/src/test/java/org/folio/rest/api/RequestBatchAPITest.java
+++ b/src/test/java/org/folio/rest/api/RequestBatchAPITest.java
@@ -3,26 +3,30 @@ package org.folio.rest.api;
 import static org.folio.rest.api.RequestsApiTest.requestStorageUrl;
 import static org.folio.rest.api.StorageTestSuite.TENANT_ID;
 import static org.folio.rest.api.StorageTestSuite.storageUrl;
-import static org.folio.rest.support.ResponseHandler.empty;
-import static org.folio.rest.support.ResponseHandler.json;
-import static org.folio.rest.support.builders.RequestRequestBuilder.OPEN_AWAITING_PICKUP;
+import static org.hamcrest.CoreMatchers.hasItems;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 
 import java.net.URL;
 import java.util.Arrays;
+import java.util.Comparator;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
 
 import org.folio.rest.support.ApiTests;
 import org.folio.rest.support.JsonResponse;
 import org.folio.rest.support.Response;
+import org.folio.rest.support.ResponseHandler;
+import org.folio.rest.support.TextResponse;
 import org.folio.rest.support.builders.RequestRequestBuilder;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
+import io.vertx.core.Handler;
+import io.vertx.core.http.HttpClientResponse;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 
@@ -42,123 +46,83 @@ public class RequestBatchAPITest extends ApiTests {
   public void canUpdateRequestPositionsInBatch() throws Exception {
     UUID itemId = UUID.randomUUID();
 
-    // 1st create some sample requests for an item
     JsonObject firstRequest = createRequestForItemAtPosition(itemId, 1);
     JsonObject secondRequest = createRequestForItemAtPosition(itemId, 2);
 
-    // 2nd: Swap positions for these requests
-    JsonObject firstRequestWithNoPosition = firstRequest.copy();
-    JsonObject secondRequestWithNoPosition = secondRequest.copy();
+    ReorderRequest firstReorderRequest = new ReorderRequest(firstRequest, 2);
+    ReorderRequest secondReorderRequest = new ReorderRequest(secondRequest, 1);
 
-    // 2.1 - release previous positions
-    secondRequestWithNoPosition.remove("position");
-    firstRequestWithNoPosition.remove("position");
-
-    // 2.2 - set new positions
-    firstRequest.put("position", 2);
-    secondRequest.put("position", 1);
-
-    CompletableFuture<Response> putCompleted = new CompletableFuture<>();
-    JsonObject allRequests = buildBatchUpdateRequest(firstRequestWithNoPosition,
-      secondRequestWithNoPosition, firstRequest, secondRequest);
-
-    client.put(batchRequestStorageUrl(), allRequests, TENANT_ID, empty(putCompleted));
-
-    Response response = putCompleted.get(5, TimeUnit.SECONDS);
-    assertThat(response.getStatusCode(), is(204));
-
-    // 3rd: Retrieve requests from DB and assert changes.
-    JsonObject requestsFromDb = getAllRequestsForItem(itemId);
-
-    JsonObject firstRequestFromDb = requestsFromDb.getJsonArray("requests").getJsonObject(0);
-    JsonObject secondRequestFromDb = requestsFromDb.getJsonArray("requests").getJsonObject(1);
-
-    assertThat(requestsFromDb.getInteger("totalRecords"), is(2));
-    assertThat(firstRequestFromDb, is(firstRequest));
-    assertThat(secondRequestFromDb, is(secondRequest));
-  }
-
-  @Test
-  public void canRollbackTransactionOnSamePositionConstraintViolation() throws Exception {
-    UUID itemId = UUID.randomUUID();
-
-    // 1st create some sample requests for an item
-    JsonObject firstRequest = createRequestForItemAtPosition(itemId, 1);
-    JsonObject secondRequest = createRequestForItemAtPosition(itemId, 2);
-
-    // 2nd: Specify same positions for the requests, so constraint violation happens
-    firstRequest.put("position", 1);
-    secondRequest.put("position", 1);
-
-    CompletableFuture<JsonResponse> putCompleted = new CompletableFuture<>();
-    client.put(batchRequestStorageUrl(),
-      buildBatchUpdateRequest(firstRequest, secondRequest),
-      TENANT_ID,
-      json(putCompleted)
+    reorderRequests(
+      // We have to remove request positions before assigning new ones
+      // in order to get through 'item-position' unique constraint
+      new ReorderRequest(firstRequest, null),
+      new ReorderRequest(secondRequest, null),
+      // Then set the actual positions.
+      firstReorderRequest,
+      secondReorderRequest
     );
 
-    JsonResponse response = putCompleted.get(5, TimeUnit.SECONDS);
-    assertThat(response.getStatusCode(), is(422));
-
-    JsonArray errors = response.getJson().getJsonArray("errors");
-    assertThat(errors.size(), is(1));
-    assertThat(errors.getJsonObject(0).getString("message"),
-      is("Cannot have more than one request with the same position in the queue"));
-
-    // 3rd: Retrieve requests from DB and assert that changes have not been applied.
-    JsonObject requestsFromDb = getAllRequestsForItem(itemId);
-
-    JsonObject firstRequestFromDb = requestsFromDb.getJsonArray("requests").getJsonObject(0);
-    JsonObject secondRequestFromDb = requestsFromDb.getJsonArray("requests").getJsonObject(1);
-
-    assertThat(requestsFromDb.getInteger("totalRecords"), is(2));
-    assertThat(firstRequestFromDb, is(firstRequest));
-    // 2nd RQ must have it's initial position - 2nd
-    assertThat(secondRequestFromDb, is(secondRequest.put("position", 2)));
+    assertRequestsUpdated(itemId, firstReorderRequest, secondReorderRequest);
   }
 
   @Test
-  public void canRollbackTransactionServerError() throws Exception {
+  public void willAbortBatchUpdateForRequestsAtTheSamePositionInAnItemsQueue() throws Exception {
+    UUID itemId = UUID.randomUUID();
+
+    JsonObject firstRequest = createRequestForItemAtPosition(itemId, 1);
+    JsonObject secondRequest = createRequestForItemAtPosition(itemId, 2);
+
+    JsonResponse reorderResponse = attemptReorderRequests(ResponseHandler::json,
+      new ReorderRequest(firstRequest, 1),
+      new ReorderRequest(secondRequest, 1)
+    );
+
+    assertPositionConstraintViolationError(reorderResponse);
+
+    assertRequestsNotUpdated(itemId, firstRequest, secondRequest);
+  }
+
+  @Test
+  public void willAbortBatchUpdateWhenOnlyOnePositionIsModified() throws Exception {
     UUID itemId = UUID.randomUUID();
 
     // 1st create some sample requests for an item
     JsonObject firstRequest = createRequestForItemAtPosition(itemId, 1);
     JsonObject secondRequest = createRequestForItemAtPosition(itemId, 2);
 
-    // 2nd: Remove ID for the request, which causes an exception and transaction to be reverted
+    JsonResponse reorderResponse = attemptReorderRequests(ResponseHandler::json,
+      new ReorderRequest(firstRequest, 2)
+    );
+
+    assertPositionConstraintViolationError(reorderResponse);
+
+    assertRequestsNotUpdated(itemId, firstRequest, secondRequest);
+  }
+
+  @Test
+  public void willAbortBatchUpdateOnNullPointerExceptionDueToNoIdInRequest() throws Exception {
+    UUID itemId = UUID.randomUUID();
+
+    JsonObject firstRequest = createRequestForItemAtPosition(itemId, 1);
+    JsonObject secondRequest = createRequestForItemAtPosition(itemId, 2);
+
     JsonObject firstRequestCopy = firstRequest.copy();
-
     firstRequestCopy.remove("id");
-    secondRequest.put("position", 10);
 
-    CompletableFuture<Response> putCompleted = new CompletableFuture<>();
-    client.put(batchRequestStorageUrl(),
-      buildBatchUpdateRequest(firstRequestCopy, secondRequest),
-      TENANT_ID,
-      empty(putCompleted)
+    TextResponse reorderResponse = attemptReorderRequests(ResponseHandler::text,
+      new ReorderRequest(firstRequestCopy, 3),
+      new ReorderRequest(secondRequest, 10)
     );
+    assertThat(reorderResponse.getStatusCode(), is(500));
 
-    // Expect server error due to Exception
-    Response response = putCompleted.get(5, TimeUnit.SECONDS);
-    assertThat(response.getStatusCode(), is(500));
-
-    // 3rd: Retrieve requests from DB and assert that changes have not been applied.
-    JsonObject requestsFromDb = getAllRequestsForItem(itemId);
-
-    JsonObject firstRequestFromDb = requestsFromDb.getJsonArray("requests").getJsonObject(0);
-    JsonObject secondRequestFromDb = requestsFromDb.getJsonArray("requests").getJsonObject(1);
-
-    assertThat(requestsFromDb.getInteger("totalRecords"), is(2));
-    assertThat(firstRequestFromDb, is(firstRequest));
-    // 2nd RQ must have it's initial position - 2nd
-    assertThat(secondRequestFromDb, is(secondRequest.put("position", 2)));
+    assertRequestsNotUpdated(itemId, firstRequest, secondRequest);
   }
 
   private JsonObject getAllRequestsForItem(UUID itemId) throws Exception {
     CompletableFuture<JsonResponse> getRequestsCompleted = new CompletableFuture<>();
 
     client.get(requestStorageUrl() + String.format("?query=itemId==%s", itemId),
-      TENANT_ID, json(getRequestsCompleted));
+      TENANT_ID, ResponseHandler.json(getRequestsCompleted));
 
     return getRequestsCompleted.get(5, TimeUnit.SECONDS).getJson();
   }
@@ -170,7 +134,7 @@ public class RequestBatchAPITest extends ApiTests {
         .withPosition(position)
         .recall()
         .toHoldShelf()
-        .withStatus(OPEN_AWAITING_PICKUP)
+        .withStatus(RequestRequestBuilder.OPEN_AWAITING_PICKUP)
         .create(),
       requestStorageUrl()
     ).getJson();
@@ -188,5 +152,83 @@ public class RequestBatchAPITest extends ApiTests {
 
   private URL batchRequestStorageUrl() throws Exception {
     return storageUrl("/request-storage-batch/requests");
+  }
+
+  private <T> T attemptReorderRequests(
+    Function<CompletableFuture<T>, Handler<HttpClientResponse>> bodyHandler,
+    ReorderRequest... requests) throws Exception {
+
+    JsonObject[] requestsToReorder = Arrays.stream(requests)
+      .map(reorderRequest -> {
+        JsonObject requestCopy = reorderRequest.request.copy();
+        return requestCopy.put("position", reorderRequest.newPosition);
+      })
+      .toArray(JsonObject[]::new);
+
+    CompletableFuture<T> postCompleted = new CompletableFuture<>();
+    client.post(batchRequestStorageUrl(),
+      buildBatchUpdateRequest(requestsToReorder),
+      TENANT_ID,
+      bodyHandler.apply(postCompleted)
+    );
+
+    return postCompleted.get(5, TimeUnit.SECONDS);
+  }
+
+  private void reorderRequests(ReorderRequest... requests) throws Exception {
+    Response response = attemptReorderRequests(ResponseHandler::empty, requests);
+
+    assertThat(response.getStatusCode(), is(201));
+  }
+
+  private void assertRequestsUpdated(UUID itemId, ReorderRequest... requests) throws Exception {
+    JsonObject requestsForItemReply = getAllRequestsForItem(itemId);
+
+    assertThat(requestsForItemReply.size(), is(requests.length));
+    assertThat(requestsForItemReply.getInteger("totalRecords"), is(requests.length));
+
+    JsonObject[] sortedExpectedRequests = Arrays.stream(requests)
+      .sorted(Comparator.comparingInt(rr -> rr.newPosition))
+      .map(rr -> rr.request.copy().put("position", rr.newPosition))
+      .toArray(JsonObject[]::new);
+    JsonArray requestsFromDb = requestsForItemReply.getJsonArray("requests");
+
+    assertThat(requestsFromDb, hasItems(sortedExpectedRequests));
+  }
+
+  private void assertRequestsNotUpdated(UUID itemId, JsonObject... requests) throws Exception {
+    JsonObject requestsForItemReply = getAllRequestsForItem(itemId);
+
+    assertThat(requestsForItemReply.size(), is(requests.length));
+    assertThat(requestsForItemReply.getInteger("totalRecords"), is(requests.length));
+
+    JsonObject[] sortedExpectedRequests = Arrays.stream(requests)
+      .sorted(Comparator.comparingInt(rr -> rr.getInteger("position")))
+      .toArray(JsonObject[]::new);
+    JsonArray requestsFromDb = requestsForItemReply.getJsonArray("requests");
+
+    assertThat(requestsFromDb, hasItems(sortedExpectedRequests));
+  }
+
+  private void assertPositionConstraintViolationError(JsonResponse response) {
+    assertThat(response.getStatusCode(), is(422));
+
+    JsonArray errors = response.getJson().getJsonArray("errors");
+    assertThat(errors.size(), is(1));
+    assertThat(errors.getJsonObject(0).getString("message"),
+      is("Cannot have more than one request with the same position in the queue"));
+  }
+
+  /**
+   * Holder for request reorder operation. Holds request and new position for it.
+   */
+  private static class ReorderRequest {
+    private final JsonObject request;
+    private final Integer newPosition;
+
+    ReorderRequest(JsonObject request, Integer newPosition) {
+      this.request = request;
+      this.newPosition = newPosition;
+    }
   }
 }

--- a/src/test/java/org/folio/rest/api/StorageTestSuite.java
+++ b/src/test/java/org/folio/rest/api/StorageTestSuite.java
@@ -55,7 +55,8 @@ import io.vertx.ext.sql.ResultSet;
   RequestPoliciesApiTest.class,
   RequestExpirationApiTest.class,
   ScheduledNoticesAPITest.class,
-  PatronActionSessionAPITest.class
+  PatronActionSessionAPITest.class,
+  RequestBatchAPITest.class
 })
 
 public class StorageTestSuite {


### PR DESCRIPTION
https://issues.folio.org/browse/CIRCSTORE-164: Create new request batch update endpoint.

### Approach:

Implemented `POST` `/request-storage-batch/requests` endpoint that allows to execute request updates **sequentially** within the **same transaction**. Any failures occurred during update will cause transaction to be rejected.

### Sample request to swap positions for two requests:
```
{
    "requests": [
        {
            "id" : "rq1 id",
            // position attribute removed
            ...
        },
        {
            "id" : "rq2 id",
            // position attribute removed
            ...
        },
        {
            "id" : "rq1 id",
            "position": 2
            ...
        },
        {
            "id" : "rq2 id",
            "position": 1
            ...
        }
    ],
    // Not required here, as 'Same' is default value
    "transactionMode": "Same"
}
```