### PR TITLE
CIRCSTORE-257: Loan policy: Allow recalls to extend overdue loans

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -80,7 +80,7 @@
     },
     {
       "id": "loan-policy-storage",
-      "version": "2.1",
+      "version": "2.2",
       "handlers": [
         {
           "methods": ["GET"],

--- a/ramls/examples/loan-policy.json
+++ b/ramls/examples/loan-policy.json
@@ -47,7 +47,6 @@
         "duration": 3,
         "intervalId": "Days"
       },
-      "alternateRecallReturn": true,
       "alternateRecallReturnInterval": {
         "duration": 4,
         "intervalId": "Hours"

--- a/ramls/examples/loan-policy.json
+++ b/ramls/examples/loan-policy.json
@@ -14,16 +14,70 @@
       "duration": 7,
       "intervalId": "Days"
     },
+    "openingTimeOffset": {
+      "duration": 2,
+      "intervalId": "Weeks"
+    },
+    "fixedDueDateScheduleId": "",
     "itemLimit": 1000
   },
   "renewable": true,
   "renewalsPolicy": {
     "unlimited": true,
+    "numberAllowed": 2,
     "renewFromId": "CURRENT_DUE_DATE",
     "differentPeriod": true,
     "period": {
       "duration": 30,
       "intervalId": "Days"
+    },
+    "alternateFixedDueDateScheduleId": ""
+  },
+  "requestManagement": {
+    "recalls": {
+      "alternateGracePeriod": {
+        "duration": 1,
+        "intervalId": "Months"
+      },
+      "minimumGuaranteedLoanPeriod": {
+        "duration": 2,
+        "intervalId": "Weeks"
+      },
+      "recallReturnInterval": {
+        "duration": 3,
+        "intervalId": "Days"
+      },
+      "alternateRecallReturn": true,
+      "alternateRecallReturnInterval": {
+        "duration": 4,
+        "intervalId": "Hours"
+      }
+    }
+  },
+  "holds": {
+    "recalls": {
+      "alternateCheckoutLoanPeriod": {
+        "duration": 1,
+        "intervalId": "Months"
+      },
+      "renewItemsWithRequest": true,
+      "alternateRenewalLoanPeriod": {
+        "duration": 2,
+        "intervalId": "Weeks"
+      }
+    }
+  },
+  "pages": {
+    "recalls": {
+      "alternateCheckoutLoanPeriod": {
+        "duration": 1,
+        "intervalId": "Months"
+      },
+      "renewItemsWithRequest": true,
+      "alternateRenewalLoanPeriod": {
+        "duration": 2,
+        "intervalId": "Weeks"
+      }
     }
   }
 }

--- a/ramls/loan-policy-storage.raml
+++ b/ramls/loan-policy-storage.raml
@@ -1,6 +1,6 @@
 #%RAML 1.0
 title: Loan Policy Storage
-version: v2.1
+version: v2.2
 protocols: [ HTTP, HTTPS ]
 baseUri: http://localhost:9130
 

--- a/ramls/loan-policy.json
+++ b/ramls/loan-policy.json
@@ -109,6 +109,15 @@
               "type": "object",
               "$ref": "period.json",
               "description": "Recall return interval"
+            },
+            "alternateRecallReturn": {
+              "type": "boolean",
+              "description": "Allow recall return interval for overdue loans"
+            },
+            "alternateRecallReturnInterval": {
+              "type": "object",
+              "$ref": "period.json",
+              "description": "Alternate recall return interval for overdue loans"
             }
           }
         },

--- a/ramls/loan-policy.json
+++ b/ramls/loan-policy.json
@@ -110,10 +110,6 @@
               "$ref": "period.json",
               "description": "Recall return interval"
             },
