### PR TITLE
CIRCSTORE-208: rename itemEffectiveLocationAtCheckOut

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -15,7 +15,7 @@
     },
     {
       "id": "loan-storage",
-      "version": "6.7",
+      "version": "7.0",
       "handlers": [
         {
           "methods": ["GET"],

--- a/ramls/examples/loan.json
+++ b/ramls/examples/loan.json
@@ -5,7 +5,7 @@
   "itemId": "cb20f34f-b773-462f-a091-b233cc96b9e6",
   "loanDate": "2017-03-01T23:11:00-01:00",
   "dueDate": "2017-03-15T23:11:00-01:00",
-  "itemEffectiveLocationAtCheckOut": "07f83048-6737-4c6a-a3bc-c49cd9beaa38",
+  "itemEffectiveLocationIdAtCheckOut": "07f83048-6737-4c6a-a3bc-c49cd9beaa38",
   "checkoutServicePointId": "8bb53832-c9fb-47ef-986d-5b1a498a8b30",
   "checkinServicePointId": "8bb53832-c9fb-47ef-986d-5b1a498a8b30",
   "status": {

--- a/ramls/loan-storage.raml
+++ b/ramls/loan-storage.raml
@@ -1,6 +1,6 @@
 #%RAML 1.0
 title: Loan Storage
-version: v6.7
+version: v6.8
 protocols: [ HTTP, HTTPS ]
 baseUri: http://localhost:9130
 

--- a/ramls/loan-storage.raml
+++ b/ramls/loan-storage.raml
@@ -1,6 +1,6 @@
 #%RAML 1.0
 title: Loan Storage
-version: v6.8
+version: v7.0
 protocols: [ HTTP, HTTPS ]
 baseUri: http://localhost:9130
 

--- a/ramls/loan.json
+++ b/ramls/loan.json
@@ -52,7 +52,7 @@
     },
     "systemReturnDate" : {
       "description": "Date time when the returned item is actually processed",
-      "type" : "string",
+      "type": "string",
       "format": "date-time"
     },
     "action": {
@@ -125,7 +125,7 @@
         "lostItemHasBeenBilled": {
           "description": "Indicates if the aged to lost fee has been billed (for use where delayed billing is set up)",
           "type": "boolean"
-        },    
+        },
         "dateLostItemShouldBeBilled": {
           "description": "Indicates when the aged to lost fee should be billed (for use where delayed billing is set up)",
           "type": "string",
@@ -133,7 +133,7 @@
         }
       }
     }
-  },  
+  },
   "additionalProperties": false,
   "required": [
     "itemId",

--- a/ramls/loan.json
+++ b/ramls/loan.json
@@ -95,7 +95,7 @@
     },
     "declaredLostDate" : {
       "description": "Date and time the item was declared lost during this loan",
-      "type" : "string",
+      "type": "string",
       "format": "date-time"
     },
     "claimedReturnedDate": {

--- a/ramls/loan.json
+++ b/ramls/loan.json
@@ -21,7 +21,7 @@
       "description": "ID of the item lent to the patron",
       "type": "string"
     },
