### PR TITLE
CIRCSTORE-219: Create request.requestType b-tree index

### DIFF
--- a/src/main/resources/templates/db_scripts/schema.json
+++ b/src/main/resources/templates/db_scripts/schema.json
@@ -150,7 +150,7 @@
         },
         {
           "fieldName": "requestType",
-          "tOps": "ADD",
+          "tOps": "DELETE",
           "caseSensitive": false,
           "removeAccents": true
         },
@@ -176,6 +176,12 @@
         },
         {
           "fieldName": "requesterId",
+          "tOps": "ADD",
+          "caseSensitive": false,
+          "removeAccents": false
+        },
+        {
+          "fieldName": "requestType",
           "tOps": "ADD",
           "caseSensitive": false,
           "removeAccents": false


### PR DESCRIPTION
request.requestType is an enum with these values: ["Hold", "Recall", "Page"]
The correct match operator is the field matching `==`
The existing "ginIndex" should be removed and a b-tree "index" created.
It should be case insensitive (for usability, the same as other request
b-tree indexes) and accents sensitive (we don't expect "Höld" searches.
The new index will also provide better totalRecords estimations resolving
https://issues.folio.org/browse/CIRCSTORE-210 .