-            "alternateRecallReturn": {
-              "type": "boolean",
-              "description": "Allow recall return interval for overdue loans"
-            },
             "alternateRecallReturnInterval": {
               "type": "object",
               "$ref": "period.json",

--- a/src/test/java/org/folio/rest/api/LoanPoliciesApiTest.java
+++ b/src/test/java/org/folio/rest/api/LoanPoliciesApiTest.java
@@ -995,7 +995,6 @@ public class LoanPoliciesApiTest extends ApiTests {
     assertThat(recalls.getJsonObject("alternateGracePeriod"), matchesPeriod(1, "Months"));
     assertThat(recalls.getJsonObject("minimumGuaranteedLoanPeriod"), matchesPeriod(1, "Weeks"));
     assertThat(recalls.getJsonObject("recallReturnInterval"), matchesPeriod(1, "Days"));
-    assertThat(recalls.getBoolean("alternateRecallReturn"), is(true));
     assertThat(recalls.getJsonObject("alternateRecallReturnInterval"), matchesPeriod(4, "Hours"));
     JsonObject holds = requestManagement.getJsonObject("holds");
     assertThat(holds.getJsonObject("alternateCheckoutLoanPeriod"), matchesPeriod(2, "Months"));

--- a/src/test/java/org/folio/rest/api/LoanPoliciesApiTest.java
+++ b/src/test/java/org/folio/rest/api/LoanPoliciesApiTest.java
@@ -995,6 +995,8 @@ public class LoanPoliciesApiTest extends ApiTests {
     assertThat(recalls.getJsonObject("alternateGracePeriod"), matchesPeriod(1, "Months"));
     assertThat(recalls.getJsonObject("minimumGuaranteedLoanPeriod"), matchesPeriod(1, "Weeks"));
     assertThat(recalls.getJsonObject("recallReturnInterval"), matchesPeriod(1, "Days"));
+    assertThat(recalls.getBoolean("alternateRecallReturn"), is(true));
+    assertThat(recalls.getJsonObject("alternateRecallReturnInterval"), matchesPeriod(4, "Hours"));
     JsonObject holds = requestManagement.getJsonObject("holds");
     assertThat(holds.getJsonObject("alternateCheckoutLoanPeriod"), matchesPeriod(2, "Months"));
     assertThat(holds.getBoolean("renewItemsWithRequest"), is(true));

--- a/src/test/java/org/folio/rest/support/builders/LoanPolicyRequestBuilder.java
+++ b/src/test/java/org/folio/rest/support/builders/LoanPolicyRequestBuilder.java
@@ -64,6 +64,8 @@ public class LoanPolicyRequestBuilder {
     recalls.put("alternateGracePeriod", createPeriod(1, "Months"));
     recalls.put("minimumGuaranteedLoanPeriod", createPeriod(1, "Weeks"));
     recalls.put("recallReturnInterval", createPeriod(1, "Days"));
+    recalls.put("alternateRecallReturn", true);
+    recalls.put("alternateRecallReturnInterval", createPeriod(4, "Hours"));
     if (holdsRenewalLoanPeriod != null) {
       JsonObject holds = new JsonObject();
       holds.put("alternateCheckoutLoanPeriod", createPeriod(2, "Months"));

--- a/src/test/java/org/folio/rest/support/builders/LoanPolicyRequestBuilder.java
+++ b/src/test/java/org/folio/rest/support/builders/LoanPolicyRequestBuilder.java
@@ -64,7 +64,6 @@ public class LoanPolicyRequestBuilder {
     recalls.put("alternateGracePeriod", createPeriod(1, "Months"));
     recalls.put("minimumGuaranteedLoanPeriod", createPeriod(1, "Weeks"));
     recalls.put("recallReturnInterval", createPeriod(1, "Days"));
-    recalls.put("alternateRecallReturn", true);
     recalls.put("alternateRecallReturnInterval", createPeriod(4, "Hours"));
     if (holdsRenewalLoanPeriod != null) {
       JsonObject holds = new JsonObject();


### PR DESCRIPTION
## Purpose
Provide the storage for the Boolean and Period representing the Alternate Recall Return and Alternate Recall Return Interval.

Resolves: https://issues.folio.org/browse/CIRCSTORE-257

## Approach
Update the loan-policy raml and its respective version.
Update the appropriate examples.
Update the relevant tests.
I also noticed that the example loan policy could be more thorough of an example.