### PR TITLE
CIRCSTORE-252: Upgrade to RMB 31.1.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -120,7 +120,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <ramlfiles_path>${basedir}/ramls</ramlfiles_path>
-    <raml-module-builder-version>31.1.4</raml-module-builder-version>
+    <raml-module-builder-version>31.1.5</raml-module-builder-version>
     <vertx-version>3.9.4</vertx-version>
     <lombok.version>1.18.12</lombok.version>
     <spring.version>5.2.7.RELEASE</spring.version>


### PR DESCRIPTION
RMB 31.1.5 provides

* RMB-750 Change lock for "tuple concurrently updated" when upgrading Q2 to Q3 (REVOKE)