### PR TITLE
CIRCSTORE-181: Store instance identifiers in request.

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -4,7 +4,7 @@
   "provides": [
     {
       "id": "request-storage-batch",
-      "version": "0.2",
+      "version": "0.3",
       "handlers": [
         {
           "methods": ["POST"],
@@ -111,7 +111,7 @@
     },
     {
       "id": "request-storage",
-      "version": "3.2",
+      "version": "3.3",
       "handlers": [
         {
           "methods": ["GET"],

--- a/ramls/request-storage-batch.raml
+++ b/ramls/request-storage-batch.raml
@@ -1,6 +1,6 @@
 #%RAML 1.0
 title: Request Storage Batch
-version: v0.2
+version: v0.3
 protocols: [ HTTP, HTTPS ]
 baseUri: http://localhost:9130
 

--- a/ramls/request-storage.raml
+++ b/ramls/request-storage.raml
@@ -1,6 +1,6 @@
 #%RAML 1.0
 title: Request Storage
-version: v3.2
+version: v3.3
 protocols: [ HTTP, HTTPS ]
 baseUri: http://localhost:9130
 

--- a/ramls/request.json
+++ b/ramls/request.json
@@ -94,7 +94,7 @@
               "identifierTypeId": {
                 "type": "string",
                 "description": "UUID of resource identifier type (e.g. ISBN, ISSN, LCCN, CODEN, Locally defined identifiers)",
-                "$ref": "uuid.json"
+                "$ref": "raml-util/schemas/uuid.schema"
               }
             },
             "additionalProperties": false,

--- a/ramls/request.json
+++ b/ramls/request.json
@@ -79,6 +79,30 @@
         "barcode": {
           "description": "barcode of the item",
           "type": "string"
+        },
+        "identifiers": {
+          "type": "array",
+          "description": "An extensible set of name-value pairs of identifiers associated with the resource",
+          "minItems": 0,
+          "items": {
+            "type": "object",
+            "properties": {
+              "value": {
+                "type": "string",
+                "description": "Resource identifier value"
+              },
+              "identifierTypeId": {
+                "type": "string",
+                "description": "UUID of resource identifier type (e.g. ISBN, ISSN, LCCN, CODEN, Locally defined identifiers)",
+                "$ref": "uuid.json"
+              }
+            },
+            "additionalProperties": false,
+            "required": [
+              "value",
+              "identifierTypeId"
+            ]
+          }
         }
       },
       "additionalProperties": false

--- a/ramls/uuid.json
+++ b/ramls/uuid.json
@@ -1,0 +1,5 @@
+{
+  "description": "A universally unique identifier (UUID), this is a 128-bit number used to identify a record and is shown in hex with dashes, for example 6312d172-f0cf-40f6-b27d-9fa8feaf332f; the UUID version must be from 1-5; see https://dev.folio.org/guides/uuids/",
+  "type": "string",
+  "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$"
+}

--- a/ramls/uuid.json
+++ b/ramls/uuid.json
@@ -1,5 +1,0 @@
-{
-  "description": "A universally unique identifier (UUID), this is a 128-bit number used to identify a record and is shown in hex with dashes, for example 6312d172-f0cf-40f6-b27d-9fa8feaf332f; the UUID version must be from 1-5; see https://dev.folio.org/guides/uuids/",
-  "type": "string",
-  "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$"
-}

--- a/src/main/resources/templates/db_scripts/schema.json
+++ b/src/main/resources/templates/db_scripts/schema.json
@@ -83,7 +83,6 @@
       "tableName": "request",
       "withMetadata": true,
       "withAuditing": false,
-      "fromModuleVersion": "10.1.0",
       "foreignKeys": [
         {
           "fieldName": "cancellationReasonId",
@@ -115,37 +114,6 @@
           "tOps": "ADD",
           "caseSensitive": false,
           "removeAccents": true
-        },
-        {
-          "fieldName": "item.identifiers",
-          "tOps": "ADD",
-          "caseSensitive": false,
-          "removeAccents": true
-        },
-        {
-          "fieldName": "requesterId",
-          "tOps": "ADD",
-          "caseSensitive": false,
-          "removeAccents": true
-        }
-      ],
-      "fullTextIndex": [
-        {
-          "fieldName": "item.identifiers",
-          "arraySubfield" : "value",
-          "arrayModifiers": ["identifierTypeId"]
-        },
-        {
-          "fieldName": "item.barcode",
-          "tOps": "ADD"
-        },
-        {
-          "fieldName": "item.title",
-          "tOps": "ADD"
-        },
-        {
-          "fieldName": "requester.barcode",
-          "tOps": "ADD"
         }
       ],
       "customSnippetPath": "requestUpdateTrigger.sql"

--- a/src/main/resources/templates/db_scripts/schema.json
+++ b/src/main/resources/templates/db_scripts/schema.json
@@ -83,6 +83,7 @@
       "tableName": "request",
       "withMetadata": true,
       "withAuditing": false,
+      "fromModuleVersion": "10.1.0",
       "foreignKeys": [
         {
           "fieldName": "cancellationReasonId",
@@ -114,6 +115,37 @@
           "tOps": "ADD",
           "caseSensitive": false,
           "removeAccents": true
+        },
+        {
+          "fieldName": "item.identifiers",
+          "tOps": "ADD",
+          "caseSensitive": false,
+          "removeAccents": true
+        },
+        {
+          "fieldName": "requesterId",
+          "tOps": "ADD",
+          "caseSensitive": false,
+          "removeAccents": true
+        }
+      ],
+      "fullTextIndex": [
+        {
+          "fieldName": "item.identifiers",
+          "arraySubfield" : "value",
+          "arrayModifiers": ["identifierTypeId"]
+        },
+        {
+          "fieldName": "item.barcode",
+          "tOps": "ADD"
+        },
+        {
+          "fieldName": "item.title",
+          "tOps": "ADD"
+        },
+        {
+          "fieldName": "requester.barcode",
+          "tOps": "ADD"
         }
       ],
       "customSnippetPath": "requestUpdateTrigger.sql"

--- a/src/test/java/org/folio/rest/api/RequestsApiTest.java
+++ b/src/test/java/org/folio/rest/api/RequestsApiTest.java
@@ -101,11 +101,11 @@ public class RequestsApiTest extends ApiTests {
     DateTime holdShelfExpirationDate = new DateTime(2017, 8, 31, 0, 0, DateTimeZone.UTC);
 
     UUID isbnIdentifierId = UUID.randomUUID();
-    UUID bnbIdentifierId = UUID.randomUUID();
+    UUID issnIdentifierId = UUID.randomUUID();
 
     final ItemSummary nod = new ItemSummary("Nod", "565578437802")
       .addIdentifier(isbnIdentifierId, "978-92-8011-566-9")
-      .addIdentifier(bnbIdentifierId, "2193988");
+      .addIdentifier(issnIdentifierId, "2193988");
 
     JsonObject representation = createEntity(
       new RequestRequestBuilder()
@@ -155,7 +155,7 @@ public class RequestsApiTest extends ApiTests {
     assertThat(identifiers.getJsonObject(0).getString("value"),
       is("978-92-8011-566-9"));
     assertThat(identifiers.getJsonObject(1).getString("identifierTypeId"),
-      is(bnbIdentifierId.toString()));
+      is(issnIdentifierId.toString()));
     assertThat(identifiers.getJsonObject(1).getString("value"), is("2193988"));
 
     assertThat(representation.containsKey("requester"), is(true));

--- a/src/test/java/org/folio/rest/api/RequestsApiTest.java
+++ b/src/test/java/org/folio/rest/api/RequestsApiTest.java
@@ -1707,7 +1707,7 @@ public class RequestsApiTest extends ApiTests {
       requestStorageUrl());
 
     List<JsonObject> isbnRequests = findRequestsByQuery(
-      "item.identifiers = /@identifierTypeId=%s %s", isbnIdentifierId, isbn);
+      "item.identifiers = %s and item.identifiers = %s", isbnIdentifierId, isbn);
 
     assertThat(isbnRequests.size(), is(2));
     assertThat(isbnRequests.get(0).getString("id"), is(nodRequestId.toString()));

--- a/src/test/java/org/folio/rest/api/RequestsApiTest.java
+++ b/src/test/java/org/folio/rest/api/RequestsApiTest.java
@@ -2,14 +2,6 @@ package org.folio.rest.api;
 
 import static java.net.HttpURLConnection.HTTP_CREATED;
 import static java.util.Arrays.asList;
-import static org.hamcrest.CoreMatchers.containsString;
-import static org.hamcrest.CoreMatchers.not;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.collection.IsIterableContainingInOrder.contains;
-import static org.hamcrest.core.Is.is;
-import static org.hamcrest.core.IsNull.notNullValue;
-import static org.hamcrest.core.IsNull.nullValue;
-
 import static org.folio.rest.api.StorageTestSuite.TENANT_ID;
 import static org.folio.rest.support.builders.RequestRequestBuilder.CLOSED_CANCELLED;
 import static org.folio.rest.support.builders.RequestRequestBuilder.CLOSED_FILLED;
@@ -19,11 +11,17 @@ import static org.folio.rest.support.builders.RequestRequestBuilder.OPEN_AWAITIN
 import static org.folio.rest.support.builders.RequestRequestBuilder.OPEN_AWAITING_PICKUP;
 import static org.folio.rest.support.builders.RequestRequestBuilder.OPEN_IN_TRANSIT;
 import static org.folio.rest.support.builders.RequestRequestBuilder.OPEN_NOT_YET_FILLED;
-import static org.folio.rest.support.builders.RequestRequestBuilder.ItemSummary;
 import static org.folio.rest.support.matchers.TextDateTimeMatcher.equivalentTo;
 import static org.folio.rest.support.matchers.TextDateTimeMatcher.withinSecondsAfter;
 import static org.folio.rest.support.matchers.ValidationErrorMatchers.hasMessage;
 import static org.folio.rest.support.matchers.ValidationResponseMatchers.isValidationResponseWhich;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.collection.IsIterableContainingInOrder.contains;
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsNull.notNullValue;
+import static org.hamcrest.core.IsNull.nullValue;
 
 import java.io.UnsupportedEncodingException;
 import java.net.HttpURLConnection;
@@ -38,11 +36,16 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.stream.Collectors;
 
-import io.vertx.core.json.JsonArray;
-import io.vertx.core.json.JsonObject;
-import junitparams.JUnitParamsRunner;
-import junitparams.Parameters;
-
+import org.folio.rest.jaxrs.model.Tags;
+import org.folio.rest.support.ApiTests;
+import org.folio.rest.support.IndividualResource;
+import org.folio.rest.support.JsonArrayHelper;
+import org.folio.rest.support.JsonResponse;
+import org.folio.rest.support.Response;
+import org.folio.rest.support.ResponseHandler;
+import org.folio.rest.support.TextResponse;
+import org.folio.rest.support.builders.RequestItemSummary;
+import org.folio.rest.support.builders.RequestRequestBuilder;
 import org.folio.util.StringUtil;
 import org.hamcrest.junit.MatcherAssert;
 import org.joda.time.DateTime;
@@ -54,15 +57,10 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import org.folio.rest.jaxrs.model.Tags;
-import org.folio.rest.support.ApiTests;
-import org.folio.rest.support.IndividualResource;
-import org.folio.rest.support.JsonArrayHelper;
-import org.folio.rest.support.JsonResponse;
-import org.folio.rest.support.Response;
-import org.folio.rest.support.ResponseHandler;
-import org.folio.rest.support.TextResponse;
-import org.folio.rest.support.builders.RequestRequestBuilder;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import junitparams.JUnitParamsRunner;
+import junitparams.Parameters;
 
 @RunWith(JUnitParamsRunner.class)
 public class RequestsApiTest extends ApiTests {
@@ -103,7 +101,7 @@ public class RequestsApiTest extends ApiTests {
     UUID isbnIdentifierId = UUID.randomUUID();
     UUID issnIdentifierId = UUID.randomUUID();
 
-    final ItemSummary nod = new ItemSummary("Nod", "565578437802")
+    final RequestItemSummary nod = new RequestItemSummary("Nod", "565578437802")
       .addIdentifier(isbnIdentifierId, "978-92-8011-566-9")
       .addIdentifier(issnIdentifierId, "2193988");
 
@@ -1670,18 +1668,19 @@ public class RequestsApiTest extends ApiTests {
     final UUID smallAngryPlanetRequestId = UUID.randomUUID();
     final UUID issnIdentifierId = UUID.randomUUID();
     final UUID isbnIdentifierId = UUID.randomUUID();
+    final UUID bnbIdentifierId = UUID.randomUUID();
     final String isbn = "978-92-8011-566-10";
 
-    final ItemSummary nod = new ItemSummary("Nod", "565578437802")
+    final RequestItemSummary nod = new RequestItemSummary("Nod", "565578437802")
       .addIdentifier(issnIdentifierId, "978-92-8011-566-9")
-      .addIdentifier(UUID.randomUUID(), "2193988")
+      .addIdentifier(bnbIdentifierId, "2193988")
       .addIdentifier(isbnIdentifierId, isbn);
 
-    final ItemSummary smallAngryPlanet = new ItemSummary("SAP", "565578437803")
+    final RequestItemSummary smallAngryPlanet = new RequestItemSummary("SAP", "565578437803")
       .addIdentifier(isbnIdentifierId, isbn)
-      .addIdentifier(UUID.randomUUID(), "2193989");
+      .addIdentifier(bnbIdentifierId, "2193989");
 
-    final ItemSummary temeraire = new ItemSummary("Temeraire", "565578437804");
+    final RequestItemSummary temeraire = new RequestItemSummary("Temeraire", "565578437804");
 
     createEntity(new RequestRequestBuilder()
         .withId(nodRequestId)

--- a/src/test/java/org/folio/rest/support/builders/RequestItemSummary.java
+++ b/src/test/java/org/folio/rest/support/builders/RequestItemSummary.java
@@ -30,7 +30,6 @@ public class RequestItemSummary {
     return new RequestItemSummary(
       this.title,
       this.barcode,
-      copiedIdentifiers
-    );
+      copiedIdentifiers);
   }
 }

--- a/src/test/java/org/folio/rest/support/builders/RequestItemSummary.java
+++ b/src/test/java/org/folio/rest/support/builders/RequestItemSummary.java
@@ -1,0 +1,36 @@
+package org.folio.rest.support.builders;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+
+import org.apache.commons.lang3.tuple.ImmutablePair;
+import org.apache.commons.lang3.tuple.Pair;
+
+public class RequestItemSummary {
+  final String title;
+  final String barcode;
+  final List<Pair<UUID, String>> identifiers;
+
+  public RequestItemSummary(String title, String barcode) {
+    this(title, barcode, Collections.emptyList());
+  }
+
+  private RequestItemSummary(String title, String barcode, List<Pair<UUID, String>> identifiers) {
+    this.title = title;
+    this.barcode = barcode;
+    this.identifiers = new ArrayList<>(identifiers);
+  }
+
+  public RequestItemSummary addIdentifier(UUID identifierId, String value) {
+    final List<Pair<UUID, String>> copiedIdentifiers = new ArrayList<>(identifiers);
+    copiedIdentifiers.add(new ImmutablePair<>(identifierId, value));
+
+    return new RequestItemSummary(
+      this.title,
+      this.barcode,
+      copiedIdentifiers
+    );
+  }
+}

--- a/src/test/java/org/folio/rest/support/builders/RequestRequestBuilder.java
+++ b/src/test/java/org/folio/rest/support/builders/RequestRequestBuilder.java
@@ -1,16 +1,11 @@
 package org.folio.rest.support.builders;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 
-import org.apache.commons.lang3.tuple.ImmutablePair;
-import org.apache.commons.lang3.tuple.Pair;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 
@@ -36,7 +31,7 @@ public class RequestRequestBuilder extends JsonBuilder {
   private final UUID deliveryAddressTypeId;
   private final DateTime requestExpirationDate;
   private final DateTime holdShelfExpirationDate;
-  private final ItemSummary itemSummary;
+  private final RequestItemSummary itemSummary;
   private final PatronSummary requesterSummary;
   private final PatronSummary proxySummary;
   private final String status;
@@ -83,7 +78,7 @@ public class RequestRequestBuilder extends JsonBuilder {
     UUID deliveryAddressTypeId,
     DateTime requestExpirationDate,
     DateTime holdShelfExpirationDate,
-    ItemSummary itemSummary,
+    RequestItemSummary itemSummary,
     PatronSummary requesterSummary,
     PatronSummary proxySummary,
     String status,
@@ -433,10 +428,10 @@ public class RequestRequestBuilder extends JsonBuilder {
   }
 
   public RequestRequestBuilder withItem(String title, String barcode) {
-    return withItem(new ItemSummary(title, barcode));
+    return withItem(new RequestItemSummary(title, barcode));
   }
 
-  public RequestRequestBuilder withItem(ItemSummary item) {
+  public RequestRequestBuilder withItem(RequestItemSummary item) {
     return new RequestRequestBuilder(
       this.id,
       this.requestType,
@@ -801,33 +796,6 @@ public class RequestRequestBuilder extends JsonBuilder {
       this.position,
       this.pickupServicePointId,
       tags);
-  }
-
-  public static class ItemSummary {
-    final String title;
-    final String barcode;
-    final List<Pair<UUID, String>> identifiers;
-
-    public ItemSummary(String title, String barcode) {
-      this(title, barcode, Collections.emptyList());
-    }
-
-    private ItemSummary(String title, String barcode, List<Pair<UUID, String>> identifiers) {
-      this.title = title;
-      this.barcode = barcode;
-      this.identifiers = new ArrayList<>(identifiers);
-    }
-
-    public ItemSummary addIdentifier(UUID identifierId, String value) {
-      final List<Pair<UUID, String>> copiedIdentifiers = new ArrayList<>(identifiers);
-      copiedIdentifiers.add(new ImmutablePair<>(identifierId, value));
-
-      return new ItemSummary(
-        this.title,
-        this.barcode,
-        copiedIdentifiers
-      );
-    }
   }
 
   private class PatronSummary {


### PR DESCRIPTION
https://issues.folio.org/browse/CIRCSTORE-181: Backend: Search for requests by instance ISBN (or other Identifiers).

* Add `item.identifiers` array;
* Add full text indexes for the new property;
* Add missed indexes for request search box. The query is following:
`((requesterId=="900" or requester.barcode="900*" or item.title="900*" or item.barcode="900*" or itemId=="900")) sortby requestDate`, so need indexes for:
  * requesterId
  * requester.barcode
  * item.title
  * item.barcode
  * itemId


