### PR TITLE
CIRCSTORE-184: Add several loan indexes.

### DIFF
--- a/src/main/resources/templates/db_scripts/schema.json
+++ b/src/main/resources/templates/db_scripts/schema.json
@@ -12,6 +12,7 @@
   "tables": [
     {
       "tableName": "loan",
+      "fromModuleVersion": "10.1.0",
       "withMetadata": true,
       "withAuditing": true,
       "auditingTableName": "audit_loan",

--- a/src/main/resources/templates/db_scripts/schema.json
+++ b/src/main/resources/templates/db_scripts/schema.json
@@ -56,6 +56,36 @@
           "tOps": "ADD",
           "caseSensitive": true,
           "removeAccents": false
+        },
+        {
+          "fieldName": "checkinServicePointId",
+          "tOps": "ADD",
+          "caseSensitive": false,
+          "removeAccents": false
+        },
+        {
+          "fieldName": "checkoutServicePointId",
+          "tOps": "ADD",
+          "caseSensitive": false,
+          "removeAccents": false
+        },
+        {
+          "fieldName": "metadata.createdByUsername",
+          "tOps": "ADD",
+          "caseSensitive": false,
+          "removeAccents": true
+        },
+        {
+          "fieldName": "dueDate",
+          "tOps": "ADD",
+          "caseSensitive": false,
+          "removeAccents": false
+        },
+        {
+          "fieldName": "loanDate",
+          "tOps": "ADD",
+          "caseSensitive": false,
+          "removeAccents": false
         }
       ],
       "fullTextIndex": [


### PR DESCRIPTION
BNCF needs them for open loans queries:
https://folio-project.slack.com/archives/C9BBWRCNB/p1579860339261200

"caseSensitive" and "removeAccents" for username are taken from the definition in mod-users:
https://github.com/folio-org/mod-users/blob/v16.0.0/src/main/resources/templates/db_scripts/schema.json#L80

All other indexes are UUIDs or dates that are case insensitive and do not require accent removal.