-    "itemEffectiveLocationAtCheckOut": {
+    "itemEffectiveLocationIdAtCheckOut": {
       "description": "The effective location, at the time of checkout, of the item loaned to the patron.",
       "type": "string",
       "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[1-5][a-fA-F0-9]{3}-[89abAB][a-fA-F0-9]{3}-[a-fA-F0-9]{12}$"

--- a/ramls/loan.json
+++ b/ramls/loan.json
@@ -24,7 +24,7 @@
     "itemEffectiveLocationIdAtCheckOut": {
       "description": "The effective location, at the time of checkout, of the item loaned to the patron.",
       "type": "string",
-      "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[1-5][a-fA-F0-9]{3}-[89abAB][a-fA-F0-9]{3}-[a-fA-F0-9]{12}$"
+      "$ref": "raml-util/schemas/uuid.schema"
     },
     "status": {
       "description": "Overall status of the loan",

--- a/src/test/java/org/folio/rest/api/LoansApiTest.java
+++ b/src/test/java/org/folio/rest/api/LoansApiTest.java
@@ -98,7 +98,7 @@ public class LoansApiTest extends ApiTests {
       .withAction("checkedout")
       .withItemStatus("Checked out")
       .withDueDate(new DateTime(2017, 7, 27, 10, 23, 43, DateTimeZone.UTC))
-      .withItemEffectiveLocationAtCheckOut(itemLocationAtCheckOut)
+      .withItemEffectiveLocationIdAtCheckOut(itemLocationAtCheckOut)
       .withLoanPolicyId(loanPolicyId)
       .withDeclaredLostDate(expectedLostDate)
       .withOverdueFinePolicyId(overdueFinePolicyId)
@@ -134,8 +134,8 @@ public class LoansApiTest extends ApiTests {
     assertThat("item status is not checked out",
       loan.getString("itemStatus"), is("Checked out"));
 
-    assertThat("itemEffectiveLocationAtCheckOut does not match",
-      loan.getString("itemEffectiveLocationAtCheckOut"), is(itemLocationAtCheckOut.toString()));
+    assertThat("itemEffectiveLocationIdAtCheckOut does not match",
+      loan.getString("itemEffectiveLocationIdAtCheckOut"), is(itemLocationAtCheckOut.toString()));
 
     assertThat("loan policy should be set",
       loan.getString("loanPolicyId"), is(loanPolicyId.toString()));

--- a/src/test/java/org/folio/rest/support/builders/LoanRequestBuilder.java
+++ b/src/test/java/org/folio/rest/support/builders/LoanRequestBuilder.java
@@ -20,7 +20,7 @@ public class LoanRequestBuilder implements Builder {
   private final DateTime dueDate;
   private final String action;
   private final String actionComment;
-  private final UUID itemEffectiveLocationAtCheckOut;
+  private final UUID itemEffectiveLocationIdAtCheckOut;
   private final UUID loanPolicyId;
   private DateTime returnDate;
   private DateTime systemReturnDate;
@@ -67,7 +67,7 @@ public class LoanRequestBuilder implements Builder {
     String action,
     String actionComment,
     DateTime dueDate,
-    UUID itemEffectiveLocationAtCheckOut,
+    UUID itemEffectiveLocationIdAtCheckOut,
     UUID loanPolicyId,
     DateTime returnDate,
     DateTime systemReturnDate,
@@ -89,7 +89,7 @@ public class LoanRequestBuilder implements Builder {
     this.action = action;
     this.actionComment = actionComment;
     this.dueDate = dueDate;
-    this.itemEffectiveLocationAtCheckOut = itemEffectiveLocationAtCheckOut;
+    this.itemEffectiveLocationIdAtCheckOut = itemEffectiveLocationIdAtCheckOut;
     this.loanPolicyId = loanPolicyId;
     this.returnDate = returnDate;
     this.systemReturnDate = systemReturnDate;
@@ -133,8 +133,8 @@ public class LoanRequestBuilder implements Builder {
       ? DateTime.parse(example.getString("dueDate"))
       : null;
 
-    final UUID itemEffectiveLocationAtCheckOut = example.containsKey("itemEffectiveLocationAtCheckOut")
-      ? UUID.fromString(example.getString("itemEffectiveLocationAtCheckOut"))
+    final UUID itemEffectiveLocationIdAtCheckOut = example.containsKey("itemEffectiveLocationIdAtCheckOut")
+      ? UUID.fromString(example.getString("itemEffectiveLocationIdAtCheckOut"))
       : null;
 
     final DateTime returnDate = example.containsKey("returnDate")
@@ -185,7 +185,7 @@ public class LoanRequestBuilder implements Builder {
       example.getString("action"),
       example.getString("actionComment"),
       dueDate,
-      itemEffectiveLocationAtCheckOut,
+      itemEffectiveLocationIdAtCheckOut,
       loanPolicyId,
       returnDate,
       systemReturnDate,
@@ -242,8 +242,8 @@ public class LoanRequestBuilder implements Builder {
       }
     }
 
-    if(itemEffectiveLocationAtCheckOut != null) {
-      request.put("itemEffectiveLocationAtCheckOut", itemEffectiveLocationAtCheckOut.toString());
+    if(itemEffectiveLocationIdAtCheckOut != null) {
+      request.put("itemEffectiveLocationIdAtCheckOut", itemEffectiveLocationIdAtCheckOut.toString());
     }
 
     if(loanPolicyId != null) {
@@ -298,7 +298,7 @@ public class LoanRequestBuilder implements Builder {
       this.action,
       this.actionComment,
       this.dueDate,
-      this.itemEffectiveLocationAtCheckOut,
+      this.itemEffectiveLocationIdAtCheckOut,
       this.loanPolicyId,
       this.returnDate,
       this.systemReturnDate,
@@ -328,7 +328,7 @@ public class LoanRequestBuilder implements Builder {
       this.action,
       this.actionComment,
       this.dueDate,
-      this.itemEffectiveLocationAtCheckOut,
+      this.itemEffectiveLocationIdAtCheckOut,
       this.loanPolicyId,
       this.returnDate,
       this.systemReturnDate,
@@ -353,7 +353,7 @@ public class LoanRequestBuilder implements Builder {
       this.action,
       this.actionComment,
       this.dueDate,
-      this.itemEffectiveLocationAtCheckOut,
+      this.itemEffectiveLocationIdAtCheckOut,
       this.loanPolicyId,
       this.returnDate,
       this.systemReturnDate,
@@ -382,7 +382,7 @@ public class LoanRequestBuilder implements Builder {
       this.action,
       this.actionComment,
       this.dueDate,
-      this.itemEffectiveLocationAtCheckOut,
+      this.itemEffectiveLocationIdAtCheckOut,
       this.loanPolicyId,
       this.returnDate,
       this.systemReturnDate,
@@ -408,7 +408,7 @@ public class LoanRequestBuilder implements Builder {
       this.action,
       this.actionComment,
       this.dueDate,
-      this.itemEffectiveLocationAtCheckOut,
+      this.itemEffectiveLocationIdAtCheckOut,
       this.loanPolicyId,
       this.returnDate,
       this.systemReturnDate,
@@ -434,7 +434,7 @@ public class LoanRequestBuilder implements Builder {
       this.action,
       this.actionComment,
       this.dueDate,
-      this.itemEffectiveLocationAtCheckOut,
+      this.itemEffectiveLocationIdAtCheckOut,
       this.loanPolicyId,
       this.returnDate,
       this.systemReturnDate,
@@ -468,7 +468,7 @@ public class LoanRequestBuilder implements Builder {
       this.action,
       this.actionComment,
       this.dueDate,
-      this.itemEffectiveLocationAtCheckOut,
+      this.itemEffectiveLocationIdAtCheckOut,
       this.loanPolicyId,
       this.returnDate,
       this.systemReturnDate,
@@ -493,7 +493,7 @@ public class LoanRequestBuilder implements Builder {
       action,
       this.actionComment,
       this.dueDate,
-      this.itemEffectiveLocationAtCheckOut,
+      this.itemEffectiveLocationIdAtCheckOut,
       this.loanPolicyId,
       this.returnDate,
       this.systemReturnDate,
@@ -518,7 +518,7 @@ public class LoanRequestBuilder implements Builder {
       this.action,
       actionComment,
       this.dueDate,
-      this.itemEffectiveLocationAtCheckOut,
+      this.itemEffectiveLocationIdAtCheckOut,
       this.loanPolicyId,
       this.returnDate,
       this.systemReturnDate,
@@ -543,7 +543,7 @@ public class LoanRequestBuilder implements Builder {
       this.action,
       this.actionComment,
       dueDate,
-      this.itemEffectiveLocationAtCheckOut,
+      this.itemEffectiveLocationIdAtCheckOut,
       this.loanPolicyId,
       this.returnDate,
       this.systemReturnDate,
@@ -568,7 +568,7 @@ public class LoanRequestBuilder implements Builder {
       this.action,
       this.actionComment,
       this.dueDate,
-      this.itemEffectiveLocationAtCheckOut,
+      this.itemEffectiveLocationIdAtCheckOut,
       this.loanPolicyId,
       returnDate,
       this.systemReturnDate,
@@ -593,7 +593,7 @@ public class LoanRequestBuilder implements Builder {
       this.action,
       this.actionComment,
       this.dueDate,
-      this.itemEffectiveLocationAtCheckOut,
+      this.itemEffectiveLocationIdAtCheckOut,
       this.loanPolicyId,
       this.returnDate,
       systemReturnDate,
@@ -618,7 +618,7 @@ public class LoanRequestBuilder implements Builder {
     return requestDate.toString(ISODateTimeFormat.dateTime());
   }
 
-  public LoanRequestBuilder withItemEffectiveLocationAtCheckOut(UUID itemLocation) {
+  public LoanRequestBuilder withItemEffectiveLocationIdAtCheckOut(UUID itemLocation) {
     return new LoanRequestBuilder(
       this.id,
       this.itemId,
@@ -654,7 +654,7 @@ public class LoanRequestBuilder implements Builder {
       this.action,
       this.actionComment,
       this.dueDate,
-      this.itemEffectiveLocationAtCheckOut,
+      this.itemEffectiveLocationIdAtCheckOut,
       loanPolicyId,
       this.returnDate,
       this.systemReturnDate,
@@ -679,7 +679,7 @@ public class LoanRequestBuilder implements Builder {
       this.action,
       this.actionComment,
       this.dueDate,
-      this.itemEffectiveLocationAtCheckOut,
+      this.itemEffectiveLocationIdAtCheckOut,
       this.loanPolicyId,
       this.returnDate,
       this.systemReturnDate,
@@ -704,7 +704,7 @@ public class LoanRequestBuilder implements Builder {
       this.action,
       this.actionComment,
       this.dueDate,
-      this.itemEffectiveLocationAtCheckOut,
+      this.itemEffectiveLocationIdAtCheckOut,
       this.loanPolicyId,
       this.returnDate,
       this.systemReturnDate,
@@ -729,7 +729,7 @@ public class LoanRequestBuilder implements Builder {
       this.action,
       this.actionComment,
       this.dueDate,
-      this.itemEffectiveLocationAtCheckOut,
+      this.itemEffectiveLocationIdAtCheckOut,
       this.loanPolicyId,
       this.returnDate,
       this.systemReturnDate,
@@ -755,7 +755,7 @@ public class LoanRequestBuilder implements Builder {
       this.action,
       this.actionComment,
       this.dueDate,
-      this.itemEffectiveLocationAtCheckOut,
+      this.itemEffectiveLocationIdAtCheckOut,
       this.loanPolicyId,
       this.returnDate,
       this.systemReturnDate,
@@ -780,7 +780,7 @@ public class LoanRequestBuilder implements Builder {
       this.action,
       this.actionComment,
       this.dueDate,
-      this.itemEffectiveLocationAtCheckOut,
+      this.itemEffectiveLocationIdAtCheckOut,
       this.loanPolicyId,
       this.returnDate,
       this.systemReturnDate,
@@ -805,7 +805,7 @@ public class LoanRequestBuilder implements Builder {
       this.action,
       this.actionComment,
       this.dueDate,
-      this.itemEffectiveLocationAtCheckOut,
+      this.itemEffectiveLocationIdAtCheckOut,
       this.loanPolicyId,
       this.returnDate,
       this.systemReturnDate,
@@ -830,7 +830,7 @@ public class LoanRequestBuilder implements Builder {
       this.action,
       this.actionComment,
       this.dueDate,
-      this.itemEffectiveLocationAtCheckOut,
+      this.itemEffectiveLocationIdAtCheckOut,
       this.loanPolicyId,
       this.returnDate,
       this.systemReturnDate,


### PR DESCRIPTION
https://issues.folio.org/browse/CIRCSTORE-208

Follow-up to [CIRCSTORE-157](https://github.com/folio-org/mod-circulation-storage/pull/194) which added a new field itemEffectiveLocationAtCheckOut. This field name was renamed in mod-circulation; this issue is to propagate that rename to mod-circulation-storage.