### PR TITLE
CIRCSTORE-183: Upgrade RMB from 26.2.3 to 29.2.x

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
     <dependency>
       <groupId>org.folio</groupId>
       <artifactId>domain-models-runtime</artifactId>
-      <version>26.2.3</version>
+      <version>${raml-module-builder-version}</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>
@@ -53,6 +53,12 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>io.vertx</groupId>
+      <artifactId>vertx-web-client</artifactId>
+      <version>${vertx-version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.glassfish.web</groupId>
       <artifactId>javax.el</artifactId>
       <version>2.2.4</version>
@@ -63,6 +69,8 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <ramlfiles_path>${basedir}/ramls</ramlfiles_path>
+    <raml-module-builder-version>29.2.2</raml-module-builder-version>
+    <vertx-version>3.8.4</vertx-version>
     <argLine />
   </properties>
 
@@ -165,7 +173,7 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>aspectj-maven-plugin</artifactId>
-        <version>1.9</version>
+        <version>1.11</version>
         <configuration>
           <verbose>true</verbose>
           <showWeaveInfo>false</showWeaveInfo>
@@ -195,12 +203,12 @@
           <dependency>
             <groupId>org.aspectj</groupId>
             <artifactId>aspectjrt</artifactId>
-            <version>1.8.9</version>
+            <version>1.9.4</version>
           </dependency>
           <dependency>
             <groupId>org.aspectj</groupId>
             <artifactId>aspectjtools</artifactId>
-            <version>1.8.9</version>
+            <version>1.9.4</version>
           </dependency>
         </dependencies>
       </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <artifactId>mod-circulation-storage</artifactId>
   <groupId>org.folio</groupId>
-  <version>10.1.0-SNAPSHOT</version>
+  <version>11.0.0-SNAPSHOT</version>
   <licenses>
     <license>
       <name>Apache License 2.0</name>

--- a/ramls/loan-policy-storage.raml
+++ b/ramls/loan-policy-storage.raml
@@ -11,11 +11,13 @@ documentation:
 types:
   loan-policy: !include loan-policy.json
   loan-policies: !include loan-policies.json
+  errors: !include raml-util/schemas/errors.schema
 
 traits:
   language: !include raml-util/traits/language.raml
   pageable: !include raml-util/traits/pageable.raml
   searchable: !include raml-util/traits/searchable.raml
+  validate: !include raml-util/traits/validation.raml
 
 resourceTypes:
   collection: !include raml-util/rtypes/collection.raml
@@ -39,6 +41,7 @@ resourceTypes:
         501:
           description: "Not implemented yet"
     post:
+      is: [validate]
       responses:
         501:
           description: "Not implemented yet"

--- a/src/main/java/org/folio/rest/impl/AnonymizeStorageLoansAPI.java
+++ b/src/main/java/org/folio/rest/impl/AnonymizeStorageLoansAPI.java
@@ -25,6 +25,7 @@ import io.vertx.core.AsyncResult;
 import io.vertx.core.Context;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
+import io.vertx.core.Promise;
 import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
 import io.vertx.ext.sql.UpdateResult;
@@ -90,9 +91,9 @@ public class AnonymizeStorageLoansAPI implements AnonymizeStorageLoans {
 
   private Future<UpdateResult> executeSql(PostgresClient postgresClient,
     String sql) {
-    Future<UpdateResult> future = Future.future();
-    postgresClient.execute(sql, future);
-    return future;
+    Promise<UpdateResult> promise = Promise.promise();
+    postgresClient.execute(sql, promise.future());
+    return promise.future();
   }
 
   private String createAnonymizationSQL(@NotNull Collection<String> loanIdList,

--- a/src/main/java/org/folio/rest/impl/CirculationRulesAPI.java
+++ b/src/main/java/org/folio/rest/impl/CirculationRulesAPI.java
@@ -11,6 +11,7 @@ import org.folio.rest.jaxrs.model.CirculationRules;
 import org.folio.rest.jaxrs.resource.CirculationRulesStorage;
 import org.folio.rest.persist.Criteria.Criterion;
 import org.folio.rest.persist.Criteria.UpdateSection;
+import org.folio.rest.persist.interfaces.Results;
 import org.folio.rest.persist.PostgresClient;
 import org.folio.rest.tools.utils.TenantTool;
 
@@ -35,9 +36,11 @@ public class CirculationRulesAPI implements CirculationRulesStorage {
     try {
       vertxContext.runOnContext(v -> {
         try {
+          Criterion filter = new Criterion();
           PostgresClient postgresClient = PostgresClient.getInstance(
               vertxContext.owner(), TenantTool.tenantId(okapiHeaders));
-          postgresClient.get(CIRCULATION_RULES_TABLE, CirculationRules.class, "", true, false,
+
+          postgresClient.get(CIRCULATION_RULES_TABLE, CirculationRules.class, filter, true,
             reply -> {
               try {
                 if (reply.failed()) {

--- a/src/main/java/org/folio/rest/impl/LoanPoliciesAPI.java
+++ b/src/main/java/org/folio/rest/impl/LoanPoliciesAPI.java
@@ -5,13 +5,17 @@ import io.vertx.core.Context;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import org.folio.rest.annotations.Validate;
+import org.folio.rest.jaxrs.model.Error;
+import org.folio.rest.jaxrs.model.Errors;
 import org.folio.rest.jaxrs.model.LoanPolicies;
 import org.folio.rest.jaxrs.model.LoanPolicy;
 import org.folio.rest.jaxrs.resource.LoanPolicyStorage;
 import org.folio.rest.persist.MyPgUtil;
 import org.folio.rest.persist.PgUtil;
 import org.folio.rest.persist.PostgresClient;
+import org.folio.rest.tools.RTFConsts;
 import org.folio.rest.tools.utils.TenantTool;
+import org.folio.rest.tools.utils.ValidationHelper;
 import javax.ws.rs.core.Response;
 import java.util.Map;
 import static org.folio.rest.impl.Headers.TENANT_HEADER;
@@ -48,6 +52,7 @@ public class LoanPoliciesAPI implements LoanPolicyStorage {
   }
 
   @Override
+  @Validate
   public void getLoanPolicyStorageLoanPolicies(
     int offset,
     int limit,
@@ -71,7 +76,16 @@ public class LoanPoliciesAPI implements LoanPolicyStorage {
     Context vertxContext) {
 
     PgUtil.post(LOAN_POLICY_TABLE, entity, okapiHeaders, vertxContext,
-        PostLoanPolicyStorageLoanPoliciesResponse.class, asyncResultHandler);
+        PostLoanPolicyStorageLoanPoliciesResponse.class, reply -> {
+      if (isInvalidUUIDError(reply)) {
+        asyncResultHandler.handle(
+          Future.succeededFuture(LoanPolicyStorage.PostLoanPolicyStorageLoanPoliciesResponse
+            .respond422WithApplicationJson(invalidUUIDError(entity))));
+        return;
+      }
+
+      asyncResultHandler.handle(reply);
+    });
   }
 
   @Override
@@ -111,5 +125,38 @@ public class LoanPoliciesAPI implements LoanPolicyStorage {
 
     MyPgUtil.putUpsert204(LOAN_POLICY_TABLE, entity, loanPolicyId, okapiHeaders, vertxContext,
         PutLoanPolicyStorageLoanPoliciesByLoanPolicyIdResponse.class, asyncResultHandler);
+  }
+
+  private Errors invalidUUIDError(LoanPolicy entity) {
+    return ValidationHelper.createValidationErrorMessage(
+      "itemId", entity.getId(),
+      "Provided UUID for the lone policy is invalid");
+  }
+
+  private boolean isInvalidUUIDError(AsyncResult<Response> reply) {
+    String message = "";
+
+    if (reply.succeeded() && reply.result().getStatus() >= 400 &&
+      reply.result().getStatus() < 600 && reply.result().hasEntity()) {
+
+      // When entity is an instance of Errors, the getEntity().toString()
+      // will return an object identifier. Process the object to correctly
+      // parse the message.
+      if (reply.result().getEntity() instanceof Errors) {
+        Errors errors = (Errors) reply.result().getEntity();
+
+        for (int i = 0; i < errors.getErrors().size(); i++) {
+          Error error = errors.getErrors().get(i);
+
+          if (error.getType() == RTFConsts.VALIDATION_FIELD_ERROR)
+            message = error.getMessage().toLowerCase();
+        }
+      } else {
+        message = reply.result().getEntity().toString().toLowerCase();
+      }
+    }
+
+    return message.contains("invalid input syntax for type uuid: ") ||
+      message.contains("duplicate key value violates unique constraint ");
   }
 }

--- a/src/main/java/org/folio/rest/impl/LoanPoliciesAPI.java
+++ b/src/main/java/org/folio/rest/impl/LoanPoliciesAPI.java
@@ -5,17 +5,13 @@ import io.vertx.core.Context;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import org.folio.rest.annotations.Validate;
-import org.folio.rest.jaxrs.model.Error;
-import org.folio.rest.jaxrs.model.Errors;
 import org.folio.rest.jaxrs.model.LoanPolicies;
 import org.folio.rest.jaxrs.model.LoanPolicy;
 import org.folio.rest.jaxrs.resource.LoanPolicyStorage;
 import org.folio.rest.persist.MyPgUtil;
 import org.folio.rest.persist.PgUtil;
 import org.folio.rest.persist.PostgresClient;
-import org.folio.rest.tools.RTFConsts;
 import org.folio.rest.tools.utils.TenantTool;
-import org.folio.rest.tools.utils.ValidationHelper;
 import javax.ws.rs.core.Response;
 import java.util.Map;
 import static org.folio.rest.impl.Headers.TENANT_HEADER;
@@ -76,16 +72,7 @@ public class LoanPoliciesAPI implements LoanPolicyStorage {
     Context vertxContext) {
 
     PgUtil.post(LOAN_POLICY_TABLE, entity, okapiHeaders, vertxContext,
-        PostLoanPolicyStorageLoanPoliciesResponse.class, reply -> {
-      if (isInvalidUUIDError(reply)) {
-        asyncResultHandler.handle(
-          Future.succeededFuture(LoanPolicyStorage.PostLoanPolicyStorageLoanPoliciesResponse
-            .respond422WithApplicationJson(invalidUUIDError(entity))));
-        return;
-      }
-
-      asyncResultHandler.handle(reply);
-    });
+        PostLoanPolicyStorageLoanPoliciesResponse.class, asyncResultHandler);
   }
 
   @Override
@@ -125,38 +112,5 @@ public class LoanPoliciesAPI implements LoanPolicyStorage {
 
     MyPgUtil.putUpsert204(LOAN_POLICY_TABLE, entity, loanPolicyId, okapiHeaders, vertxContext,
         PutLoanPolicyStorageLoanPoliciesByLoanPolicyIdResponse.class, asyncResultHandler);
-  }
-
-  private Errors invalidUUIDError(LoanPolicy entity) {
-    return ValidationHelper.createValidationErrorMessage(
-      "itemId", entity.getId(),
-      "Provided UUID for the lone policy is invalid");
-  }
-
-  private boolean isInvalidUUIDError(AsyncResult<Response> reply) {
-    String message = "";
-
-    if (reply.succeeded() && reply.result().getStatus() >= 400 &&
-      reply.result().getStatus() < 600 && reply.result().hasEntity()) {
-
-      // When entity is an instance of Errors, the getEntity().toString()
-      // will return an object identifier. Process the object to correctly
-      // parse the message.
-      if (reply.result().getEntity() instanceof Errors) {
-        Errors errors = (Errors) reply.result().getEntity();
-
-        for (int i = 0; i < errors.getErrors().size(); i++) {
-          Error error = errors.getErrors().get(i);
-
-          if (error.getType() == RTFConsts.VALIDATION_FIELD_ERROR)
-            message = error.getMessage().toLowerCase();
-        }
-      } else {
-        message = reply.result().getEntity().toString().toLowerCase();
-      }
-    }
-
-    return message.contains("invalid input syntax for type uuid: ") ||
-      message.contains("duplicate key value violates unique constraint ");
   }
 }

--- a/src/main/java/org/folio/rest/impl/LoansAPI.java
+++ b/src/main/java/org/folio/rest/impl/LoansAPI.java
@@ -29,6 +29,7 @@ import org.folio.rest.jaxrs.resource.LoanStorage;
 import org.folio.rest.persist.MyPgUtil;
 import org.folio.rest.persist.PgUtil;
 import org.folio.rest.persist.PostgresClient;
+import org.folio.rest.tools.RTFConsts;
 import org.folio.rest.tools.utils.TenantTool;
 import org.folio.rest.tools.utils.ValidationHelper;
 import org.folio.support.ResultHandlerFactory;
@@ -293,9 +294,30 @@ public class LoansAPI implements LoanStorage {
   }
 
   private boolean isMultipleOpenLoanError(AsyncResult<Response> reply) {
-    return reply.succeeded()
-      && reply.result().getStatus() == 400
-      && reply.result().getEntity().toString().contains("loan_itemid_idx_unique");
+    String message = "";
+
+    if (reply.succeeded() && reply.result().getStatus() >= 400 &&
+      reply.result().getStatus() < 600 && reply.result().hasEntity()) {
+
+      // When entity is an instance of Errors, the getEntity().toString()
+      // will return an object identifier. Process the object to correctly
+      // parse the message.
+      if (reply.result().getEntity() instanceof Errors) {
+        Errors errors = (Errors) reply.result().getEntity();
+
+        for (int i = 0; i < errors.getErrors().size(); i++) {
+          Error error = errors.getErrors().get(i);
+
+          if (error.getType() == RTFConsts.VALIDATION_FIELD_ERROR)
+            message = error.getMessage().toLowerCase();
+        }
+      } else {
+        message = reply.result().getEntity().toString().toLowerCase();
+      }
+    }
+
+    return message.contains("value already exists in table loan: ")
+      || message.contains("duplicate key value violates unique constraint ");
   }
 
   private boolean isOpenAndHasNoUserId(Loan loan) {
@@ -318,8 +340,6 @@ public class LoansAPI implements LoanStorage {
     asyncResultHandler.handle(succeededFuture(
       responseCreator.apply(errors)));
   }
-
-
 
   private String createAnonymizationSQL(
     @NotNull String userId,

--- a/src/main/java/org/folio/rest/impl/RequestPreferencesAPI.java
+++ b/src/main/java/org/folio/rest/impl/RequestPreferencesAPI.java
@@ -8,11 +8,13 @@ import javax.ws.rs.core.Response;
 
 import org.folio.HttpStatus;
 import org.folio.rest.annotations.Validate;
+import org.folio.rest.jaxrs.model.Error;
 import org.folio.rest.jaxrs.model.Errors;
 import org.folio.rest.jaxrs.model.RequestPreference;
 import org.folio.rest.jaxrs.model.RequestPreferences;
 import org.folio.rest.jaxrs.resource.RequestPreferenceStorage;
 import org.folio.rest.persist.PgUtil;
+import org.folio.rest.tools.RTFConsts;
 import org.folio.rest.tools.utils.ValidationHelper;
 
 import io.vertx.core.AsyncResult;
@@ -66,9 +68,30 @@ public class RequestPreferencesAPI implements RequestPreferenceStorage {
   }
 
   private boolean isUniqueUserIdViolation(AsyncResult<Response> reply) {
-    return reply.succeeded() &&
-      reply.result().getStatus() == HttpStatus.HTTP_BAD_REQUEST.toInt() &&
-      reply.result().getEntity().toString().contains("user_request_preference_userid_idx_unique");
+    String message = "";
+
+    if (reply.succeeded() && reply.result().getStatus() >= 400 &&
+      reply.result().getStatus() < 600 && reply.result().hasEntity()) {
+
+      // When entity is an instance of Errors, the getEntity().toString()
+      // will return an object identifier. Process the object to correctly
+      // parse the message.
+      if (reply.result().getEntity() instanceof Errors) {
+        Errors errors = (Errors) reply.result().getEntity();
+
+        for (int i = 0; i < errors.getErrors().size(); i++) {
+          Error error = errors.getErrors().get(i);
+
+          if (error.getType() == RTFConsts.VALIDATION_FIELD_ERROR)
+            message = error.getMessage().toLowerCase();
+        }
+      } else {
+        message = reply.result().getEntity().toString().toLowerCase();
+      }
+    }
+
+    return message.contains(" value already exists in table ") ||
+      message.contains("user_request_preference_userid_idx_unique");
   }
 
   private Errors preferenceAlreadyExistsError(String userId) {

--- a/src/main/java/org/folio/rest/impl/RequestPreferencesAPI.java
+++ b/src/main/java/org/folio/rest/impl/RequestPreferencesAPI.java
@@ -1,20 +1,19 @@
 package org.folio.rest.impl;
 
+import static org.folio.HttpStatus.HTTP_UNPROCESSABLE_ENTITY;
 import static io.vertx.core.Future.succeededFuture;
 
 import java.util.Map;
 
 import javax.ws.rs.core.Response;
 
-import org.folio.HttpStatus;
 import org.folio.rest.annotations.Validate;
-import org.folio.rest.jaxrs.model.Error;
+import org.folio.rest.impl.util.OkapiResponseUtil;
 import org.folio.rest.jaxrs.model.Errors;
 import org.folio.rest.jaxrs.model.RequestPreference;
 import org.folio.rest.jaxrs.model.RequestPreferences;
 import org.folio.rest.jaxrs.resource.RequestPreferenceStorage;
 import org.folio.rest.persist.PgUtil;
-import org.folio.rest.tools.RTFConsts;
 import org.folio.rest.tools.utils.ValidationHelper;
 
 import io.vertx.core.AsyncResult;
@@ -59,7 +58,8 @@ public class RequestPreferencesAPI implements RequestPreferenceStorage {
     return reply -> {
       if (isUniqueUserIdViolation(reply)) {
         asyncResultHandler.handle(
-          succeededFuture(Response.status(HttpStatus.HTTP_UNPROCESSABLE_ENTITY.toInt()).header("Content-Type", "application/json")
+          succeededFuture(Response.status(HTTP_UNPROCESSABLE_ENTITY.toInt())
+            .header("Content-Type", "application/json")
             .entity(preferenceAlreadyExistsError(entity.getUserId())).build()));
       } else {
         asyncResultHandler.handle(reply);
@@ -68,30 +68,8 @@ public class RequestPreferencesAPI implements RequestPreferenceStorage {
   }
 
   private boolean isUniqueUserIdViolation(AsyncResult<Response> reply) {
-    String message = "";
-
-    if (reply.succeeded() && reply.result().getStatus() >= 400 &&
-      reply.result().getStatus() < 600 && reply.result().hasEntity()) {
-
-      // When entity is an instance of Errors, the getEntity().toString()
-      // will return an object identifier. Process the object to correctly
-      // parse the message.
-      if (reply.result().getEntity() instanceof Errors) {
-        Errors errors = (Errors) reply.result().getEntity();
-
-        for (int i = 0; i < errors.getErrors().size(); i++) {
-          Error error = errors.getErrors().get(i);
-
-          if (error.getType() == RTFConsts.VALIDATION_FIELD_ERROR)
-            message = error.getMessage().toLowerCase();
-        }
-      } else {
-        message = reply.result().getEntity().toString().toLowerCase();
-      }
-    }
-
-    return message.contains(" value already exists in table ") ||
-      message.contains("user_request_preference_userid_idx_unique");
+    return OkapiResponseUtil.containsErrorMessage(
+      reply, " value already exists in table ");
   }
 
   private Errors preferenceAlreadyExistsError(String userId) {

--- a/src/main/java/org/folio/rest/impl/RequestPreferencesAPI.java
+++ b/src/main/java/org/folio/rest/impl/RequestPreferencesAPI.java
@@ -6,6 +6,7 @@ import java.util.Map;
 
 import javax.ws.rs.core.Response;
 
+import org.folio.HttpStatus;
 import org.folio.rest.annotations.Validate;
 import org.folio.rest.jaxrs.model.Errors;
 import org.folio.rest.jaxrs.model.RequestPreference;
@@ -56,7 +57,7 @@ public class RequestPreferencesAPI implements RequestPreferenceStorage {
     return reply -> {
       if (isUniqueUserIdViolation(reply)) {
         asyncResultHandler.handle(
-          succeededFuture(Response.status(422).header("Content-Type", "application/json")
+          succeededFuture(Response.status(HttpStatus.HTTP_UNPROCESSABLE_ENTITY.toInt()).header("Content-Type", "application/json")
             .entity(preferenceAlreadyExistsError(entity.getUserId())).build()));
       } else {
         asyncResultHandler.handle(reply);
@@ -66,7 +67,7 @@ public class RequestPreferencesAPI implements RequestPreferenceStorage {
 
   private boolean isUniqueUserIdViolation(AsyncResult<Response> reply) {
     return reply.succeeded() &&
-      reply.result().getStatus() == 400 &&
+      reply.result().getStatus() == HttpStatus.HTTP_BAD_REQUEST.toInt() &&
       reply.result().getEntity().toString().contains("user_request_preference_userid_idx_unique");
   }
 

--- a/src/main/java/org/folio/rest/impl/ScheduledNoticesAPI.java
+++ b/src/main/java/org/folio/rest/impl/ScheduledNoticesAPI.java
@@ -5,7 +5,6 @@ import static io.vertx.core.Future.succeededFuture;
 import static java.lang.String.format;
 import static javax.ws.rs.core.HttpHeaders.CONTENT_TYPE;
 import static javax.ws.rs.core.MediaType.TEXT_PLAIN;
-
 import static org.folio.rest.persist.PostgresClient.convertToPsqlStandard;
 
 import java.util.Map;
@@ -16,6 +15,7 @@ import io.vertx.core.AsyncResult;
 import io.vertx.core.Context;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
+import io.vertx.core.Promise;
 import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
 import io.vertx.ext.sql.UpdateResult;
@@ -116,9 +116,9 @@ public class ScheduledNoticesAPI implements ScheduledNoticeStorage {
 
   private Future<Void> executeSql(PostgresClient pgClient, String sql) {
 
-    Future<UpdateResult> future = Future.future();
-    pgClient.execute(sql, future.completer());
-    return future.map(ur -> null);
+    Promise<UpdateResult> promise = Promise.promise();
+    pgClient.execute(sql, promise.future());
+    return promise.future().map(ur -> null);
   }
 
   private Future<String> cqlToSqlDeleteQuery(String cql, String tenant) {

--- a/src/main/java/org/folio/rest/impl/util/OkapiResponseUtil.java
+++ b/src/main/java/org/folio/rest/impl/util/OkapiResponseUtil.java
@@ -25,7 +25,7 @@ public class OkapiResponseUtil {
    *   The Okapi Response to parse for error messages.
    *
    * @return
-   *   A concatenated list of error messages associated with the reply.
+   *   A string of concatenated error messages associated with the reply.
    *   A newline is appended at the end of each distinct error message.
    */
   public static String getErrorMessage(AsyncResult<Response> reply) {

--- a/src/main/java/org/folio/rest/impl/util/OkapiResponseUtil.java
+++ b/src/main/java/org/folio/rest/impl/util/OkapiResponseUtil.java
@@ -16,6 +16,18 @@ public class OkapiResponseUtil {
     throw new UnsupportedOperationException("Do not instantiate");
   }
 
+  /**
+   * Parse an Okapi HTTP Response for error messages.
+   *
+   * This will handle only 4xx (client side) HTTP error messages.
+   *
+   * @param reply
+   *   The Okapi Response to parse for error messages.
+   *
+   * @return
+   *   A concatenated list of error messages associated with the reply.
+   *   A newline is appended at the end of each distinct error message.
+   */
   public static String getErrorMessage(AsyncResult<Response> reply) {
     String message = null;
 
@@ -28,18 +40,35 @@ public class OkapiResponseUtil {
       if (reply.result().getEntity() instanceof Errors) {
         Errors errors = (Errors) reply.result().getEntity();
 
+        if (errors.getErrors().size() > 0)
+          message = "";
+
         for (int i = 0; i < errors.getErrors().size(); i++) {
           Error error = errors.getErrors().get(i);
-          message = error.getMessage().toLowerCase();
+          message += error.getMessage().toLowerCase() + "\n";
         }
       } else {
-        message = reply.result().getEntity().toString().toLowerCase();
+        message = reply.result().getEntity().toString().toLowerCase()
+          + "\n";
       }
     }
 
     return message;
   }
 
+  /**
+   * Search for the given substring within an Okapi HTTP Response.
+   *
+   * This will handle only 4xx (client side) HTTP error messages.
+   *
+   * @param reply
+   *   The Okapi Response to parse for error messages.
+   * @param subString
+   *   The substring to find within the error messages.
+   *
+   * @return
+   *   TRUE is returned on match, FALSE otherwise.
+   */
   public static boolean containsErrorMessage(AsyncResult<Response> reply, String subString) {
     String message = getErrorMessage(reply);
     return message != null && message.contains(subString);

--- a/src/main/java/org/folio/rest/impl/util/OkapiResponseUtil.java
+++ b/src/main/java/org/folio/rest/impl/util/OkapiResponseUtil.java
@@ -1,0 +1,47 @@
+package org.folio.rest.impl.util;
+
+import io.vertx.core.AsyncResult;
+
+import javax.ws.rs.core.Response;
+
+import org.folio.rest.jaxrs.model.Error;
+import org.folio.rest.jaxrs.model.Errors;
+
+/**
+ * Utility methods for Okapi Responses.
+ */
+public class OkapiResponseUtil {
+
+  private OkapiResponseUtil() {
+    throw new UnsupportedOperationException("Do not instantiate");
+  }
+
+  public static String getErrorMessage(AsyncResult<Response> reply) {
+    String message = null;
+
+    if (reply.succeeded() && reply.result().getStatus() >= 400
+      && reply.result().getStatus() < 500 && reply.result().hasEntity()) {
+
+      // When entity is an instance of Errors, the getEntity().toString()
+      // will return an object identifier. Process the object to correctly
+      // parse the message.
+      if (reply.result().getEntity() instanceof Errors) {
+        Errors errors = (Errors) reply.result().getEntity();
+
+        for (int i = 0; i < errors.getErrors().size(); i++) {
+          Error error = errors.getErrors().get(i);
+          message = error.getMessage().toLowerCase();
+        }
+      } else {
+        message = reply.result().getEntity().toString().toLowerCase();
+      }
+    }
+
+    return message;
+  }
+
+  public static boolean containsErrorMessage(AsyncResult<Response> reply, String subString) {
+    String message = getErrorMessage(reply);
+    return message != null && message.contains(subString);
+  }
+}

--- a/src/main/java/org/folio/rest/impl/util/OkapiResponseUtil.java
+++ b/src/main/java/org/folio/rest/impl/util/OkapiResponseUtil.java
@@ -45,11 +45,10 @@ public class OkapiResponseUtil {
 
         for (int i = 0; i < errors.getErrors().size(); i++) {
           Error error = errors.getErrors().get(i);
-          message += error.getMessage().toLowerCase() + "\n";
+          message += error.getMessage() + "\n";
         }
       } else {
-        message = reply.result().getEntity().toString().toLowerCase()
-          + "\n";
+        message = reply.result().getEntity().toString() + "\n";
       }
     }
 

--- a/src/main/java/org/folio/rest/impl/util/OkapiResponseUtil.java
+++ b/src/main/java/org/folio/rest/impl/util/OkapiResponseUtil.java
@@ -40,8 +40,7 @@ public class OkapiResponseUtil {
       if (reply.result().getEntity() instanceof Errors) {
         Errors errors = (Errors) reply.result().getEntity();
 
-        for (int i = 0; i < errors.getErrors().size(); i++) {
-          Error error = errors.getErrors().get(i);
+        for (Error error : errors.getErrors()) {
           builder.append(error.getMessage());
           builder.append("\n");
         }

--- a/src/main/java/org/folio/rest/impl/util/OkapiResponseUtil.java
+++ b/src/main/java/org/folio/rest/impl/util/OkapiResponseUtil.java
@@ -29,7 +29,7 @@ public class OkapiResponseUtil {
    *   A newline is appended at the end of each distinct error message.
    */
   public static String getErrorMessage(AsyncResult<Response> reply) {
-    String message = null;
+    StringBuilder builder = new StringBuilder();
 
     if (reply.succeeded() && reply.result().getStatus() >= 400
       && reply.result().getStatus() < 500 && reply.result().hasEntity()) {
@@ -40,19 +40,18 @@ public class OkapiResponseUtil {
       if (reply.result().getEntity() instanceof Errors) {
         Errors errors = (Errors) reply.result().getEntity();
 
-        if (errors.getErrors().size() > 0)
-          message = "";
-
         for (int i = 0; i < errors.getErrors().size(); i++) {
           Error error = errors.getErrors().get(i);
-          message += error.getMessage() + "\n";
+          builder.append(error.getMessage());
+          builder.append("\n");
         }
       } else {
-        message = reply.result().getEntity().toString() + "\n";
+        builder.append(reply.result().getEntity().toString());
+        builder.append("\n");
       }
     }
 
-    return message;
+    return builder.toString();
   }
 
   /**

--- a/src/main/java/org/folio/rest/impl/util/RequestsApiUtil.java
+++ b/src/main/java/org/folio/rest/impl/util/RequestsApiUtil.java
@@ -20,7 +20,9 @@ public class RequestsApiUtil {
   }
 
   public static boolean hasSamePositionConstraintViolated(String errorMessage) {
-    return errorMessage != null && errorMessage.contains("request_itemid_position_idx_unique");
+    return errorMessage != null &&
+      (errorMessage.contains("request_itemid_position_idx_unique") ||
+      errorMessage.contains("value already exists in table "));
   }
 
   public static Errors samePositionInQueueError(String item, Integer position) {

--- a/src/main/java/org/folio/service/BatchResourceService.java
+++ b/src/main/java/org/folio/service/BatchResourceService.java
@@ -13,6 +13,7 @@ import com.google.common.collect.Lists;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
+import io.vertx.core.Promise;
 import io.vertx.core.json.JsonArray;
 import io.vertx.ext.sql.SQLConnection;
 import io.vertx.ext.sql.UpdateResult;
@@ -84,15 +85,15 @@ public class BatchResourceService {
     String tableName, String id, T entity) {
 
     return connection -> {
-      Future<UpdateResult> updateResultFuture = Future.future();
+      Promise<UpdateResult> promise = Promise.promise();
       Future<SQLConnection> connectionResult = Future.succeededFuture(connection);
 
       LOG.debug("Updating entity {} with id {}", entity, id);
 
       postgresClient.update(connectionResult, tableName, entity, "jsonb",
-        String.format(WHERE_CLAUSE, id), false, updateResultFuture);
+        String.format(WHERE_CLAUSE, id), false, promise.future());
 
-      return updateResultFuture;
+      return promise.future();
     };
   }
 
@@ -108,15 +109,15 @@ public class BatchResourceService {
     String query, Collection<?> params) {
 
     return connection -> {
-      Future<UpdateResult> updateResultFuture = Future.future();
+      Promise<UpdateResult> promise = Promise.promise();
       LOG.debug("Executing SQL [{}], got [{}] parameters", query, params.size());
 
       connection.updateWithParams(query,
         new JsonArray(Lists.newArrayList(params)),
-        updateResultFuture
+        promise.future()
       );
 
-      return updateResultFuture;
+      return promise.future();
     };
   }
 }

--- a/src/main/java/org/folio/support/PgClientFutureAdapter.java
+++ b/src/main/java/org/folio/support/PgClientFutureAdapter.java
@@ -7,6 +7,7 @@ import org.folio.rest.persist.PostgresClient;
 
 import io.vertx.core.Context;
 import io.vertx.core.Future;
+import io.vertx.core.Promise;
 import io.vertx.ext.sql.ResultSet;
 import io.vertx.ext.sql.UpdateResult;
 
@@ -23,14 +24,14 @@ public class PgClientFutureAdapter {
   }
 
   public Future<ResultSet> select(String sql) {
-    Future<ResultSet> future = Future.future();
-    client.select(sql, future);
-    return future;
+    Promise<ResultSet> promise = Promise.promise();
+    client.select(sql, promise.future());
+    return promise.future();
   }
 
   public Future<UpdateResult> execute(String sql) {
-    Future<UpdateResult> future = Future.future();
-    client.execute(sql, future);
-    return future;
+    Promise<UpdateResult> promise = Promise.promise();
+    client.execute(sql, promise.future());
+    return promise.future();
   }
 }

--- a/src/main/resources/templates/db_scripts/schema.json
+++ b/src/main/resources/templates/db_scripts/schema.json
@@ -1,7 +1,4 @@
 {
-  "fullText": {
-    "defaultDictionary": "simple"
-  },
   "scripts": [
     {
       "run": "before",
@@ -32,30 +29,10 @@
       ],
       "ginIndex": [
         {
-          "fieldName": "userId",
-          "tOps": "ADD",
-          "caseSensitive": false,
-          "removeAccents": true
-        },
-        {
-          "fieldName": "itemId",
-          "tOps": "ADD",
-          "caseSensitive": false,
-          "removeAccents": true
-        },
-        {
           "fieldName": "status.name",
           "tOps": "ADD",
           "caseSensitive": false,
           "removeAccents": true
-        }
-      ],
-      "index": [
-        {
-          "fieldName": "id",
-          "tOps": "ADD",
-          "caseSensitive": true,
-          "removeAccents": false
         }
       ],
       "fullTextIndex": [
@@ -97,12 +74,6 @@
         }
       ],
       "ginIndex": [
-        {
-          "fieldName": "itemId",
-          "tOps": "ADD",
-          "caseSensitive": false,
-          "removeAccents": true
-        },
         {
           "fieldName": "requestType",
           "tOps": "ADD",

--- a/src/main/resources/templates/db_scripts/schema.json
+++ b/src/main/resources/templates/db_scripts/schema.json
@@ -29,7 +29,39 @@
       ],
       "ginIndex": [
         {
+          "fieldName": "userId",
+          "tOps": "DELETE",
+          "caseSensitive": false,
+          "removeAccents": true
+        },
+        {
+          "fieldName": "itemId",
+          "tOps": "DELETE",
+          "caseSensitive": false,
+          "removeAccents": true
+        },
+        {
           "fieldName": "status.name",
+          "tOps": "ADD",
+          "caseSensitive": false,
+          "removeAccents": true
+        }
+      ],
+      "index": [
+        {
+          "fieldName": "id",
+          "tOps": "DELETE",
+          "caseSensitive": true,
+          "removeAccents": false
+        },
+        {
+          "fieldName": "userId",
+          "tOps": "ADD",
+          "caseSensitive": false,
+          "removeAccents": true
+        },
+        {
+          "fieldName": "itemId",
           "tOps": "ADD",
           "caseSensitive": false,
           "removeAccents": true
@@ -75,6 +107,12 @@
       ],
       "ginIndex": [
         {
+          "fieldName": "itemId",
+          "tOps": "DELETE",
+          "caseSensitive": false,
+          "removeAccents": true
+        },
+        {
           "fieldName": "requestType",
           "tOps": "ADD",
           "caseSensitive": false,
@@ -82,6 +120,14 @@
         },
         {
           "fieldName": "status",
+          "tOps": "ADD",
+          "caseSensitive": false,
+          "removeAccents": true
+        }
+      ],
+      "index": [
+        {
+          "fieldName": "itemId",
           "tOps": "ADD",
           "caseSensitive": false,
           "removeAccents": true

--- a/src/test/java/org/folio/rest/api/CancellationReasonsApiTest.java
+++ b/src/test/java/org/folio/rest/api/CancellationReasonsApiTest.java
@@ -1,6 +1,8 @@
 package org.folio.rest.api;
 
 import io.vertx.core.json.JsonObject;
+
+import org.folio.HttpStatus;
 import org.folio.rest.support.*;
 import org.folio.rest.support.builders.RequestRequestBuilder;
 import org.hamcrest.junit.MatcherAssert;
@@ -256,7 +258,7 @@ public class CancellationReasonsApiTest extends ApiTests {
     assertCreateCancellationReason(request);
     assertDeleteCancellationReason(id);
     JsonResponse getResponse = getCancellationReason(id);
-    assertTrue(getResponse.getStatusCode() == 404);
+    assertEquals(HttpStatus.HTTP_NOT_FOUND.toInt(), getResponse.getStatusCode());
   }
 
   @Test
@@ -273,7 +275,7 @@ public class CancellationReasonsApiTest extends ApiTests {
         .put("description", "Chicken grease stains on item");
     assertCreateCancellationReason(request);
     JsonResponse response = createCancellationReason(request2);
-    assertEquals(400, response.getStatusCode());
+    assertEquals(HttpStatus.HTTP_UNPROCESSABLE_ENTITY.toInt(), response.getStatusCode());
   }
 
   @Test
@@ -317,9 +319,9 @@ public class CancellationReasonsApiTest extends ApiTests {
     client.post(requestStorageUrl(), requestRequest, StorageTestSuite.TENANT_ID,
         ResponseHandler.json(createRequestFuture));
     JsonResponse createRequestResponse = createRequestFuture.get(5, TimeUnit.SECONDS);
-    assertEquals(201, createRequestResponse.getStatusCode());
+    assertEquals(HttpStatus.HTTP_CREATED.toInt(), createRequestResponse.getStatusCode());
     TextResponse deleteReasonResponse = deleteCancellationReason(cancellationReasonId.toString());
-    assertEquals(400, deleteReasonResponse.getStatusCode());
+    assertEquals(HttpStatus.HTTP_BAD_REQUEST.toInt(), deleteReasonResponse.getStatusCode());
 
   }
   @Test

--- a/src/test/java/org/folio/rest/api/CancellationReasonsApiTest.java
+++ b/src/test/java/org/folio/rest/api/CancellationReasonsApiTest.java
@@ -2,7 +2,6 @@ package org.folio.rest.api;
 
 import io.vertx.core.json.JsonObject;
 
-import org.folio.HttpStatus;
 import org.folio.rest.support.*;
 import org.folio.rest.support.builders.RequestRequestBuilder;
 import org.hamcrest.junit.MatcherAssert;
@@ -11,7 +10,6 @@ import org.joda.time.DateTimeZone;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.net.HttpURLConnection;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.UUID;
@@ -20,10 +18,16 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
+import static org.folio.rest.support.matchers.OkapiResponseStatusCodeMatchers.matchesBadRequest;
+import static org.folio.rest.support.matchers.OkapiResponseStatusCodeMatchers.matchesCreated;
+import static org.folio.rest.support.matchers.OkapiResponseStatusCodeMatchers.matchesNoContent;
+import static org.folio.rest.support.matchers.OkapiResponseStatusCodeMatchers.matchesNotFound;
+import static org.folio.rest.support.matchers.OkapiResponseStatusCodeMatchers.matchesOk;
+import static org.folio.rest.support.matchers.OkapiResponseStatusCodeMatchers.matchesUnprocessableEntity;
 import static org.folio.rest.api.RequestsApiTest.requestStorageUrl;
 import static org.folio.rest.support.builders.RequestRequestBuilder.CLOSED_CANCELLED;
-import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 /**
@@ -52,8 +56,7 @@ public class CancellationReasonsApiTest extends ApiTests {
     JsonResponse response = createCancellationReason(request);
 
     MatcherAssert.assertThat(String.format("Failed to create cancellation reason: %s",
-        response.getBody()),
-      response.getStatusCode(), is(HttpURLConnection.HTTP_CREATED));
+        response.getBody()), response, matchesCreated());
 
     new IndividualResource(response);
   }
@@ -80,7 +83,7 @@ public class CancellationReasonsApiTest extends ApiTests {
 
     MatcherAssert.assertThat(String.format("Failed to retrieve cancellation reason: %s (%s)",
         response.getBody(), response.getStatusCode()),
-        response.getStatusCode(), is(HttpURLConnection.HTTP_OK));
+        response, matchesOk());
 
     return new IndividualResource(response);
   }
@@ -136,7 +139,7 @@ public class CancellationReasonsApiTest extends ApiTests {
 
     MatcherAssert.assertThat(String.format("Failed to update cancellation reason: %s (%s)",
         response.getBody(), response.getStatusCode()),
-        response.getStatusCode(), is(HttpURLConnection.HTTP_NO_CONTENT));
+        response, matchesNoContent());
   }
 
   private TextResponse deleteCancellationReason(String id)
@@ -161,7 +164,7 @@ public class CancellationReasonsApiTest extends ApiTests {
 
     MatcherAssert.assertThat(String.format("Failed to delete cancellation reason: %s (%s)",
         response.getBody(), response.getStatusCode()),
-        response.getStatusCode(), is(HttpURLConnection.HTTP_NO_CONTENT));
+        response, matchesNoContent());
   }
   //Test Init
   @Before
@@ -258,7 +261,7 @@ public class CancellationReasonsApiTest extends ApiTests {
     assertCreateCancellationReason(request);
     assertDeleteCancellationReason(id);
     JsonResponse getResponse = getCancellationReason(id);
-    assertEquals(HttpStatus.HTTP_NOT_FOUND.toInt(), getResponse.getStatusCode());
+    assertThat(getResponse, matchesNotFound());
   }
 
   @Test
@@ -275,7 +278,7 @@ public class CancellationReasonsApiTest extends ApiTests {
         .put("description", "Chicken grease stains on item");
     assertCreateCancellationReason(request);
     JsonResponse response = createCancellationReason(request2);
-    assertEquals(HttpStatus.HTTP_UNPROCESSABLE_ENTITY.toInt(), response.getStatusCode());
+    assertThat(response, matchesUnprocessableEntity());
   }
 
   @Test
@@ -319,9 +322,9 @@ public class CancellationReasonsApiTest extends ApiTests {
     client.post(requestStorageUrl(), requestRequest, StorageTestSuite.TENANT_ID,
         ResponseHandler.json(createRequestFuture));
     JsonResponse createRequestResponse = createRequestFuture.get(5, TimeUnit.SECONDS);
-    assertEquals(HttpStatus.HTTP_CREATED.toInt(), createRequestResponse.getStatusCode());
+    assertThat(createRequestResponse, matchesCreated());
     TextResponse deleteReasonResponse = deleteCancellationReason(cancellationReasonId.toString());
-    assertEquals(HttpStatus.HTTP_BAD_REQUEST.toInt(), deleteReasonResponse.getStatusCode());
+    assertThat(deleteReasonResponse, matchesBadRequest());
 
   }
   @Test

--- a/src/test/java/org/folio/rest/api/CirculationRulesApiTest.java
+++ b/src/test/java/org/folio/rest/api/CirculationRulesApiTest.java
@@ -1,6 +1,8 @@
 package org.folio.rest.api;
 
 import io.vertx.core.json.JsonObject;
+
+import org.folio.HttpStatus;
 import org.folio.rest.jaxrs.model.CirculationRules;
 import org.folio.rest.support.ApiTests;
 import org.folio.rest.support.JsonResponse;
@@ -21,7 +23,6 @@ import static org.hamcrest.core.IsNull.notNullValue;
 
 @FixMethodOrder(MethodSorters.NAME_ASCENDING)
 public class CirculationRulesApiTest extends ApiTests {
-  private static final int HTTP_VALIDATION_ERROR = 422;
   private String uuid;
 
   public static URL rulesStorageUrl() throws MalformedURLException {
@@ -91,6 +92,6 @@ public class CirculationRulesApiTest extends ApiTests {
   @Test
   public void putNullFields() throws Exception {
     CirculationRules circulationRules = new CirculationRules();
-    assertThat(putResponse(circulationRules).getStatusCode(), is(HTTP_VALIDATION_ERROR));
+    assertThat(putResponse(circulationRules).getStatusCode(), is(HttpStatus.HTTP_UNPROCESSABLE_ENTITY.toInt()));
   }
 }

--- a/src/test/java/org/folio/rest/api/CirculationRulesApiTest.java
+++ b/src/test/java/org/folio/rest/api/CirculationRulesApiTest.java
@@ -57,7 +57,7 @@ public class CirculationRulesApiTest extends ApiTests {
   /** @return the JSON of the get response, asserts an HTTP_OK=200 response */
   private JsonObject get() throws Exception {
     JsonResponse response = getResponse();
-    assertThat(response.getBody(), response, matchesOk());
+    assertThat(response, matchesOk());
     return response.getJson();
   }
 
@@ -72,7 +72,7 @@ public class CirculationRulesApiTest extends ApiTests {
   /** @return the message of the put response, asserts an HTTP_OK=200 response */
   private String put204(CirculationRules circulationRules) throws Exception {
     JsonResponse response = putResponse(circulationRules);
-    assertThat(response.getBody(), response, matchesNoContent());
+    assertThat(response, matchesNoContent());
     return response.getBody();
   }
 

--- a/src/test/java/org/folio/rest/api/CirculationRulesApiTest.java
+++ b/src/test/java/org/folio/rest/api/CirculationRulesApiTest.java
@@ -2,7 +2,6 @@ package org.folio.rest.api;
 
 import io.vertx.core.json.JsonObject;
 
-import org.folio.HttpStatus;
 import org.folio.rest.jaxrs.model.CirculationRules;
 import org.folio.rest.support.ApiTests;
 import org.folio.rest.support.JsonResponse;
@@ -11,19 +10,19 @@ import org.junit.FixMethodOrder;
 import org.junit.Test;
 import org.junit.runners.MethodSorters;
 
-import java.net.HttpURLConnection;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 
+import static org.folio.rest.support.matchers.OkapiResponseStatusCodeMatchers.matchesNoContent;
+import static org.folio.rest.support.matchers.OkapiResponseStatusCodeMatchers.matchesOk;
+import static org.folio.rest.support.matchers.OkapiResponseStatusCodeMatchers.matchesUnprocessableEntity;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
-import static org.hamcrest.core.IsNull.notNullValue;
 
 @FixMethodOrder(MethodSorters.NAME_ASCENDING)
 public class CirculationRulesApiTest extends ApiTests {
-  private String uuid;
 
   public static URL rulesStorageUrl() throws MalformedURLException {
     return rulesStorageUrl("");
@@ -58,7 +57,7 @@ public class CirculationRulesApiTest extends ApiTests {
   /** @return the JSON of the get response, asserts an HTTP_OK=200 response */
   private JsonObject get() throws Exception {
     JsonResponse response = getResponse();
-    assertThat(response.getBody(), response.getStatusCode(), is(HttpURLConnection.HTTP_OK));
+    assertThat(response.getBody(), response, matchesOk());
     return response.getJson();
   }
 
@@ -73,7 +72,7 @@ public class CirculationRulesApiTest extends ApiTests {
   /** @return the message of the put response, asserts an HTTP_OK=200 response */
   private String put204(CirculationRules circulationRules) throws Exception {
     JsonResponse response = putResponse(circulationRules);
-    assertThat(response.getBody(), response.getStatusCode(), is(HttpURLConnection.HTTP_NO_CONTENT));
+    assertThat(response.getBody(), response, matchesNoContent());
     return response.getBody();
   }
 
@@ -92,6 +91,6 @@ public class CirculationRulesApiTest extends ApiTests {
   @Test
   public void putNullFields() throws Exception {
     CirculationRules circulationRules = new CirculationRules();
-    assertThat(putResponse(circulationRules).getStatusCode(), is(HttpStatus.HTTP_UNPROCESSABLE_ENTITY.toInt()));
+    assertThat(putResponse(circulationRules), matchesUnprocessableEntity());
   }
 }

--- a/src/test/java/org/folio/rest/api/FixedDueDateApiTest.java
+++ b/src/test/java/org/folio/rest/api/FixedDueDateApiTest.java
@@ -69,7 +69,6 @@ public class FixedDueDateApiTest extends ApiTests {
     JsonResponse response = createCompleted.get(5, TimeUnit.SECONDS);
     assertThat(String.format("Failed to create due date: %s", response.getBody()),
       response.getStatusCode(), isCreated());
-    //assertThat(response, isOkapiCreated());
     JsonObject representation = response.getJson();
     assertThat(representation.getString("id"), is(id.toString()));
     ////////////////////////////////////

--- a/src/test/java/org/folio/rest/api/FixedDueDateApiTest.java
+++ b/src/test/java/org/folio/rest/api/FixedDueDateApiTest.java
@@ -2,6 +2,8 @@ package org.folio.rest.api;
 
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
+
+import org.folio.HttpStatus;
 import org.folio.rest.support.*;
 import org.hamcrest.junit.MatcherAssert;
 import org.junit.After;
@@ -10,7 +12,6 @@ import org.junit.Ignore;
 import org.junit.Test;
 
 import java.io.UnsupportedEncodingException;
-import java.net.HttpURLConnection;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLEncoder;
@@ -62,7 +63,7 @@ public class FixedDueDateApiTest extends ApiTests {
       ResponseHandler.json(createCompleted));
     JsonResponse response = createCompleted.get(5, TimeUnit.SECONDS);
     assertThat(String.format("Failed to create due date: %s", response.getBody()),
-      response.getStatusCode(), is(HttpURLConnection.HTTP_CREATED));
+      response.getStatusCode(), is(HttpStatus.HTTP_CREATED.toInt()));
     JsonObject representation = response.getJson();
     assertThat(representation.getString("id"), is(id.toString()));
     ////////////////////////////////////
@@ -78,7 +79,7 @@ public class FixedDueDateApiTest extends ApiTests {
       ResponseHandler.empty(updateCompleted));
     Response updateResponse = updateCompleted.get(5, TimeUnit.SECONDS);
     assertThat(String.format("Failed to create due date: %s", representation.encodePrettily()),
-      updateResponse.getStatusCode(), is(HttpURLConnection.HTTP_NO_CONTENT));
+      updateResponse.getStatusCode(), is(HttpStatus.HTTP_NO_CONTENT.toInt()));
     ////////////////////////////////////////////////
 
     //update the fixed due date with a valid schedule
@@ -91,7 +92,7 @@ public class FixedDueDateApiTest extends ApiTests {
       ResponseHandler.empty(updateBad3Completed));
     Response updateBad3Response = updateBad3Completed.get(5, TimeUnit.SECONDS);
     assertThat(String.format("Failed to create due date: %s", representation.encodePrettily()),
-      updateBad3Response.getStatusCode(), is(422));
+      updateBad3Response.getStatusCode(), is(HttpStatus.HTTP_UNPROCESSABLE_ENTITY.toInt()));
     ////////////////////////////////////////////////
 
     //update the fixed due date with an in-valid schedule
@@ -104,7 +105,7 @@ public class FixedDueDateApiTest extends ApiTests {
       ResponseHandler.text(updateBadCompleted));
     TextResponse updateBadResponse = updateBadCompleted.get(5, TimeUnit.SECONDS);
     assertThat(String.format("Failed to create due date: %s", representation.encodePrettily()),
-      updateBadResponse.getStatusCode(), is(422));
+      updateBadResponse.getStatusCode(), is(HttpStatus.HTTP_UNPROCESSABLE_ENTITY.toInt()));
     ////////////////////////////////////////////////
 
     //update the fixed due date with a bad date in schedule
@@ -117,7 +118,7 @@ public class FixedDueDateApiTest extends ApiTests {
       ResponseHandler.text(updateBad2Completed));
     TextResponse updateBad2Response = updateBad2Completed.get(5, TimeUnit.SECONDS);
     assertThat(String.format("Failed to create due date: %s", fixDueDate.encodePrettily()),
-      updateBad2Response.getStatusCode(), is(HttpURLConnection.HTTP_BAD_REQUEST));
+      updateBad2Response.getStatusCode(), is(HttpStatus.HTTP_BAD_REQUEST.toInt()));
     ////////////////////////////////////////////////
 
     //try to create fixed due date without a mandatory name field
@@ -129,7 +130,7 @@ public class FixedDueDateApiTest extends ApiTests {
       ResponseHandler.json(createCompleted2));
     JsonResponse response2 = createCompleted2.get(5, TimeUnit.SECONDS);
     assertThat(String.format("Failed to create due date: %s", response2.getBody()),
-      response2.getStatusCode(), is(422));
+      response2.getStatusCode(), is(HttpStatus.HTTP_UNPROCESSABLE_ENTITY.toInt()));
     ////////////////////////////////////
 
     //create fixed due date without id, server generated
@@ -143,7 +144,7 @@ public class FixedDueDateApiTest extends ApiTests {
       ResponseHandler.json(updateCompleted2));
     JsonResponse updateCompleted2Response = updateCompleted2.get(5, TimeUnit.SECONDS);
     assertThat(String.format("Failed to create due date: %s", fixDueDate3.encodePrettily()),
-      updateCompleted2Response.getStatusCode(), is(422));
+      updateCompleted2Response.getStatusCode(), is(HttpStatus.HTTP_UNPROCESSABLE_ENTITY.toInt()));
     ////////////////////////////////////////////
 
     //create fixed due date without id, server generated
@@ -157,7 +158,7 @@ public class FixedDueDateApiTest extends ApiTests {
       ResponseHandler.json(updateGoodCompleted));
     JsonResponse updateCompleted5Response = updateGoodCompleted.get(5, TimeUnit.SECONDS);
     assertThat(String.format("Failed to create due date: %s", fixDueDate7.encodePrettily()),
-      updateCompleted5Response.getStatusCode(), is(HttpURLConnection.HTTP_CREATED));
+      updateCompleted5Response.getStatusCode(), is(HttpStatus.HTTP_CREATED.toInt()));
     fixDueDate7 = updateCompleted5Response.getJson();
     fixDueDate7.remove("metadata");
     String newId = fixDueDate7.getString("id");
@@ -173,7 +174,7 @@ public class FixedDueDateApiTest extends ApiTests {
       ResponseHandler.empty(updateBad4Completed));
     Response updateBad4Response = updateBad4Completed.get(5, TimeUnit.SECONDS);
     assertThat(String.format("Failed to create due date: %s", fixDueDate7.encodePrettily()),
-      updateBad4Response.getStatusCode(), is(HttpURLConnection.HTTP_NO_CONTENT));
+      updateBad4Response.getStatusCode(), is(HttpStatus.HTTP_NO_CONTENT.toInt()));
     ////////////////////////////////////////////////
 
     //update the fixed due date with a valid schedule
@@ -186,7 +187,7 @@ public class FixedDueDateApiTest extends ApiTests {
       ResponseHandler.empty(updateBad5Completed));
     Response updateBad5Response = updateBad5Completed.get(5, TimeUnit.SECONDS);
     assertThat(String.format("Failed to create due date: %s", fixDueDate7.encodePrettily()),
-      updateBad5Response.getStatusCode(), is(HttpURLConnection.HTTP_NO_CONTENT));
+      updateBad5Response.getStatusCode(), is(HttpStatus.HTTP_NO_CONTENT.toInt()));
     ////////////////////////////////////////////////
 
     //create duplicate name due date
@@ -197,7 +198,7 @@ public class FixedDueDateApiTest extends ApiTests {
       ResponseHandler.json(updateCompleted3));
     JsonResponse updateCompleted3Response = updateCompleted3.get(5, TimeUnit.SECONDS);
     assertThat(String.format("Failed to create due date: %s", fixDueDate4.encodePrettily()),
-      updateCompleted3Response.getStatusCode(), is(HttpURLConnection.HTTP_BAD_REQUEST));
+      updateCompleted3Response.getStatusCode(), is(HttpStatus.HTTP_UNPROCESSABLE_ENTITY.toInt()));
     ////////////////////////////////////////////
 
     //create duplicate name with different case - due date <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
@@ -208,7 +209,7 @@ public class FixedDueDateApiTest extends ApiTests {
       ResponseHandler.json(updateBadCompleted5));
     JsonResponse updateBadCompleted3Response = updateBadCompleted5.get(5, TimeUnit.SECONDS);
     assertThat(String.format("Failed to create due date: %s", fixBadDueDate5.encodePrettily()),
-      updateBadCompleted3Response.getStatusCode(), is(HttpURLConnection.HTTP_BAD_REQUEST));*/
+      updateBadCompleted3Response.getStatusCode(), is(HttpStatus.HTTP_UNPROCESSABLE_ENTITY.toInt()));*/
 
     ////////////////////////////////////////////
     //create and then update with a duplicate name due date
@@ -220,7 +221,7 @@ public class FixedDueDateApiTest extends ApiTests {
     JsonResponse createdCompleted3Response = createCompleted3.get(5, TimeUnit.SECONDS);
     assertThat(String.format("Failed to create due date: %s",
       createdCompleted3Response.getJson().encodePrettily()),
-      createdCompleted3Response.getStatusCode(), is(HttpURLConnection.HTTP_CREATED));
+      createdCompleted3Response.getStatusCode(), is(HttpStatus.HTTP_CREATED.toInt()));
     String newId2 = createdCompleted3Response.getJson().getString("id");
 
     ////////////////////// <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
@@ -231,7 +232,7 @@ public class FixedDueDateApiTest extends ApiTests {
       ResponseHandler.json(updateCompleted4));
     JsonResponse updateCompleted4Response = updateCompleted4.get(5, TimeUnit.SECONDS);
     assertThat(String.format("Failed to create due date: %s", fixDueDate5.encodePrettily()),
-      updateCompleted4Response.getStatusCode(), is(HttpURLConnection.HTTP_BAD_REQUEST));*/
+      updateCompleted4Response.getStatusCode(), is(HttpStatus.HTTP_UNPROCESSABLE_ENTITY.toInt()));*/
 
     ////////////////////////////////////////////
     //get with non-existing field now returns 200 / OK
@@ -243,7 +244,7 @@ public class FixedDueDateApiTest extends ApiTests {
     JsonResponse getCQLResponse2 = getCQLCompleted2.get(5, TimeUnit.SECONDS);
 
     assertThat(String.format("Failed to get schedule: %s", getCQLResponse2.getJson().encodePrettily()),
-      getCQLResponse2.getStatusCode(), is(200));
+      getCQLResponse2.getStatusCode(), is(HttpStatus.HTTP_OK.toInt()));
     //////////////////////////////////////////////////////////
 
     //// get by id ///////////////////////
@@ -252,7 +253,7 @@ public class FixedDueDateApiTest extends ApiTests {
       ResponseHandler.json(getCompleted4));
     JsonResponse getCompleted4Response = getCompleted4.get(5, TimeUnit.SECONDS);
     assertThat(String.format("Failed to create due date: %s", getCompleted4Response.getJson().encodePrettily()),
-      getCompleted4Response.getStatusCode(), is(HttpURLConnection.HTTP_OK));
+      getCompleted4Response.getStatusCode(), is(HttpStatus.HTTP_OK.toInt()));
     assertThat(getCompleted4Response.getJson().getString("name"), is("semester2"));
 
     //// delete by id ///////////////////////
@@ -261,7 +262,7 @@ public class FixedDueDateApiTest extends ApiTests {
       ResponseHandler.empty(delCompleted));
     Response delCompleted4Response = delCompleted.get(5, TimeUnit.SECONDS);
     assertThat(String.format("Failed to create due date: %s", dueDateURL("/"+newId2)),
-      delCompleted4Response.getStatusCode(), is(HttpURLConnection.HTTP_NO_CONTENT));
+      delCompleted4Response.getStatusCode(), is(HttpStatus.HTTP_NO_CONTENT.toInt()));
 
     //// get by bad id ///////////////////////
     CompletableFuture<TextResponse> getCompleted5 = new CompletableFuture<>();
@@ -269,7 +270,7 @@ public class FixedDueDateApiTest extends ApiTests {
       ResponseHandler.text(getCompleted5));
     TextResponse getCompleted5Response = getCompleted5.get(5, TimeUnit.SECONDS);
     assertThat(String.format("Failed to create due date: %s", getCompleted5Response.getBody()),
-      getCompleted5Response.getStatusCode(), is(HttpURLConnection.HTTP_NOT_FOUND));
+      getCompleted5Response.getStatusCode(), is(HttpStatus.HTTP_NOT_FOUND.toInt()));
     System.out.println(dueDateURL("/12345") + " " + getCompleted5Response.getBody());
 
 
@@ -279,7 +280,7 @@ public class FixedDueDateApiTest extends ApiTests {
       ResponseHandler.text(delCompleted5));
     TextResponse delCompleted5Response = delCompleted5.get(5, TimeUnit.SECONDS);
     assertThat(String.format("Failed to create due date: %s", delCompleted5Response.getBody()),
-      delCompleted5Response.getStatusCode(), is(HttpURLConnection.HTTP_NOT_FOUND));
+      delCompleted5Response.getStatusCode(), is(HttpStatus.HTTP_NOT_FOUND.toInt()));
     System.out.println(dueDateURL("/12345") + " " + delCompleted5Response.getBody());
 */
 
@@ -291,7 +292,7 @@ public class FixedDueDateApiTest extends ApiTests {
       ResponseHandler.text(updateBadCompleted4));
     TextResponse updateBadCompleted4Response = updateBadCompleted4.get(5, TimeUnit.SECONDS);
     assertThat(String.format("Failed to create due date: %s", updateDueDate5.encodePrettily()),
-      updateBadCompleted4Response.getStatusCode(), is(422));
+      updateBadCompleted4Response.getStatusCode(), is(HttpStatus.HTTP_UNPROCESSABLE_ENTITY.toInt()));
 
     //// get , should have 2 records ///////////////////////
     CompletableFuture<JsonResponse> get2Completed = new CompletableFuture<>();
@@ -299,7 +300,7 @@ public class FixedDueDateApiTest extends ApiTests {
       ResponseHandler.json(get2Completed));
     JsonResponse get2CompletedResponse = get2Completed.get(5, TimeUnit.SECONDS);
     assertThat(String.format("Failed to create due date: %s", get2CompletedResponse.getJson().encodePrettily()),
-      get2CompletedResponse.getStatusCode(), is(HttpURLConnection.HTTP_OK));
+      get2CompletedResponse.getStatusCode(), is(HttpStatus.HTTP_OK.toInt()));
     assertThat(get2CompletedResponse.getJson().getJsonArray("fixedDueDateSchedules").size(), is(2));
 
     //// try to delete all fdds (uses cascade so will succeed) ///////////////////////
@@ -308,7 +309,7 @@ public class FixedDueDateApiTest extends ApiTests {
       ResponseHandler.empty(delAllCompleted));
     Response delAllCompleted4Response = delAllCompleted.get(5, TimeUnit.SECONDS);
     assertThat(String.format("Failed to delete due date: %s", dueDateURL()),
-      delAllCompleted4Response.getStatusCode(), is(204));
+      delAllCompleted4Response.getStatusCode(), is(HttpStatus.HTTP_NO_CONTENT.toInt()));
     ////////////////////////////////////////////////////////
 
     //// get , should have 0 records ///////////////////////
@@ -317,7 +318,7 @@ public class FixedDueDateApiTest extends ApiTests {
       ResponseHandler.json(get3Completed));
     JsonResponse get3CompletedResponse = get3Completed.get(5, TimeUnit.SECONDS);
     assertThat(String.format("Failed to get due date: %s", get3CompletedResponse.getJson().encodePrettily()),
-      get3CompletedResponse.getStatusCode(), is(HttpURLConnection.HTTP_OK));
+      get3CompletedResponse.getStatusCode(), is(HttpStatus.HTTP_OK.toInt()));
     assertThat(get3CompletedResponse.getJson().getJsonArray("fixedDueDateSchedules").size(), is(0));
   }
 
@@ -346,7 +347,7 @@ public class FixedDueDateApiTest extends ApiTests {
 
     assertThat(String.format("Failed to get fixed due date schedules: %s",
       getResponse.getJson().encodePrettily()),
-      getResponse.getStatusCode(), is(HttpURLConnection.HTTP_OK));
+      getResponse.getStatusCode(), is(HttpStatus.HTTP_OK.toInt()));
 
     List<JsonObject> results = JsonArrayHelper.toList(getResponse.getJson()
       .getJsonArray("fixedDueDateSchedules"));
@@ -383,7 +384,7 @@ public class FixedDueDateApiTest extends ApiTests {
 
     assertThat(String.format("Failed to get fixed due date schedules: %s",
       getResponse.getJson().encodePrettily()),
-      getResponse.getStatusCode(), is(HttpURLConnection.HTTP_OK));
+      getResponse.getStatusCode(), is(HttpStatus.HTTP_OK.toInt()));
 
     List<JsonObject> results = JsonArrayHelper.toList(getResponse.getJson()
       .getJsonArray("fixedDueDateSchedules"));
@@ -421,7 +422,7 @@ public class FixedDueDateApiTest extends ApiTests {
 
     assertThat(String.format("Failed to get fixed due date schedules: %s",
       getResponse.getJson().encodePrettily()),
-      getResponse.getStatusCode(), is(HttpURLConnection.HTTP_OK));
+      getResponse.getStatusCode(), is(HttpStatus.HTTP_OK.toInt()));
 
     List<JsonObject> results = JsonArrayHelper.toList(getResponse.getJson()
       .getJsonArray("fixedDueDateSchedules"));
@@ -501,7 +502,7 @@ public class FixedDueDateApiTest extends ApiTests {
     JsonResponse response = createCompleted.get(5, TimeUnit.SECONDS);
 
     MatcherAssert.assertThat(String.format("Failed to create fixed due date: %s", response.getBody()),
-      response.getStatusCode(), is(HttpURLConnection.HTTP_CREATED));
+      response.getStatusCode(), is(HttpStatus.HTTP_CREATED.toInt()));
 
     return new IndividualResource(response);
   }

--- a/src/test/java/org/folio/rest/api/FixedDueDateApiTest.java
+++ b/src/test/java/org/folio/rest/api/FixedDueDateApiTest.java
@@ -3,7 +3,6 @@ package org.folio.rest.api;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 
-import org.folio.HttpStatus;
 import org.folio.rest.support.*;
 import org.hamcrest.junit.MatcherAssert;
 import org.junit.After;
@@ -22,6 +21,12 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
+import static org.folio.rest.support.matchers.OkapiResponseStatusCodeMatchers.isBadRequest;
+import static org.folio.rest.support.matchers.OkapiResponseStatusCodeMatchers.isCreated;
+import static org.folio.rest.support.matchers.OkapiResponseStatusCodeMatchers.isNoContent;
+import static org.folio.rest.support.matchers.OkapiResponseStatusCodeMatchers.isNotFound;
+import static org.folio.rest.support.matchers.OkapiResponseStatusCodeMatchers.isOk;
+import static org.folio.rest.support.matchers.OkapiResponseStatusCodeMatchers.isUnprocessableEntity;
 import static org.folio.rest.api.LoanPoliciesApiTest.loanPolicyStorageUrl;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
@@ -63,7 +68,8 @@ public class FixedDueDateApiTest extends ApiTests {
       ResponseHandler.json(createCompleted));
     JsonResponse response = createCompleted.get(5, TimeUnit.SECONDS);
     assertThat(String.format("Failed to create due date: %s", response.getBody()),
-      response.getStatusCode(), is(HttpStatus.HTTP_CREATED.toInt()));
+      response.getStatusCode(), isCreated());
+    //assertThat(response, isOkapiCreated());
     JsonObject representation = response.getJson();
     assertThat(representation.getString("id"), is(id.toString()));
     ////////////////////////////////////
@@ -79,7 +85,7 @@ public class FixedDueDateApiTest extends ApiTests {
       ResponseHandler.empty(updateCompleted));
     Response updateResponse = updateCompleted.get(5, TimeUnit.SECONDS);
     assertThat(String.format("Failed to create due date: %s", representation.encodePrettily()),
-      updateResponse.getStatusCode(), is(HttpStatus.HTTP_NO_CONTENT.toInt()));
+      updateResponse.getStatusCode(), isNoContent());
     ////////////////////////////////////////////////
 
     //update the fixed due date with a valid schedule
@@ -92,7 +98,7 @@ public class FixedDueDateApiTest extends ApiTests {
       ResponseHandler.empty(updateBad3Completed));
     Response updateBad3Response = updateBad3Completed.get(5, TimeUnit.SECONDS);
     assertThat(String.format("Failed to create due date: %s", representation.encodePrettily()),
-      updateBad3Response.getStatusCode(), is(HttpStatus.HTTP_UNPROCESSABLE_ENTITY.toInt()));
+      updateBad3Response.getStatusCode(), isUnprocessableEntity());
     ////////////////////////////////////////////////
 
     //update the fixed due date with an in-valid schedule
@@ -105,7 +111,7 @@ public class FixedDueDateApiTest extends ApiTests {
       ResponseHandler.text(updateBadCompleted));
     TextResponse updateBadResponse = updateBadCompleted.get(5, TimeUnit.SECONDS);
     assertThat(String.format("Failed to create due date: %s", representation.encodePrettily()),
-      updateBadResponse.getStatusCode(), is(HttpStatus.HTTP_UNPROCESSABLE_ENTITY.toInt()));
+      updateBadResponse.getStatusCode(), isUnprocessableEntity());
     ////////////////////////////////////////////////
 
     //update the fixed due date with a bad date in schedule
@@ -118,7 +124,7 @@ public class FixedDueDateApiTest extends ApiTests {
       ResponseHandler.text(updateBad2Completed));
     TextResponse updateBad2Response = updateBad2Completed.get(5, TimeUnit.SECONDS);
     assertThat(String.format("Failed to create due date: %s", fixDueDate.encodePrettily()),
-      updateBad2Response.getStatusCode(), is(HttpStatus.HTTP_BAD_REQUEST.toInt()));
+      updateBad2Response.getStatusCode(), isBadRequest());
     ////////////////////////////////////////////////
 
     //try to create fixed due date without a mandatory name field
@@ -130,7 +136,7 @@ public class FixedDueDateApiTest extends ApiTests {
       ResponseHandler.json(createCompleted2));
     JsonResponse response2 = createCompleted2.get(5, TimeUnit.SECONDS);
     assertThat(String.format("Failed to create due date: %s", response2.getBody()),
-      response2.getStatusCode(), is(HttpStatus.HTTP_UNPROCESSABLE_ENTITY.toInt()));
+      response2.getStatusCode(), isUnprocessableEntity());
     ////////////////////////////////////
 
     //create fixed due date without id, server generated
@@ -144,7 +150,7 @@ public class FixedDueDateApiTest extends ApiTests {
       ResponseHandler.json(updateCompleted2));
     JsonResponse updateCompleted2Response = updateCompleted2.get(5, TimeUnit.SECONDS);
     assertThat(String.format("Failed to create due date: %s", fixDueDate3.encodePrettily()),
-      updateCompleted2Response.getStatusCode(), is(HttpStatus.HTTP_UNPROCESSABLE_ENTITY.toInt()));
+      updateCompleted2Response.getStatusCode(), isUnprocessableEntity());
     ////////////////////////////////////////////
 
     //create fixed due date without id, server generated
@@ -158,7 +164,7 @@ public class FixedDueDateApiTest extends ApiTests {
       ResponseHandler.json(updateGoodCompleted));
     JsonResponse updateCompleted5Response = updateGoodCompleted.get(5, TimeUnit.SECONDS);
     assertThat(String.format("Failed to create due date: %s", fixDueDate7.encodePrettily()),
-      updateCompleted5Response.getStatusCode(), is(HttpStatus.HTTP_CREATED.toInt()));
+      updateCompleted5Response.getStatusCode(), isCreated());
     fixDueDate7 = updateCompleted5Response.getJson();
     fixDueDate7.remove("metadata");
     String newId = fixDueDate7.getString("id");
@@ -174,7 +180,7 @@ public class FixedDueDateApiTest extends ApiTests {
       ResponseHandler.empty(updateBad4Completed));
     Response updateBad4Response = updateBad4Completed.get(5, TimeUnit.SECONDS);
     assertThat(String.format("Failed to create due date: %s", fixDueDate7.encodePrettily()),
-      updateBad4Response.getStatusCode(), is(HttpStatus.HTTP_NO_CONTENT.toInt()));
+      updateBad4Response.getStatusCode(), isNoContent());
     ////////////////////////////////////////////////
 
     //update the fixed due date with a valid schedule
@@ -187,7 +193,7 @@ public class FixedDueDateApiTest extends ApiTests {
       ResponseHandler.empty(updateBad5Completed));
     Response updateBad5Response = updateBad5Completed.get(5, TimeUnit.SECONDS);
     assertThat(String.format("Failed to create due date: %s", fixDueDate7.encodePrettily()),
-      updateBad5Response.getStatusCode(), is(HttpStatus.HTTP_NO_CONTENT.toInt()));
+      updateBad5Response.getStatusCode(), isNoContent());
     ////////////////////////////////////////////////
 
     //create duplicate name due date
@@ -198,18 +204,8 @@ public class FixedDueDateApiTest extends ApiTests {
       ResponseHandler.json(updateCompleted3));
     JsonResponse updateCompleted3Response = updateCompleted3.get(5, TimeUnit.SECONDS);
     assertThat(String.format("Failed to create due date: %s", fixDueDate4.encodePrettily()),
-      updateCompleted3Response.getStatusCode(), is(HttpStatus.HTTP_UNPROCESSABLE_ENTITY.toInt()));
+      updateCompleted3Response.getStatusCode(), isUnprocessableEntity());
     ////////////////////////////////////////////
-
-    //create duplicate name with different case - due date <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
-/*    CompletableFuture<JsonResponse> updateBadCompleted5 = new CompletableFuture<>();
-    JsonObject fixBadDueDate5 = createFixedDueDate(null, "semester", "desc2");
-    client.post(dueDateURL(),
-      fixBadDueDate5, StorageTestSuite.TENANT_ID,
-      ResponseHandler.json(updateBadCompleted5));
-    JsonResponse updateBadCompleted3Response = updateBadCompleted5.get(5, TimeUnit.SECONDS);
-    assertThat(String.format("Failed to create due date: %s", fixBadDueDate5.encodePrettily()),
-      updateBadCompleted3Response.getStatusCode(), is(HttpStatus.HTTP_UNPROCESSABLE_ENTITY.toInt()));*/
 
     ////////////////////////////////////////////
     //create and then update with a duplicate name due date
@@ -221,18 +217,8 @@ public class FixedDueDateApiTest extends ApiTests {
     JsonResponse createdCompleted3Response = createCompleted3.get(5, TimeUnit.SECONDS);
     assertThat(String.format("Failed to create due date: %s",
       createdCompleted3Response.getJson().encodePrettily()),
-      createdCompleted3Response.getStatusCode(), is(HttpStatus.HTTP_CREATED.toInt()));
+      createdCompleted3Response.getStatusCode(), isCreated());
     String newId2 = createdCompleted3Response.getJson().getString("id");
-
-    ////////////////////// <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
-/*    CompletableFuture<JsonResponse> updateCompleted4 = new CompletableFuture<>();
-    JsonObject fixDueDate5 = createFixedDueDate(newId2, "Semester", "desc2");
-    client.put(dueDateURL("/"+newId2),
-      fixDueDate5, StorageTestSuite.TENANT_ID,
-      ResponseHandler.json(updateCompleted4));
-    JsonResponse updateCompleted4Response = updateCompleted4.get(5, TimeUnit.SECONDS);
-    assertThat(String.format("Failed to create due date: %s", fixDueDate5.encodePrettily()),
-      updateCompleted4Response.getStatusCode(), is(HttpStatus.HTTP_UNPROCESSABLE_ENTITY.toInt()));*/
 
     ////////////////////////////////////////////
     //get with non-existing field now returns 200 / OK
@@ -244,7 +230,7 @@ public class FixedDueDateApiTest extends ApiTests {
     JsonResponse getCQLResponse2 = getCQLCompleted2.get(5, TimeUnit.SECONDS);
 
     assertThat(String.format("Failed to get schedule: %s", getCQLResponse2.getJson().encodePrettily()),
-      getCQLResponse2.getStatusCode(), is(HttpStatus.HTTP_OK.toInt()));
+      getCQLResponse2.getStatusCode(), isOk());
     //////////////////////////////////////////////////////////
 
     //// get by id ///////////////////////
@@ -253,7 +239,7 @@ public class FixedDueDateApiTest extends ApiTests {
       ResponseHandler.json(getCompleted4));
     JsonResponse getCompleted4Response = getCompleted4.get(5, TimeUnit.SECONDS);
     assertThat(String.format("Failed to create due date: %s", getCompleted4Response.getJson().encodePrettily()),
-      getCompleted4Response.getStatusCode(), is(HttpStatus.HTTP_OK.toInt()));
+      getCompleted4Response.getStatusCode(), isOk());
     assertThat(getCompleted4Response.getJson().getString("name"), is("semester2"));
 
     //// delete by id ///////////////////////
@@ -262,7 +248,7 @@ public class FixedDueDateApiTest extends ApiTests {
       ResponseHandler.empty(delCompleted));
     Response delCompleted4Response = delCompleted.get(5, TimeUnit.SECONDS);
     assertThat(String.format("Failed to create due date: %s", dueDateURL("/"+newId2)),
-      delCompleted4Response.getStatusCode(), is(HttpStatus.HTTP_NO_CONTENT.toInt()));
+      delCompleted4Response.getStatusCode(), isNoContent());
 
     //// get by bad id ///////////////////////
     CompletableFuture<TextResponse> getCompleted5 = new CompletableFuture<>();
@@ -270,19 +256,8 @@ public class FixedDueDateApiTest extends ApiTests {
       ResponseHandler.text(getCompleted5));
     TextResponse getCompleted5Response = getCompleted5.get(5, TimeUnit.SECONDS);
     assertThat(String.format("Failed to create due date: %s", getCompleted5Response.getBody()),
-      getCompleted5Response.getStatusCode(), is(HttpStatus.HTTP_NOT_FOUND.toInt()));
+      getCompleted5Response.getStatusCode(), isNotFound());
     System.out.println(dueDateURL("/12345") + " " + getCompleted5Response.getBody());
-
-
-    //// delete by bad id /////////////////////// <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
-/*    CompletableFuture<TextResponse> delCompleted5 = new CompletableFuture<>();
-    client.delete(dueDateURL("/12345"), StorageTestSuite.TENANT_ID,
-      ResponseHandler.text(delCompleted5));
-    TextResponse delCompleted5Response = delCompleted5.get(5, TimeUnit.SECONDS);
-    assertThat(String.format("Failed to create due date: %s", delCompleted5Response.getBody()),
-      delCompleted5Response.getStatusCode(), is(HttpStatus.HTTP_NOT_FOUND.toInt()));
-    System.out.println(dueDateURL("/12345") + " " + delCompleted5Response.getBody());
-*/
 
     //update by bad id
     CompletableFuture<TextResponse> updateBadCompleted4 = new CompletableFuture<>();
@@ -292,7 +267,7 @@ public class FixedDueDateApiTest extends ApiTests {
       ResponseHandler.text(updateBadCompleted4));
     TextResponse updateBadCompleted4Response = updateBadCompleted4.get(5, TimeUnit.SECONDS);
     assertThat(String.format("Failed to create due date: %s", updateDueDate5.encodePrettily()),
-      updateBadCompleted4Response.getStatusCode(), is(HttpStatus.HTTP_UNPROCESSABLE_ENTITY.toInt()));
+      updateBadCompleted4Response.getStatusCode(), isUnprocessableEntity());
 
     //// get , should have 2 records ///////////////////////
     CompletableFuture<JsonResponse> get2Completed = new CompletableFuture<>();
