### PR TITLE
CIRC-598: Fix loan.userId fullTextIndex

### DIFF
--- a/src/main/resources/templates/db_scripts/schema.json
+++ b/src/main/resources/templates/db_scripts/schema.json
@@ -5,7 +5,7 @@
   "scripts": [
     {
       "run": "before",
-      "fromModuleVersion": "10.0.1",
+      "fromModuleVersion": "10.1.0",
       "snippet": "DROP INDEX IF EXISTS loan_userid_idx_ft;"
     }
   ],

--- a/src/main/resources/templates/db_scripts/schema.json
+++ b/src/main/resources/templates/db_scripts/schema.json
@@ -1,4 +1,14 @@
 {
+  "fullText": {
+    "defaultDictionary": "simple"
+  },
+  "scripts": [
+    {
+      "run": "before",
+      "fromModuleVersion": "10.0.1",
+      "snippet": "DROP INDEX IF EXISTS loan_userid_idx_ft;"
+    }
+  ],
   "tables": [
     {
       "tableName": "loan",


### PR DESCRIPTION
Change dictionary from english to simple.

The upgrade script drops the old index with 'english' dictionary.
RMB only (re-)creates the index with the correct 'simple' dictionary if
an index with that name does not exist.