### PR TITLE
 CIRCSTORE-220: Upgrade to raml-module-builder (RMB) 30.2.4 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -99,8 +99,8 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <ramlfiles_path>${basedir}/ramls</ramlfiles_path>
-    <raml-module-builder-version>30.0.1</raml-module-builder-version>
-    <vertx-version>3.9.0</vertx-version>
+    <raml-module-builder-version>30.2.4</raml-module-builder-version>
+    <vertx-version>3.9.1</vertx-version>
     <lombok.version>1.18.12</lombok.version>
     <spring.version>5.2.7.RELEASE</spring.version>
     <rest-assured.version>3.3.0</rest-assured.version>

--- a/src/test/java/org/folio/rest/api/CheckInStorageApiTest.java
+++ b/src/test/java/org/folio/rest/api/CheckInStorageApiTest.java
@@ -81,7 +81,7 @@ public class CheckInStorageApiTest extends ApiTests {
 
     JsonResponse createResponse = checkInClient.attemptCreate(checkInToCreate);
 
-    assertThat(createResponse, isValidationResponseWhich(hasMessage("may not be null")));
+    assertThat(createResponse, isValidationResponseWhich(hasMessage("must not be null")));
     assertThat(createResponse, isValidationResponseWhich(hasParameter("occurredDateTime", "null")));
     assertThat(checkInClient.attemptGetById(recordId).getStatusCode(), is(404));
   }

--- a/src/test/java/org/folio/rest/api/LoansApiTest.java
+++ b/src/test/java/org/folio/rest/api/LoansApiTest.java
@@ -446,7 +446,7 @@ public class LoansApiTest extends ApiTests {
     JsonResponse response = loansClient.attemptCreate(loanRequest);
 
     assertThat(response, isValidationResponseWhich(allOf(
-      anyOf(hasMessage("may not be null"), hasMessage("darf nicht null sein")),  // any server language
+      anyOf(hasMessage("must not be null"), hasMessage("darf nicht null sein")),  // any server language
       hasParameter("action", "null"))));
   }
 

--- a/src/test/java/org/folio/rest/api/RequestPoliciesApiTest.java
+++ b/src/test/java/org/folio/rest/api/RequestPoliciesApiTest.java
@@ -88,7 +88,7 @@ public class RequestPoliciesApiTest extends ApiTests {
     assertThat(response2, isUnprocessableEntity());
     JsonObject error = extractErrorObject(response2);
     assertThat("unexpected error message", error,
-        anyOf(hasMessage("may not be null"), hasMessage("darf nicht null sein")));  // any server language
+        anyOf(hasMessage("must not be null"), hasMessage("darf nicht null sein")));  // any server language
   }
 
   @Test
@@ -574,7 +574,7 @@ public class RequestPoliciesApiTest extends ApiTests {
 
     JsonObject error = extractErrorObject(response2);
     assertThat("unexpected error message", error,
-        anyOf(hasMessage("may not be null"), hasMessage("darf nicht null sein")));  // any server language
+        anyOf(hasMessage("must not be null"), hasMessage("darf nicht null sein")));  // any server language
   }
 
   @Test


### PR DESCRIPTION
Updating RMB from 30.0.1 to RMB 30.2.4 fixes
https://issues.folio.org/browse/CIRCSTORE-210 "Requests -Filtering
by Request Type returns (Total Records = 1000) when there are more"
because it includes these fixes:

* [RMB-637](https://issues.folio.org/browse/RMB-637) Run ANALYZE after index (re-)creation
* [RMB-645](https://issues.folio.org/browse/RMB-645) Use where-only clause for the "count query"
* [RMB-639](https://issues.folio.org/browse/RMB-639) Unexpected breaking changes streamGet and getWithOptimizedSql

https://github.com/folio-org/raml-module-builder/blob/master/doc/upgrading.md#version-302 advises:
> https://issues.folio.org/browse/RMB-652 error message "may not be null" changed to "must not be null" (hibernate-validator)