@@ -300,7 +275,7 @@ public class FixedDueDateApiTest extends ApiTests {
       ResponseHandler.json(get2Completed));
     JsonResponse get2CompletedResponse = get2Completed.get(5, TimeUnit.SECONDS);
     assertThat(String.format("Failed to create due date: %s", get2CompletedResponse.getJson().encodePrettily()),
-      get2CompletedResponse.getStatusCode(), is(HttpStatus.HTTP_OK.toInt()));
+      get2CompletedResponse.getStatusCode(), isOk());
     assertThat(get2CompletedResponse.getJson().getJsonArray("fixedDueDateSchedules").size(), is(2));
 
     //// try to delete all fdds (uses cascade so will succeed) ///////////////////////
@@ -309,7 +284,7 @@ public class FixedDueDateApiTest extends ApiTests {
       ResponseHandler.empty(delAllCompleted));
     Response delAllCompleted4Response = delAllCompleted.get(5, TimeUnit.SECONDS);
     assertThat(String.format("Failed to delete due date: %s", dueDateURL()),
-      delAllCompleted4Response.getStatusCode(), is(HttpStatus.HTTP_NO_CONTENT.toInt()));
+      delAllCompleted4Response.getStatusCode(), isNoContent());
     ////////////////////////////////////////////////////////
 
     //// get , should have 0 records ///////////////////////
