### PR TITLE
[CIRCSTORE-248] New triggering events for 'aged to lost' item status and lost item fees/fines

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -245,7 +245,7 @@
     },
     {
       "id": "patron-notice-policy-storage",
-      "version": "0.12",
+      "version": "0.13",
       "handlers": [
         {
           "methods": ["POST"],

--- a/ramls/patron-notice-policy.json
+++ b/ramls/patron-notice-policy.json
@@ -87,7 +87,8 @@
                   "Check in",
                   "Check out",
                   "Manual due date change",
-                  "Item recalled"
+                  "Item recalled",
+                  "Aged to lost"
                 ]
               },
               "sendBy": {
@@ -168,7 +169,10 @@
                 "description": "Triggering event",
                 "enum": [
                   "Overdue fine returned",
-                  "Overdue fine renewed"
+                  "Overdue fine renewed",
+                  "Aged to lost - fine charged",
+                  "Aged to lost & item returned - fine adjusted",
+                  "Aged to lost & item replaced - fine adjusted"
                 ]
               },
               "sendBy": {

--- a/ramls/patron-notice-policy.raml
+++ b/ramls/patron-notice-policy.raml
@@ -1,6 +1,6 @@
 #%RAML 1.0
 title: Patron Notice Policies
-version: v0.12
+version: v0.13
 protocols: [ HTTP, HTTPS ]
 baseUri: http://localhost:9130
 

--- a/src/test/java/org/folio/rest/api/PatronNoticePoliciesApiTest.java
+++ b/src/test/java/org/folio/rest/api/PatronNoticePoliciesApiTest.java
@@ -69,6 +69,13 @@ public class PatronNoticePoliciesApiTest extends ApiTests {
       .put("sendOptions", new JsonObject()
         .put("sendWhen", "Item recalled"));
 
+    JsonObject agedToLostNotice = new JsonObject()
+      .put("templateId", UUID.randomUUID().toString())
+      .put("format", "Email")
+      .put("realTime", "true")
+      .put("sendOptions", new JsonObject()
+        .put("sendWhen", "Aged to lost"));
+
     JsonObject holdExpirationChangeNotice = new JsonObject()
       .put("templateId", UUID.randomUUID().toString())
       .put("format", "Email")
@@ -107,7 +114,8 @@ public class PatronNoticePoliciesApiTest extends ApiTests {
         .add(holdExpirationChangeNotice))
       .put("loanNotices", new JsonArray()
         .add(manualDueDateChangeNotice)
-        .add(itemRecalledNotice))
+        .add(itemRecalledNotice)
+        .add(agedToLostNotice))
       .put("feeFineNotices", new JsonArray()
         .add(oneTimeOverdueFineReturnedNotice)
         .add(recurringOverdueFineRenewedNotice));


### PR DESCRIPTION
## Purpose
Add new triggering events for "Aged to lost" item status.
Resolves story: [CIRCSTORE-248](https://issues.folio.org/browse/CIRCSTORE-248)
## Approach
- Added new triggering events according to the story