### PR TITLE
CIRCSTORE-196: Store additional check-in properties for in-house use.

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -419,7 +419,7 @@
     },
     {
       "id": "check-in-storage",
-      "version": "0.1",
+      "version": "0.2",
       "handlers": [
         {
           "methods": [

--- a/ramls/check-in-storage.raml
+++ b/ramls/check-in-storage.raml
@@ -1,6 +1,6 @@
 #%RAML 1.0
 title: Check-in storage
-version: v0.1
+version: v0.2
 protocols: [ HTTP, HTTPS ]
 baseUri: http://localhost:9130
 

--- a/ramls/check-in.json
+++ b/ramls/check-in.json
@@ -18,9 +18,9 @@
       "description": "Id of item that has checked in",
       "$ref": "raml-util/schemas/uuid.schema"
     },
-    "itemStatus": {
+    "itemStatusPriorToCheckIn": {
       "type": "string",
-      "description": "Item status on check-in"
+      "description": "Item status prior to check-in"
     },
     "requestQueueSize": {
       "type": "integer",
@@ -29,7 +29,7 @@
     },
     "itemLocationId": {
       "type": "string",
-      "description": "Effective location of the item",
+      "description": "Location of the item in check-in time",
       "$ref": "raml-util/schemas/uuid.schema"
     },
     "servicePointId": {

--- a/ramls/check-in.json
+++ b/ramls/check-in.json
@@ -18,6 +18,20 @@
       "description": "Id of item that has checked in",
       "$ref": "raml-util/schemas/uuid.schema"
     },
+    "itemStatus": {
+      "type": "string",
+      "description": "Item status on check-in"
+    },
+    "requestQueueSize": {
+      "type": "integer",
+      "description": "Request queue size for the item",
+      "minimum": 0
+    },
+    "itemLocationId": {
+      "type": "string",
+      "description": "Effective location of the item",
+      "$ref": "raml-util/schemas/uuid.schema"
+    },
     "servicePointId": {
       "type": "string",
       "description": "Service point where the item was checked in",

--- a/ramls/examples/check-in.json
+++ b/ramls/examples/check-in.json
@@ -2,7 +2,7 @@
   "id": "513eba26-081d-4566-b0eb-c6f2c8db5aab",
   "occurredDateTime": "2020-02-12T16:17:25Z",
   "itemId": "6acb77b5-53f5-4005-b5c2-8ce9c52fb891",
-  "itemStatus": "Checked out",
+  "itemStatusPriorToCheckIn": "Checked out",
   "itemLocationId": "99ea6fc9-ed59-45b7-9ae8-1f851ea20208",
   "requestQueueSize": 2,
   "servicePointId": "b0c3c66c-6738-4a61-a51e-8ef354d43e3d",

--- a/ramls/examples/check-in.json
+++ b/ramls/examples/check-in.json
@@ -2,6 +2,9 @@
   "id": "513eba26-081d-4566-b0eb-c6f2c8db5aab",
   "occurredDateTime": "2020-02-12T16:17:25Z",
   "itemId": "6acb77b5-53f5-4005-b5c2-8ce9c52fb891",
+  "itemStatus": "Checked out",
+  "itemLocationId": "99ea6fc9-ed59-45b7-9ae8-1f851ea20208",
+  "requestQueueSize": 2,
   "servicePointId": "b0c3c66c-6738-4a61-a51e-8ef354d43e3d",
   "performedByUserId": "f9246eac-ef6f-4043-885b-0325a1e3a9eb"
 }

--- a/ramls/examples/check-ins.json
+++ b/ramls/examples/check-ins.json
@@ -4,7 +4,7 @@
       "id": "513eba26-081d-4566-b0eb-c6f2c8db5aab",
       "occurredDateTime": "2020-02-12T16:17:25Z",
       "itemId": "6acb77b5-53f5-4005-b5c2-8ce9c52fb891",
-      "itemStatus": "Available",
+      "itemStatusPriorToCheckIn": "Available",
       "itemLocationId": "99ea6fc9-ed59-45b7-9ae8-1f851ea20208",
       "requestQueueSize": 0,
       "servicePointId": "b0c3c66c-6738-4a61-a51e-8ef354d43e3d",

--- a/ramls/examples/check-ins.json
+++ b/ramls/examples/check-ins.json
@@ -4,6 +4,9 @@
       "id": "513eba26-081d-4566-b0eb-c6f2c8db5aab",
       "occurredDateTime": "2020-02-12T16:17:25Z",
       "itemId": "6acb77b5-53f5-4005-b5c2-8ce9c52fb891",
+      "itemStatus": "Available",
+      "itemLocationId": "99ea6fc9-ed59-45b7-9ae8-1f851ea20208",
+      "requestQueueSize": 0,
       "servicePointId": "b0c3c66c-6738-4a61-a51e-8ef354d43e3d",
       "performedByUserId": "f9246eac-ef6f-4043-885b-0325a1e3a9eb"
     }

--- a/src/test/java/org/folio/rest/api/CheckInStorageApiTest.java
+++ b/src/test/java/org/folio/rest/api/CheckInStorageApiTest.java
@@ -83,8 +83,7 @@ public class CheckInStorageApiTest extends ApiTests {
 
     assertThat(createResponse, isValidationResponseWhich(hasMessage("may not be null")));
     assertThat(createResponse, isValidationResponseWhich(hasParameter("occurredDateTime", "null")));
-    assertThat(checkInClient.attemptGetById(recordId).getStatusCode(),
-      is(404));
+    assertThat(checkInClient.attemptGetById(recordId).getStatusCode(), is(404));
   }
 
   @Test
@@ -179,7 +178,7 @@ public class CheckInStorageApiTest extends ApiTests {
     ExecutionException, TimeoutException, MalformedURLException {
 
     JsonObject checkInToCreate = createSampleCheckIn()
-      .withItemStatus(null)
+      .withItemStatusPriorToCheckIn(null)
       .withItemLocationId(null)
       .withRequestQueueSize(null)
       .create();
@@ -205,8 +204,7 @@ public class CheckInStorageApiTest extends ApiTests {
       isValidationResponseWhich(hasMessage("must be greater than or equal to 0")));
     assertThat(createResult,
       isValidationResponseWhich(hasParameter("requestQueueSize", "-1")));
-    assertThat(checkInClient.attemptGetById(recordId).getStatusCode(),
-      is(404));
+    assertThat(checkInClient.attemptGetById(recordId).getStatusCode(), is(404));
   }
 
   private CheckInBuilder createSampleCheckIn() {
@@ -216,7 +214,7 @@ public class CheckInStorageApiTest extends ApiTests {
       .withItemId(UUID.randomUUID())
       .withServicePointId(UUID.randomUUID())
       .withPerformedByUserId(UUID.randomUUID())
-      .withItemStatus("Available")
+      .withItemStatusPriorToCheckIn("Available")
       .withItemLocationId(UUID.randomUUID())
       .withRequestQueueSize(0);
   }

--- a/src/test/java/org/folio/rest/api/CheckInStorageApiTest.java
+++ b/src/test/java/org/folio/rest/api/CheckInStorageApiTest.java
@@ -171,12 +171,46 @@ public class CheckInStorageApiTest extends ApiTests {
     assertThat(checkInById.getStatusCode(), is(404));
   }
 
+  @Test
+  public void canCreateRecordWithoutOptionalParameters() throws InterruptedException,
+    ExecutionException, TimeoutException, MalformedURLException {
+
+    JsonObject checkInToCreate = createSampleCheckIn()
+      .withItemStatus(null)
+      .withItemLocationId(null)
+      .withRequestQueueSize(null)
+      .create();
+
+    IndividualResource createResult = checkInClient.create(checkInToCreate);
+
+    assertThat(createResult.getJson(), is(checkInToCreate));
+  }
+
+  @Test
+  public void cannotCreateRecordWithNegativeRequestQueueSize() throws InterruptedException,
+    ExecutionException, TimeoutException, MalformedURLException {
+
+    JsonObject checkInToCreate = createSampleCheckIn()
+      .withRequestQueueSize(-1)
+      .create();
+
+    JsonResponse createResult = checkInClient.attemptCreate(checkInToCreate);
+
+    assertThat(createResult,
+      isValidationResponseWhich(hasMessage("must be greater than or equal to 0")));
+    assertThat(createResult,
+      isValidationResponseWhich(hasParameter("requestQueueSize", "-1")));
+  }
+
   private CheckInBuilder createSampleCheckIn() {
     return new CheckInBuilder()
       .withId(UUID.randomUUID())
       .withOccurredDateTime(DateTime.now(DateTimeZone.UTC))
       .withItemId(UUID.randomUUID())
       .withServicePointId(UUID.randomUUID())
-      .withPerformedByUserId(UUID.randomUUID());
+      .withPerformedByUserId(UUID.randomUUID())
+      .withItemStatus("Available")
+      .withItemLocationId(UUID.randomUUID())
+      .withRequestQueueSize(0);
   }
 }

--- a/src/test/java/org/folio/rest/api/CheckInStorageApiTest.java
+++ b/src/test/java/org/folio/rest/api/CheckInStorageApiTest.java
@@ -76,12 +76,15 @@ public class CheckInStorageApiTest extends ApiTests {
   public void cannotCreateCheckInIfRequiredPropertyMissing() throws InterruptedException,
     ExecutionException, TimeoutException, MalformedURLException {
 
-    JsonObject checkInToCreate = new CheckInBuilder().create();
+    UUID recordId = UUID.randomUUID();
+    JsonObject checkInToCreate = new CheckInBuilder().withId(recordId).create();
 
     JsonResponse createResponse = checkInClient.attemptCreate(checkInToCreate);
 
     assertThat(createResponse, isValidationResponseWhich(hasMessage("may not be null")));
     assertThat(createResponse, isValidationResponseWhich(hasParameter("occurredDateTime", "null")));
+    assertThat(checkInClient.attemptGetById(recordId).getStatusCode(),
+      is(404));
   }
 
   @Test
@@ -190,7 +193,9 @@ public class CheckInStorageApiTest extends ApiTests {
   public void cannotCreateRecordWithNegativeRequestQueueSize() throws InterruptedException,
     ExecutionException, TimeoutException, MalformedURLException {
 
+    UUID recordId = UUID.randomUUID();
     JsonObject checkInToCreate = createSampleCheckIn()
+      .withId(recordId)
       .withRequestQueueSize(-1)
       .create();
 
@@ -200,6 +205,8 @@ public class CheckInStorageApiTest extends ApiTests {
       isValidationResponseWhich(hasMessage("must be greater than or equal to 0")));
     assertThat(createResult,
       isValidationResponseWhich(hasParameter("requestQueueSize", "-1")));
+    assertThat(checkInClient.attemptGetById(recordId).getStatusCode(),
+      is(404));
   }
 
   private CheckInBuilder createSampleCheckIn() {

--- a/src/test/java/org/folio/rest/support/builders/CheckInBuilder.java
+++ b/src/test/java/org/folio/rest/support/builders/CheckInBuilder.java
@@ -56,6 +56,25 @@ public class CheckInBuilder implements Builder {
     return this;
   }
 
+  public CheckInBuilder withItemStatus(String itemStatus) {
+    delegate.withItemStatus(itemStatus);
+
+    return this;
+  }
+
+  public CheckInBuilder withRequestQueueSize(Integer requestQueueSize) {
+    delegate.withRequestQueueSize(requestQueueSize);
+
+    return this;
+  }
+
+  public CheckInBuilder withItemLocationId(UUID itemLocationId) {
+    delegate.withItemLocationId(itemLocationId != null
+      ? itemLocationId.toString() : null);
+
+    return this;
+  }
+
   @Override
   public JsonObject create() {
     try {

--- a/src/test/java/org/folio/rest/support/builders/CheckInBuilder.java
+++ b/src/test/java/org/folio/rest/support/builders/CheckInBuilder.java
@@ -56,8 +56,8 @@ public class CheckInBuilder implements Builder {
     return this;
   }
 
-  public CheckInBuilder withItemStatus(String itemStatus) {
-    delegate.withItemStatus(itemStatus);
+  public CheckInBuilder withItemStatusPriorToCheckIn(String itemStatus) {
+    delegate.withItemStatusPriorToCheckIn(itemStatus);
 
     return this;
   }


### PR DESCRIPTION
https://issues.folio.org/browse/CIRCSTORE-196: Store additional properties in check-in-storage.

Add properties needed for in-house use:
* itemStatus
* itemLocationId;
* requestQueueSize;