@@ -318,7 +293,7 @@ public class FixedDueDateApiTest extends ApiTests {
       ResponseHandler.json(get3Completed));
     JsonResponse get3CompletedResponse = get3Completed.get(5, TimeUnit.SECONDS);
     assertThat(String.format("Failed to get due date: %s", get3CompletedResponse.getJson().encodePrettily()),
-      get3CompletedResponse.getStatusCode(), is(HttpStatus.HTTP_OK.toInt()));
+      get3CompletedResponse.getStatusCode(), isOk());
     assertThat(get3CompletedResponse.getJson().getJsonArray("fixedDueDateSchedules").size(), is(0));
   }
 
@@ -347,7 +322,7 @@ public class FixedDueDateApiTest extends ApiTests {
 
     assertThat(String.format("Failed to get fixed due date schedules: %s",
       getResponse.getJson().encodePrettily()),
-      getResponse.getStatusCode(), is(HttpStatus.HTTP_OK.toInt()));
+      getResponse.getStatusCode(), isOk());
 
     List<JsonObject> results = JsonArrayHelper.toList(getResponse.getJson()
       .getJsonArray("fixedDueDateSchedules"));
@@ -384,7 +359,7 @@ public class FixedDueDateApiTest extends ApiTests {
 
     assertThat(String.format("Failed to get fixed due date schedules: %s",
       getResponse.getJson().encodePrettily()),
-      getResponse.getStatusCode(), is(HttpStatus.HTTP_OK.toInt()));
+      getResponse.getStatusCode(), isOk());
 
     List<JsonObject> results = JsonArrayHelper.toList(getResponse.getJson()
       .getJsonArray("fixedDueDateSchedules"));
