### PR TITLE
CIRCSTORE-237: Upgrade to raml-module-builder (RMB) 30.2.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -99,8 +99,8 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <ramlfiles_path>${basedir}/ramls</ramlfiles_path>
-    <raml-module-builder-version>30.2.5</raml-module-builder-version>
-    <vertx-version>3.9.1</vertx-version>
+    <raml-module-builder-version>30.2.6</raml-module-builder-version>
+    <vertx-version>3.9.2</vertx-version>
     <lombok.version>1.18.12</lombok.version>
     <spring.version>5.2.7.RELEASE</spring.version>
     <rest-assured.version>3.3.0</rest-assured.version>


### PR DESCRIPTION
RMB 30.2.6 release notes -
https://github.com/folio-org/raml-module-builder/releases/tag/v30.2.6

 * [RMB-701](https://issues.folio.org/browse/RMB-701) Update to [Vert.x 3.9.2](https://github.com/vert-x3/wiki/wiki/3.9.2-Release-Notes), fixing WebClient request timeout races
 * [RMB-700](https://issues.folio.org/browse/RMB-700) NPE when RestVerticle calls LogUtil.formatStatsLogMessage
 * [RMB-677](https://issues.folio.org/browse/RMB-677) Close PostgreSQL connection after invalid CQL failure