### PR TITLE
CIRCSTORE-171: Create default lost item fees policy.

### DIFF
--- a/reference-data/circulation-rules-storage/single-rule.json
+++ b/reference-data/circulation-rules-storage/single-rule.json
@@ -1,3 +1,3 @@
 {
-  "rulesAsText": "priority: t, s, c, b, a, m, g\nfallback-policy: l d9cd0bed-1b49-4b5e-a7bd-064b8d177231 r 334e5a9e-94f9-4673-8d1d-ab552863886b n 122b3d2b-4788-4f1e-9117-56daa91cb75c o fallback-overdue-fine-policy \nm 1a54b431-2e4f-452d-9cae-9cee66c9a892: l 43198de5-f56a-4a53-a0bd-5a324418967a r 334e5a9e-94f9-4673-8d1d-ab552863886b n 122b3d2b-4788-4f1e-9117-56daa91cb75c o overdue-fine-policy"
+  "rulesAsText": "priority: t, s, c, b, a, m, g\nfallback-policy: l d9cd0bed-1b49-4b5e-a7bd-064b8d177231 r 334e5a9e-94f9-4673-8d1d-ab552863886b n 122b3d2b-4788-4f1e-9117-56daa91cb75c o fallback-overdue-fine-policy i fallback-lost-item-fee-policy \nm 1a54b431-2e4f-452d-9cae-9cee66c9a892: l 43198de5-f56a-4a53-a0bd-5a324418967a r 334e5a9e-94f9-4673-8d1d-ab552863886b n 122b3d2b-4788-4f1e-9117-56daa91cb75c o overdue-fine-policy i lost-item-fee-policy"
 }


### PR DESCRIPTION
New default lost item fee policies added to the 'single-rule.json' file.

**This change should be merged with CIRC-467** (PR:https://github.com/folio-org/mod-circulation/pull/399)

This PR is similar to the previous PR regarding adding a new default overdue fine policy 'o', which was reviewed and merged: https://github.com/folio-org/mod-circulation-storage/pull/215