@@ -422,7 +397,7 @@ public class FixedDueDateApiTest extends ApiTests {
 
     assertThat(String.format("Failed to get fixed due date schedules: %s",
       getResponse.getJson().encodePrettily()),
-      getResponse.getStatusCode(), is(HttpStatus.HTTP_OK.toInt()));
+      getResponse.getStatusCode(), isOk());
 
     List<JsonObject> results = JsonArrayHelper.toList(getResponse.getJson()
       .getJsonArray("fixedDueDateSchedules"));
@@ -502,7 +477,7 @@ public class FixedDueDateApiTest extends ApiTests {
     JsonResponse response = createCompleted.get(5, TimeUnit.SECONDS);
 
     MatcherAssert.assertThat(String.format("Failed to create fixed due date: %s", response.getBody()),
-      response.getStatusCode(), is(HttpStatus.HTTP_CREATED.toInt()));
+      response.getStatusCode(), isCreated());
 
     return new IndividualResource(response);
   }

--- a/src/test/java/org/folio/rest/api/LoanPoliciesApiTest.java
+++ b/src/test/java/org/folio/rest/api/LoanPoliciesApiTest.java
@@ -3,6 +3,7 @@ package org.folio.rest.api;
 import static org.folio.rest.support.builders.LoanPolicyRequestBuilder.defaultRollingPolicy;
 import static org.folio.rest.support.builders.LoanPolicyRequestBuilder.emptyPolicy;
 import static org.folio.rest.support.matchers.HttpResponseStatusCodeMatchers.isBadRequest;
+import static org.folio.rest.support.matchers.HttpResponseStatusCodeMatchers.isUnprocessableEntity;
 import static org.folio.rest.support.matchers.periodJsonObjectMatcher.matchesPeriod;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
@@ -123,7 +124,7 @@ public class LoanPoliciesApiTest extends ApiTests {
       badLoanPolicyRequest, StorageTestSuite.TENANT_ID,
       ResponseHandler.json(createBadLPCompleted));
     JsonResponse badlpResponse = createBadLPCompleted.get(5, TimeUnit.SECONDS);
-    assertThat(String.format("Non-existent foreign key: %s", badlpResponse.getBody()), badlpResponse, isBadRequest());
+    assertThat(String.format("Non-existent foreign key: %s", badlpResponse.getBody()), badlpResponse, isUnprocessableEntity());
     //////////////////////////////////////////
 
     ///////////bad foreign key
@@ -140,7 +141,7 @@ public class LoanPoliciesApiTest extends ApiTests {
       bad2LoanPolicyRequest, StorageTestSuite.TENANT_ID,
       ResponseHandler.json(createBadLP2Completed));
     JsonResponse badlpResponse2 = createBadLP2Completed.get(5, TimeUnit.SECONDS);
-    assertThat("Bad foreign key", badlpResponse2, isBadRequest());
+    assertThat("Bad foreign key", badlpResponse2, isUnprocessableEntity());
     //////////////////////////////////////////
 
     id2 = UUID.randomUUID();

--- a/src/test/java/org/folio/rest/api/LoanPoliciesApiTest.java
+++ b/src/test/java/org/folio/rest/api/LoanPoliciesApiTest.java
@@ -311,7 +311,7 @@ public class LoanPoliciesApiTest extends ApiTests {
     JsonResponse response = createCompleted.get(5, TimeUnit.SECONDS);
 
     assertThat(String.format("Should fail to create loan policy: %s", response.getBody()),
-      response.getStatusCode(), is(HttpStatus.HTTP_VALIDATION_ERROR.toInt()));
+      response.getStatusCode(), is(HttpStatus.HTTP_UNPROCESSABLE_ENTITY.toInt()));
   }
 
   @Test
@@ -370,7 +370,7 @@ public class LoanPoliciesApiTest extends ApiTests {
     JsonResponse response = createCompleted.get(5, TimeUnit.SECONDS);
 
     assertThat(String.format("Should fail to create loan policy: %s", response.getBody()),
-      response.getStatusCode(), is(HttpStatus.HTTP_VALIDATION_ERROR.toInt()));
+      response.getStatusCode(), is(HttpStatus.HTTP_UNPROCESSABLE_ENTITY.toInt()));
 
     JsonObject error = getErrorFromResponse(response);
     JsonObject parameters = error.getJsonArray("parameters").getJsonObject(0);
@@ -406,7 +406,7 @@ public class LoanPoliciesApiTest extends ApiTests {
     JsonResponse response = createCompleted.get(5, TimeUnit.SECONDS);
 
     assertThat(String.format("Should fail to create loan policy: %s", response.getBody()),
-      response.getStatusCode(), is(HttpStatus.HTTP_VALIDATION_ERROR.toInt()));
+      response.getStatusCode(), is(HttpStatus.HTTP_UNPROCESSABLE_ENTITY.toInt()));
 
     JsonObject error = getErrorFromResponse(response);
     JsonObject parameters = error.getJsonArray("parameters").getJsonObject(0);

--- a/src/test/java/org/folio/rest/api/LoansApiTest.java
+++ b/src/test/java/org/folio/rest/api/LoansApiTest.java
@@ -1219,7 +1219,10 @@ public class LoansApiTest extends ApiTests {
     JsonResponse response4 = get2.get(5, TimeUnit.SECONDS);
 
     assertThat("Metadata section not populated correctly " + id2.toString(),
-      response4.getJson().getJsonObject("metadata"), is(nullValue()));
+      response4.getJson().getJsonObject("metadata"), not(nullValue()));
+
+    assertThat("Metadata section requires createdDate property " + id2.toString(),
+      response4.getJson().getJsonObject("metadata").containsKey("createdDate"), not(nullValue()));
 
     ///////////////post loan//////////////////////
     client.post(InterfaceUrls.loanStorageUrl(), j3, StorageTestSuite.TENANT_ID,

--- a/src/test/java/org/folio/rest/api/RequestBatchAPITest.java
+++ b/src/test/java/org/folio/rest/api/RequestBatchAPITest.java
@@ -28,10 +28,13 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
+import io.vertx.core.AsyncResult;
 import io.vertx.core.Handler;
+import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.HttpClientResponse;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
+import io.vertx.ext.web.client.HttpResponse;
 
 public class RequestBatchAPITest extends ApiTests {
 
@@ -228,7 +231,7 @@ public class RequestBatchAPITest extends ApiTests {
   }
 
   private <T> T attemptReorderRequests(
-    Function<CompletableFuture<T>, Handler<HttpClientResponse>> bodyHandler,
+    Function<CompletableFuture<T>, Handler<AsyncResult<HttpResponse<Buffer>>>> bodyHandler,
     ReorderRequest... requests) throws Exception {
 
     JsonObject[] requestsToReorder = Arrays.stream(requests)

--- a/src/test/java/org/folio/rest/api/RequestPreferencesApiTest.java
+++ b/src/test/java/org/folio/rest/api/RequestPreferencesApiTest.java
@@ -67,7 +67,7 @@ public class RequestPreferencesApiTest extends ApiTests {
 
     JsonResponse response2 = createRequestPreference();
     assertThat(response2, isUnprocessableEntity());
-    assertThat(response2.getJson().toString(), containsString(" value already exists in table "));
+    assertThat(response2.getJson().toString(), containsString("Request preference for specified user already exists"));
   }
 
   @Test
@@ -140,7 +140,7 @@ public class RequestPreferencesApiTest extends ApiTests {
     RequestPreference preference = createRequestPreference().getJson().mapTo(RequestPreference.class);
     preference.setDelivery(false);
     preference.setDefaultDeliveryAddressTypeId(null);
-    JsonResponse response = udpatePreference(preference);
+    JsonResponse response = updatePreference(preference);
     assertThat(response, isNoContent());
 
     RequestPreference updatedPreference = getPreference(preference.getId()).getJson().mapTo(RequestPreference.class);
@@ -150,7 +150,7 @@ public class RequestPreferencesApiTest extends ApiTests {
   @Test
   public void cannotUpdateRequestPreferenceWithNotExistingId() {
     RequestPreference preference = constructDefaultPreference(USER_ID).withId(UUID.randomUUID().toString());
-    JsonResponse response = udpatePreference(preference);
+    JsonResponse response = updatePreference(preference);
     assertThat(response, isNotFound());
   }
 
@@ -159,15 +159,15 @@ public class RequestPreferencesApiTest extends ApiTests {
     createRequestPreference(USER_ID);
     RequestPreference secondPreference = createRequestPreference(USER_ID2).getJson().mapTo(RequestPreference.class);
 
-    JsonResponse response = udpatePreference(constructDefaultPreference(USER_ID).withId(secondPreference.getId()));
+    JsonResponse response = updatePreference(constructDefaultPreference(USER_ID).withId(secondPreference.getId()));
     assertThat(response, isUnprocessableEntity());
-    assertThat(response.getJson().toString(), containsString(" value already exists in table "));
+    assertThat(response.getJson().toString(), containsString("Request preference for specified user already exists"));
   }
 
   @Test
   public void cannotUpdateRequestPreferenceWithInvalidId() {
     RequestPreference preference = constructDefaultPreference(USER_ID).withId("invalid_id");
-    JsonResponse response = udpatePreference(preference);
+    JsonResponse response = updatePreference(preference);
     assertThat(response, isUnprocessableEntity());
   }
 
@@ -197,7 +197,7 @@ public class RequestPreferencesApiTest extends ApiTests {
     return getFromFuture(getCompleted);
   }
 
-  private JsonResponse udpatePreference(RequestPreference preference) {
+  private JsonResponse updatePreference(RequestPreference preference) {
     CompletableFuture<JsonResponse> getCompleted = new CompletableFuture<>();
     client.put(requestPreferenceStorageUrl("/" + preference.getId()), preference, StorageTestSuite.TENANT_ID,
       ResponseHandler.json(getCompleted));

--- a/src/test/java/org/folio/rest/api/RequestPreferencesApiTest.java
+++ b/src/test/java/org/folio/rest/api/RequestPreferencesApiTest.java
@@ -67,7 +67,7 @@ public class RequestPreferencesApiTest extends ApiTests {
 
     JsonResponse response2 = createRequestPreference();
     assertThat(response2, isUnprocessableEntity());
-    assertThat(response2.getJson().toString(), containsString("Request preference for specified user already exists"));
+    assertThat(response2.getJson().toString(), containsString(" value already exists in table "));
   }
 
   @Test
@@ -161,7 +161,7 @@ public class RequestPreferencesApiTest extends ApiTests {
 
     JsonResponse response = udpatePreference(constructDefaultPreference(USER_ID).withId(secondPreference.getId()));
     assertThat(response, isUnprocessableEntity());
-    assertThat(response.getJson().toString(), containsString("Request preference for specified user already exists"));
+    assertThat(response.getJson().toString(), containsString(" value already exists in table "));
   }
 
   @Test

--- a/src/test/java/org/folio/rest/api/RequestUpdateTriggerTest.java
+++ b/src/test/java/org/folio/rest/api/RequestUpdateTriggerTest.java
@@ -18,6 +18,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
 import io.vertx.core.Future;
+import io.vertx.core.Promise;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.sql.UpdateResult;
 
@@ -119,25 +120,25 @@ class RequestUpdateTriggerTest {
 
   private Future<Void> saveRequest(String id, Request request) {
 
-    Future<String> future = Future.future();
-    pgClient.save(REQUEST_TABLE, id, request, future.completer());
+    Promise<String> promise = Promise.promise();
+    pgClient.save(REQUEST_TABLE, id, request, promise.future());
 
-    return future.map(s -> null);
+    return promise.future().map(s -> null);
   }
 
   private Future<Void> updateRequest(String id, Request request) {
 
-    Future<UpdateResult> future = Future.future();
-    pgClient.update(REQUEST_TABLE, request, id, future.completer());
+    Promise<UpdateResult> promise = Promise.promise();
+    pgClient.update(REQUEST_TABLE, request, id, promise.future());
 
-    return future.map(ur -> null);
+    return promise.future().map(ur -> null);
   }
 
   private Future<JsonObject> getRequest(String id) {
 
-    Future<JsonObject> future = Future.future();
-    pgClient.getById(REQUEST_TABLE, id, future.completer());
+    Promise<JsonObject> promise = Promise.promise();
+    pgClient.getById(REQUEST_TABLE, id, promise.future());
 
-    return future;
+    return promise.future();
   }
 }

--- a/src/test/java/org/folio/rest/api/RequestsApiTest.java
+++ b/src/test/java/org/folio/rest/api/RequestsApiTest.java
@@ -22,7 +22,6 @@ import static org.folio.rest.support.builders.RequestRequestBuilder.OPEN_NOT_YET
 import static org.folio.rest.support.matchers.TextDateTimeMatcher.equivalentTo;
 import static org.folio.rest.support.matchers.TextDateTimeMatcher.withinSecondsAfter;
 import static org.folio.rest.support.matchers.ValidationErrorMatchers.hasMessage;
-import static org.folio.rest.support.matchers.ValidationErrorMatchers.hasMessageContaining;
 import static org.folio.rest.support.matchers.ValidationResponseMatchers.isValidationResponseWhich;
 
 import java.io.UnsupportedEncodingException;

--- a/src/test/java/org/folio/rest/api/RequestsApiTest.java
+++ b/src/test/java/org/folio/rest/api/RequestsApiTest.java
@@ -22,6 +22,7 @@ import static org.folio.rest.support.builders.RequestRequestBuilder.OPEN_NOT_YET
 import static org.folio.rest.support.matchers.TextDateTimeMatcher.equivalentTo;
 import static org.folio.rest.support.matchers.TextDateTimeMatcher.withinSecondsAfter;
 import static org.folio.rest.support.matchers.ValidationErrorMatchers.hasMessage;
+import static org.folio.rest.support.matchers.ValidationErrorMatchers.hasMessageContaining;
 import static org.folio.rest.support.matchers.ValidationResponseMatchers.isValidationResponseWhich;
 
 import java.io.UnsupportedEncodingException;

--- a/src/test/java/org/folio/rest/api/StorageTestSuite.java
+++ b/src/test/java/org/folio/rest/api/StorageTestSuite.java
@@ -19,7 +19,7 @@ import java.util.concurrent.TimeoutException;
 import org.folio.rest.RestVerticle;
 import org.folio.rest.api.loans.LoansAnonymizationApiTest;
 import org.folio.rest.persist.PostgresClient;
-import org.folio.rest.support.WebClient;
+import org.folio.rest.support.OkapiHttpClient;
 import org.folio.rest.support.Response;
 import org.folio.rest.support.ResponseHandler;
 import org.folio.rest.support.TextResponse;
@@ -194,7 +194,7 @@ public class StorageTestSuite {
   }
 
   public static void deleteAll(URL rootUrl) {
-    WebClient client = new WebClient(getVertx());
+    OkapiHttpClient client = new OkapiHttpClient(getVertx());
 
     CompletableFuture<Response> deleteAllFinished = new CompletableFuture<>();
 
@@ -279,7 +279,7 @@ public class StorageTestSuite {
     log.info("Making request to prepare tenant in module");
 
     try {
-      WebClient client = new WebClient(vertx);
+      OkapiHttpClient client = new OkapiHttpClient(vertx);
 
       JsonArray ar = new JsonArray();
 
@@ -311,7 +311,7 @@ public class StorageTestSuite {
     log.info("Making request to clean up tenant in module");
 
     try {
-      WebClient client = new WebClient(vertx);
+      OkapiHttpClient client = new OkapiHttpClient(vertx);
 
       client.delete(storageUrl("/_/tenant"), tenantId,
         ResponseHandler.text(tenantDeleted));

--- a/src/test/java/org/folio/rest/api/StorageTestSuite.java
+++ b/src/test/java/org/folio/rest/api/StorageTestSuite.java
@@ -19,7 +19,7 @@ import java.util.concurrent.TimeoutException;
 import org.folio.rest.RestVerticle;
 import org.folio.rest.api.loans.LoansAnonymizationApiTest;
 import org.folio.rest.persist.PostgresClient;
-import org.folio.rest.support.HttpClient;
+import org.folio.rest.support.WebClient;
 import org.folio.rest.support.Response;
 import org.folio.rest.support.ResponseHandler;
 import org.folio.rest.support.TextResponse;
@@ -194,7 +194,7 @@ public class StorageTestSuite {
   }
 
   public static void deleteAll(URL rootUrl) {
-    HttpClient client = new HttpClient(getVertx());
+    WebClient client = new WebClient(getVertx());
 
     CompletableFuture<Response> deleteAllFinished = new CompletableFuture<>();
 
@@ -279,7 +279,7 @@ public class StorageTestSuite {
     log.info("Making request to prepare tenant in module");
 
     try {
-      HttpClient client = new HttpClient(vertx);
+      WebClient client = new WebClient(vertx);
 
       JsonArray ar = new JsonArray();
 
@@ -311,7 +311,7 @@ public class StorageTestSuite {
     log.info("Making request to clean up tenant in module");
 
     try {
-      HttpClient client = new HttpClient(vertx);
+      WebClient client = new WebClient(vertx);
 
       client.delete(storageUrl("/_/tenant"), tenantId,
         ResponseHandler.text(tenantDeleted));

--- a/src/test/java/org/folio/rest/support/ApiTests.java
+++ b/src/test/java/org/folio/rest/support/ApiTests.java
@@ -22,7 +22,7 @@ import static org.hamcrest.core.Is.is;
 public class ApiTests {
   private static boolean runningOnOwn;
 
-  protected final HttpClient client = new HttpClient(StorageTestSuite.getVertx());
+  protected final WebClient client = new WebClient(StorageTestSuite.getVertx());
 
   @BeforeClass
   public static void before()

--- a/src/test/java/org/folio/rest/support/ApiTests.java
+++ b/src/test/java/org/folio/rest/support/ApiTests.java
@@ -22,7 +22,7 @@ import static org.hamcrest.core.Is.is;
 public class ApiTests {
   private static boolean runningOnOwn;
 
-  protected final WebClient client = new WebClient(StorageTestSuite.getVertx());
+  protected final OkapiHttpClient client = new OkapiHttpClient(StorageTestSuite.getVertx());
 
   @BeforeClass
   public static void before()

--- a/src/test/java/org/folio/rest/support/OkapiHttpClient.java
+++ b/src/test/java/org/folio/rest/support/OkapiHttpClient.java
@@ -15,9 +15,9 @@ import io.vertx.core.logging.LoggerFactory;
 import io.vertx.ext.web.client.HttpRequest;
 import io.vertx.ext.web.client.HttpResponse;
 
-public class WebClient {
+public class OkapiHttpClient {
 
-  private static final Logger log = LoggerFactory.getLogger(WebClient.class);
+  private static final Logger log = LoggerFactory.getLogger(OkapiHttpClient.class);
 
   private static final String TENANT_HEADER = "X-Okapi-Tenant";
   private static final String USERID_HEADER = "X-Okapi-User-Id";
@@ -26,7 +26,7 @@ public class WebClient {
 
   private final String defaultUserId = UUID.randomUUID().toString();
 
-  public WebClient(Vertx vertx) {
+  public OkapiHttpClient(Vertx vertx) {
     client = io.vertx.ext.web.client.WebClient.create(vertx);
   }
 
@@ -66,12 +66,13 @@ public class WebClient {
 
     if (body == null) {
       request.send(responseHandler);
-    } else {
-      Buffer encodedBody = Buffer.buffer(Json.encodePrettily(body));
-      log.info(String.format("POST %s, Request: %s",
-        url.toString(), body));
-      request.sendBuffer(encodedBody, responseHandler);
+      return;
     }
+
+    Buffer encodedBody = Buffer.buffer(Json.encodePrettily(body));
+    log.info(String.format("POST %s, Request: %s",
+      url.toString(), body));
+    request.sendBuffer(encodedBody, responseHandler);
   }
 
   public void post(URL url,

--- a/src/test/java/org/folio/rest/support/WebClient.java
+++ b/src/test/java/org/folio/rest/support/WebClient.java
@@ -5,30 +5,32 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.UUID;
 
+import io.vertx.core.AsyncResult;
 import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
-import io.vertx.core.http.HttpClientRequest;
-import io.vertx.core.http.HttpClientResponse;
+import io.vertx.core.buffer.Buffer;
 import io.vertx.core.json.Json;
 import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
+import io.vertx.ext.web.client.HttpRequest;
+import io.vertx.ext.web.client.HttpResponse;
 
-public class HttpClient {
+public class WebClient {
 
-  private static final Logger log = LoggerFactory.getLogger(HttpClient.class);
+  private static final Logger log = LoggerFactory.getLogger(WebClient.class);
 
   private static final String TENANT_HEADER = "X-Okapi-Tenant";
   private static final String USERID_HEADER = "X-Okapi-User-Id";
 
-  private final io.vertx.core.http.HttpClient client;
+  private io.vertx.ext.web.client.WebClient client;
 
   private final String defaultUserId = UUID.randomUUID().toString();
 
-  public HttpClient(Vertx vertx) {
-    client = vertx.createHttpClient();
+  public WebClient(Vertx vertx) {
+    client = io.vertx.ext.web.client.WebClient.create(vertx);
   }
 
-  private void stdHeaders(HttpClientRequest request, URL url, String tenantId, String userId) {
+  private void stdHeaders(HttpRequest<Buffer> request, URL url, String tenantId, String userId) {
     if (url != null) {
       request.headers().add("X-Okapi-Url", url.getProtocol() + "://" + url.getHost() + ":" + url.getPort());
       request.headers().add("X-Okapi-Url-to", url.getProtocol() + "://" + url.getHost() + ":" + url.getPort());
@@ -44,7 +46,7 @@ public class HttpClient {
   public void post(URL url,
     Object body,
     String tenantId,
-    Handler<HttpClientResponse> responseHandler) {
+    Handler<AsyncResult<HttpResponse<Buffer>>> responseHandler) {
 
     post(url, body, tenantId, defaultUserId, responseHandler);
   }
@@ -53,34 +55,34 @@ public class HttpClient {
     Object body,
     String tenantId,
     String userId,
-    Handler<HttpClientResponse> responseHandler) {
+    Handler<AsyncResult<HttpResponse<Buffer>>> responseHandler) {
 
-    HttpClientRequest request = client.postAbs(url.toString(),
-      responseHandler);
+    HttpRequest<Buffer> request = client.postAbs(url.toString());
 
     request.headers().add("Accept", "application/json, text/plain");
     request.headers().add("Content-type", "application/json");
 
     stdHeaders(request, url, tenantId, userId);
-    if (body != null) {
-      String encodedBody = Json.encodePrettily(body);
-      log.info(String.format("POST %s, Request: %s",
-        url.toString(), encodedBody));
-      request.end(encodedBody);
+
+    if (body == null) {
+      request.send(responseHandler);
     } else {
-      request.end();
+      Buffer encodedBody = Buffer.buffer(Json.encodePrettily(body));
+      log.info(String.format("POST %s, Request: %s",
+        url.toString(), body));
+      request.sendBuffer(encodedBody, responseHandler);
     }
   }
 
   public void post(URL url,
     String tenantId,
-    Handler<HttpClientResponse> responseHandler) {
+    Handler<AsyncResult<HttpResponse<Buffer>>> responseHandler) {
 
     post(url, null, tenantId, responseHandler);
   }
 
   public void get(URL url,
-    Handler<HttpClientResponse> responseHandler)
+    Handler<AsyncResult<HttpResponse<Buffer>>> responseHandler)
     throws UnsupportedEncodingException {
 
     get(url, null, responseHandler);
@@ -89,7 +91,7 @@ public class HttpClient {
   public void put(URL url,
     Object body,
     String tenantId,
-    Handler<HttpClientResponse> responseHandler) {
+    Handler<AsyncResult<HttpResponse<Buffer>>> responseHandler) {
 
     put(url, body, tenantId, defaultUserId, responseHandler);
   }
@@ -98,24 +100,24 @@ public class HttpClient {
     Object body,
     String tenantId,
     String userId,
-    Handler<HttpClientResponse> responseHandler) {
+    Handler<AsyncResult<HttpResponse<Buffer>>> responseHandler) {
 
-    HttpClientRequest request = client.putAbs(url.toString(), responseHandler);
+    HttpRequest<Buffer> request = client.putAbs(url.toString());
 
     request.headers().add("Accept", "application/json, text/plain");
     request.headers().add("Content-type", "application/json");
 
     stdHeaders(request, url, tenantId, userId);
-    String encodedBody = Json.encodePrettily(body);
-    log.info(String.format("PUT %s, Request: %s",
-      url.toString(), encodedBody));
 
-    request.end(encodedBody);
+    Buffer encodedBody = Buffer.buffer(Json.encodePrettily(body));
+    log.info(String.format("PUT %s, Request: %s",
+      url.toString(), body));
+    request.sendBuffer(encodedBody, responseHandler);
   }
 
   public void get(URL url,
     String tenantId,
-    Handler<HttpClientResponse> responseHandler) {
+    Handler<AsyncResult<HttpResponse<Buffer>>> responseHandler) {
 
     get(url.toString(), tenantId, responseHandler);
   }
@@ -123,7 +125,7 @@ public class HttpClient {
   public void get(URL url,
     String query,
     String tenantId,
-    Handler<HttpClientResponse> responseHandler)
+    Handler<AsyncResult<HttpResponse<Buffer>>> responseHandler)
     throws MalformedURLException {
 
     get(new URL(url.getProtocol(), url.getHost(), url.getPort(),
@@ -133,32 +135,32 @@ public class HttpClient {
 
   public void get(String url,
     String tenantId,
-    Handler<HttpClientResponse> responseHandler) {
+    Handler<AsyncResult<HttpResponse<Buffer>>> responseHandler) {
 
-    HttpClientRequest request = client.getAbs(url, responseHandler);
+    HttpRequest<Buffer> request = client.getAbs(url);
 
     request.headers().add("Accept", "application/json");
 
     stdHeaders(request, null, tenantId, defaultUserId);
-    request.end();
+    request.send(responseHandler);
   }
 
   public void delete(URL url,
     String tenantId,
-    Handler<HttpClientResponse> responseHandler) {
+    Handler<AsyncResult<HttpResponse<Buffer>>> responseHandler) {
 
     delete(url.toString(), tenantId, responseHandler);
   }
 
   public void delete(String url,
     String tenantId,
-    Handler<HttpClientResponse> responseHandler) {
+    Handler<AsyncResult<HttpResponse<Buffer>>> responseHandler) {
 
-    HttpClientRequest request = client.deleteAbs(url, responseHandler);
+    HttpRequest<Buffer> request = client.deleteAbs(url);
 
     request.headers().add("Accept", "application/json, text/plain");
 
     stdHeaders(request, null, tenantId, defaultUserId);
-    request.end();
+    request.send(responseHandler);
   }
 }

--- a/src/test/java/org/folio/rest/support/http/AssertingRecordClient.java
+++ b/src/test/java/org/folio/rest/support/http/AssertingRecordClient.java
@@ -17,7 +17,7 @@ import java.util.concurrent.TimeoutException;
 import io.vertx.core.json.JsonObject;
 
 import org.folio.rest.api.StorageTestSuite;
-import org.folio.rest.support.HttpClient;
+import org.folio.rest.support.WebClient;
 import org.folio.rest.support.IndividualResource;
 import org.folio.rest.support.JsonResponse;
 import org.folio.rest.support.MultipleRecords;
@@ -27,13 +27,13 @@ import org.folio.rest.support.builders.Builder;
 import org.folio.rest.support.builders.LoanRequestBuilder;
 
 public class AssertingRecordClient {
-  private final HttpClient client;
+  private final WebClient client;
   private final String tenantId;
   private final UrlMaker urlMaker;
   private final String collectionPropertyName;
 
   public AssertingRecordClient(
-    HttpClient client,
+    WebClient client,
     String tenantId,
     UrlMaker urlMaker,
     String collectionPropertyName) {

--- a/src/test/java/org/folio/rest/support/http/AssertingRecordClient.java
+++ b/src/test/java/org/folio/rest/support/http/AssertingRecordClient.java
@@ -17,7 +17,7 @@ import java.util.concurrent.TimeoutException;
 import io.vertx.core.json.JsonObject;
 
 import org.folio.rest.api.StorageTestSuite;
-import org.folio.rest.support.WebClient;
+import org.folio.rest.support.OkapiHttpClient;
 import org.folio.rest.support.IndividualResource;
 import org.folio.rest.support.JsonResponse;
 import org.folio.rest.support.MultipleRecords;
@@ -27,13 +27,13 @@ import org.folio.rest.support.builders.Builder;
 import org.folio.rest.support.builders.LoanRequestBuilder;
 
 public class AssertingRecordClient {
-  private final WebClient client;
+  private final OkapiHttpClient client;
   private final String tenantId;
   private final UrlMaker urlMaker;
   private final String collectionPropertyName;
 
   public AssertingRecordClient(
-    WebClient client,
+    OkapiHttpClient client,
     String tenantId,
     UrlMaker urlMaker,
     String collectionPropertyName) {

--- a/src/test/java/org/folio/rest/support/matchers/OkapiResponseStatusCodeMatchers.java
+++ b/src/test/java/org/folio/rest/support/matchers/OkapiResponseStatusCodeMatchers.java
@@ -1,0 +1,113 @@
+package org.folio.rest.support.matchers;
+
+import static org.folio.HttpStatus.HTTP_BAD_REQUEST;
+import static org.folio.HttpStatus.HTTP_CREATED;
+import static org.folio.HttpStatus.HTTP_INTERNAL_SERVER_ERROR;
+import static org.folio.HttpStatus.HTTP_NO_CONTENT;
+import static org.folio.HttpStatus.HTTP_NOT_FOUND;
+import static org.folio.HttpStatus.HTTP_OK;
+import static org.folio.HttpStatus.HTTP_UNPROCESSABLE_ENTITY;
+import static org.hamcrest.CoreMatchers.is;
+
+import org.folio.rest.support.TextResponse;
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.TypeSafeDiagnosingMatcher;
+
+public class OkapiResponseStatusCodeMatchers {
+
+  /** HTTP Status-Code 200: Ok. */
+  public static Matcher<Integer> isOk() {
+    return is(HTTP_OK.toInt());
+  }
+
+  /** HTTP Status-Code 201: Created. */
+  public static Matcher<Integer> isCreated() {
+    return is(HTTP_CREATED.toInt());
+  }
+
+  /** HTTP Status-Code 204: No content. */
+  public static Matcher<Integer> isNoContent() {
+    return is(HTTP_NO_CONTENT.toInt());
+  }
+
+  /** HTTP Status-Code 400: Bad request. */
+  public static Matcher<Integer> isBadRequest() {
+    return is(HTTP_BAD_REQUEST.toInt());
+  }
+
+  /** HTTP Status-Code 404: Not Found. */
+  public static Matcher<Integer> isNotFound() {
+    return is(HTTP_NOT_FOUND.toInt());
+  }
+
+  /** HTTP Status-Code 422: Unprocessable entity. */
+  public static Matcher<Integer> isUnprocessableEntity() {
+    return is(HTTP_UNPROCESSABLE_ENTITY.toInt());
+  }
+
+  /** HTTP Status-Code 500: Internal server error. */
+  public static Matcher<Integer> isInternalServerError() {
+    return is(HTTP_INTERNAL_SERVER_ERROR.toInt());
+  }
+
+  /** HTTP Status-Code 200: Ok. */
+  public static TypeSafeDiagnosingMatcher<TextResponse> matchesOk() {
+    return hasStatusCode(HTTP_OK.toInt());
+  }
+
+  /** HTTP Status-Code 201: Created. */
+  public static TypeSafeDiagnosingMatcher<TextResponse> matchesCreated() {
+    return hasStatusCode(HTTP_CREATED.toInt());
+  }
+
+  /** HTTP Status-Code 204: No content. */
+  public static TypeSafeDiagnosingMatcher<TextResponse> matchesNoContent() {
+    return hasStatusCode(HTTP_NO_CONTENT.toInt());
+  }
+
+  /** HTTP Status-Code 400: Bad request. */
+  public static TypeSafeDiagnosingMatcher<TextResponse> matchesBadRequest() {
+    return hasStatusCode(HTTP_BAD_REQUEST.toInt());
+  }
+
+  /** HTTP Status-Code 404: Not Found. */
+  public static TypeSafeDiagnosingMatcher<TextResponse> matchesNotFound() {
+    return hasStatusCode(HTTP_NOT_FOUND.toInt());
+  }
+
+  /** HTTP Status-Code 422: Unprocessable entity. */
+  public static TypeSafeDiagnosingMatcher<TextResponse> matchesUnprocessableEntity() {
+    return hasStatusCode(HTTP_UNPROCESSABLE_ENTITY.toInt());
+  }
+
+  /** HTTP Status-Code 500: Internal server error. */
+  public static TypeSafeDiagnosingMatcher<TextResponse> matchInternalServerError() {
+    return hasStatusCode(HTTP_INTERNAL_SERVER_ERROR.toInt());
+  }
+
+  private static TypeSafeDiagnosingMatcher<TextResponse> hasStatusCode(Integer statusCode) {
+    return new TypeSafeDiagnosingMatcher<TextResponse>() {
+      @Override
+      public void describeTo(Description description) {
+        description.appendText("a response with status code ")
+          .appendValue(statusCode);
+      }
+
+      @Override
+      protected boolean matchesSafely(TextResponse response, Description description) {
+        final Matcher<Integer> statusCodeMatcher = is(statusCode);
+
+        statusCodeMatcher.describeMismatch(response.getStatusCode(), description);
+
+        final boolean matches = statusCodeMatcher.matches(response.getStatusCode());
+
+        if(!matches) {
+          description.appendText("\nReceived body: ").appendValue(response.getBody());
+        }
+
+        return matches;
+      }
+    };
+  }
+}


### PR DESCRIPTION
Updating to the latest RMB required significant changes.

Summary:
- Use HttpStatus more consistently.
- Perform update requirements as described in RMB upgrade cookbook.
- Remove/update/replace deprecated code/functionality.
- Address numerous issues with tests, adding new code to address behavioral changes.
- Attempt a less fragile error handling design.
- Ensure the `@validate` is in use by LoanPoliciesAPI.java.
- Rewrite tests to address change in behavior as defined in RMB-459 and RMB-353.
- Fixed random typos in the code that I observed in files that I am already changing (such as `udpatePreference`).

Of particular note, there was some discussion regarding the handling of error messages.
The discussed approach was to encourage the use of RMB's error messages.
However, after extensive review it seems that there are sometimes inconsistent status codes (500 that should be 422 or 400 that should be a 422) and multiple different messages for the same error situation.
I strongly suggest specifically reviewing the approach provided here.

see: https://issues.folio.org/browse/CIRCSTORE-183
see: https://issues.folio.org/browse/UIREQ-401
see: https://issues.folio.org/browse/RMB-459
see: https://issues.folio.org/browse/RMB-353
