### PR TITLE
CIRCSTORE-260: Anonymize loan history entries as well as loan.

### DIFF
--- a/src/main/java/org/folio/rest/impl/AnonymizeStorageLoansAPI.java
+++ b/src/main/java/org/folio/rest/impl/AnonymizeStorageLoansAPI.java
@@ -118,14 +118,14 @@ public class AnonymizeStorageLoansAPI implements AnonymizeStorageLoans {
     // Only anonymize the history for loans that are currently closed
     // meaning that we need to refer to loans in this query
     final String AnonymizeStorageLoansActionHistorySql = String.format(
-      new StringBuilder().append("UPDATE %s_%s.%s l")
+      new StringBuilder().append("UPDATE %s_%s.%s al")
         .append(" SET jsonb = jsonb #- '{loan,userId}'")
         .append(" WHERE jsonb->'loan'->>'id' IN")
         .append(" (SELECT l.jsonb->>'id' FROM %s_%s.loan l")
         .append(" WHERE l.id in ")
         .append(loanIds)
         .append(" AND l.jsonb->'status'->>'name' = 'Closed')")
-        .append(" AND  l.jsonb->'userId' is NOT NULL")
+        .append(" AND  al.jsonb->'loan'->>'userId' is NOT NULL")
         .toString(),
       tenantId, MODULE_NAME, LOAN_HISTORY_TABLE, tenantId, MODULE_NAME);
 

--- a/src/test/java/org/folio/rest/api/AnonymizeLoansApiTest.java
+++ b/src/test/java/org/folio/rest/api/AnonymizeLoansApiTest.java
@@ -1,61 +1,70 @@
 package org.folio.rest.api;
 
+import static java.lang.String.format;
+import static org.folio.rest.api.StorageTestSuite.TENANT_ID;
+import static org.folio.rest.support.ResponseHandler.json;
 import static org.folio.rest.support.http.InterfaceUrls.anonymizeLoansURL;
 import static org.folio.rest.support.matchers.LoanMatchers.isAnonymized;
-import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.everyItem;
+import static org.hamcrest.Matchers.iterableWithSize;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.junit.MatcherAssert.assertThat;
+
 import java.net.MalformedURLException;
+import java.util.Collection;
+import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+
+import org.folio.rest.jaxrs.model.AnonymizeStorageLoansResponse;
 import org.folio.rest.support.ApiTests;
 import org.folio.rest.support.JsonResponse;
-import org.folio.rest.support.ResponseHandler;
 import org.folio.rest.support.builders.LoanRequestBuilder;
 import org.folio.rest.support.http.AssertingRecordClient;
 import org.folio.rest.support.http.InterfaceUrls;
+import org.folio.rest.support.matchers.LoanHistoryMatchers;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 
 public class AnonymizeLoansApiTest extends ApiTests {
   private final AssertingRecordClient loansClient = new AssertingRecordClient(
-    client, StorageTestSuite.TENANT_ID, InterfaceUrls::loanStorageUrl, "loans");
+    client, TENANT_ID, InterfaceUrls::loanStorageUrl, "loans");
+  private final AssertingRecordClient loanHistoryClient = new AssertingRecordClient(
+    client, TENANT_ID, InterfaceUrls::loanHistoryUrl, "loansHistory");
 
-  private JsonArray loanIds;
-  private int REQUEST_TIMEOUT = 500;
+  private final String firstLoanId = UUID.randomUUID().toString();
+  private final String secondLoanId = UUID.randomUUID().toString();
 
   @Before
-  public void beforeEach()
-    throws MalformedURLException, InterruptedException, ExecutionException,
-    TimeoutException {
+  public void beforeEach() throws MalformedURLException, InterruptedException,
+    ExecutionException, TimeoutException {
 
     StorageTestSuite.deleteAll(InterfaceUrls.loanStorageUrl());
 
-    JsonObject loan1 = loansClient.create(
-      new LoanRequestBuilder().withId(UUID.randomUUID())
-        .withItemId(UUID.randomUUID())
-        .withUserId(UUID.randomUUID())
-        .closed()
-        .create()).getJson();
+    JsonObject loan1 = loansClient.create(new LoanRequestBuilder()
+      .withId(UUID.fromString(firstLoanId))
+      .withItemId(UUID.randomUUID())
+      .withUserId(UUID.randomUUID())
+      .checkedOut()
+      .create()).getJson();
 
-    JsonObject loan2 = loansClient.create(
-      new LoanRequestBuilder().withId(UUID.randomUUID())
-        .withItemId(UUID.randomUUID())
-        .withUserId(UUID.randomUUID())
-        .closed()
-        .create()).getJson();
+    JsonObject loan2 = loansClient.create(new LoanRequestBuilder()
+      .withId(UUID.fromString(secondLoanId))
+      .withItemId(UUID.randomUUID())
+      .withUserId(UUID.randomUUID())
+      .checkedOut()
+      .create()).getJson();
 
-    String loanId2 = loan2.getValue("id").toString();
-    String loanId1 = loan1.getValue("id").toString();
-
-    loanIds = new JsonArray().add(loanId1).add(loanId2);
-
+    loansClient.replace(firstLoanId, LoanRequestBuilder.from(loan1).checkedIn());
+    loansClient.replace(secondLoanId, LoanRequestBuilder.from(loan2).checkedIn());
   }
 
   @After
@@ -65,67 +74,67 @@ public class AnonymizeLoansApiTest extends ApiTests {
   }
 
   @Test
-  public void canAnonymizeLoans()
-    throws InterruptedException, ExecutionException, TimeoutException,
-    MalformedURLException {
+  public void canAnonymizeLoans() throws InterruptedException, ExecutionException,
+    TimeoutException, MalformedURLException {
 
-    JsonObject requestBody = new JsonObject().put("loanIds", loanIds);
+    final var response = anonymizeLoans(firstLoanId, secondLoanId);
 
-    CompletableFuture<JsonResponse> completed = new CompletableFuture<>();
-    client.post(anonymizeLoansURL(), requestBody, StorageTestSuite.TENANT_ID,
-      ResponseHandler.json(completed));
-    JsonResponse response = completed.get(REQUEST_TIMEOUT, TimeUnit.SECONDS);
+    assertThat(response.getAnonymizedLoans(), containsInAnyOrder(firstLoanId, secondLoanId));
+    assertThat(loansClient.getById(firstLoanId).getJson(), isAnonymized());
+    assertThat(loansClient.getById(secondLoanId).getJson(), isAnonymized());
 
-    assertThat(response.getJson().getJsonArray("anonymizedLoans"),
-      equalTo(loanIds));
-    assertThat(response.getStatusCode(), is(200));
-    assertThat(loansClient.getById(loanIds.getString(0)).getJson(),
-      isAnonymized());
-    assertThat(loansClient.getById(loanIds.getString(1)).getJson(),
-      isAnonymized());
+    // assert that history also anonymized
+    assertThat(getLoanHistoryForLoans(),
+      // Check out, check in and anonymize entries for two loans
+      allOf(iterableWithSize(6), everyItem(LoanHistoryMatchers.isAnonymized())));
   }
 
-  @Test public void canNotAnonymizeEmptyList()
-    throws InterruptedException, ExecutionException, TimeoutException,
-    MalformedURLException {
+  @Test
+  public void canNotAnonymizeEmptyList() throws MalformedURLException {
+    JsonResponse response = attemptAnonymizeLoans();
 
-    JsonObject requestBody = new JsonObject().put("loanIds", new JsonArray());
-    CompletableFuture<JsonResponse> completed = new CompletableFuture<>();
-    client.post(anonymizeLoansURL(), requestBody, StorageTestSuite.TENANT_ID,
-      ResponseHandler.json(completed));
-    JsonResponse response = completed.get(REQUEST_TIMEOUT, TimeUnit.SECONDS);
     assertThat(response.getStatusCode(), is(422));
   }
 
   @Test
-  public void canAnonymizeInvalidAndValidUuids()
-    throws InterruptedException, ExecutionException, TimeoutException,
-    MalformedURLException {
+  public void canAnonymizeInvalidAndValidUuids() throws MalformedURLException {
+    final String firstNotValidId = "not valid";
+    final String secondNotValidId = "null";
 
-    JsonArray invalidUuids = new JsonArray().add("")
-      .add("not valid")
-      .add("null");
+    final var response = anonymizeLoans(firstLoanId, secondLoanId,
+      firstNotValidId, secondNotValidId);
 
-    JsonObject requestBody = new JsonObject().put("loanIds",
-      new JsonArray().addAll(loanIds).addAll(invalidUuids));
+    assertThat(response.getAnonymizedLoans(), containsInAnyOrder(firstLoanId, secondLoanId));
+    assertThat(response.getNotAnonymizedLoans().size(), is(1));
+    assertThat(response.getNotAnonymizedLoans().get(0).getReason(), is("invalidLoanIds"));
+    assertThat(response.getNotAnonymizedLoans().get(0).getLoanIds(),
+      containsInAnyOrder(firstNotValidId, secondNotValidId));
+  }
 
-    CompletableFuture<JsonResponse> completed = new CompletableFuture<>();
-    client.post(anonymizeLoansURL(), requestBody, StorageTestSuite.TENANT_ID,
-      ResponseHandler.json(completed));
-    JsonResponse response = completed.get(REQUEST_TIMEOUT, TimeUnit.SECONDS);
+  private AnonymizeStorageLoansResponse anonymizeLoans(String... loanIds) throws MalformedURLException {
+    final JsonResponse response = attemptAnonymizeLoans(loanIds);
+
     assertThat(response.getStatusCode(), is(200));
 
-    JsonObject responseJson = response.getJson();
+    return response.getJson().mapTo(AnonymizeStorageLoansResponse.class);
+  }
 
-    assertThat(responseJson.getJsonArray("anonymizedLoans"), equalTo(loanIds));
+  private JsonResponse attemptAnonymizeLoans(String... loanIds) throws MalformedURLException {
+    final var requestBody = new JsonObject()
+      .put("loanIds", new JsonArray(List.of(loanIds)));
 
-    JsonArray notAnonymizedLoans = responseJson.getJsonArray(
-      "notAnonymizedLoans");
-    assertThat(notAnonymizedLoans.size(), is(1));
-    JsonObject notAnonimizedReasons = notAnonymizedLoans.getJsonObject(0);
-    assertThat(notAnonimizedReasons.getString("reason"),
-      equalTo("invalidLoanIds"));
-    assertThat(notAnonimizedReasons.getJsonArray("loanIds"),
-      equalTo(invalidUuids));
+    final var completed = new CompletableFuture<JsonResponse>();
+
+    client.post(anonymizeLoansURL(), requestBody, TENANT_ID, json(completed));
+
+    return get(completed);
+  }
+
+  private Collection<JsonObject> getLoanHistoryForLoans() throws InterruptedException,
+    MalformedURLException, TimeoutException, ExecutionException {
+
+    final var query = format("loan.id==(\"%s\" or \"%s\")", firstLoanId, secondLoanId);
+
+    return loanHistoryClient.getMany(query).getRecords();
   }
 }

--- a/src/test/java/org/folio/rest/support/ApiTests.java
+++ b/src/test/java/org/folio/rest/support/ApiTests.java
@@ -1,12 +1,13 @@
 package org.folio.rest.support;
 
 import io.vertx.core.json.JsonObject;
+import lombok.SneakyThrows;
+
 import org.folio.rest.api.StorageTestSuite;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.core.Is;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
-import org.junit.ClassRule;
 
 import java.net.HttpURLConnection;
 import java.net.URL;
@@ -17,7 +18,6 @@ import java.util.concurrent.TimeoutException;
 
 import static java.net.HttpURLConnection.HTTP_CREATED;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.core.Is.is;
 
 public class ApiTests {
@@ -99,5 +99,10 @@ public class ApiTests {
     int statusCode = getCompleted.get(5, TimeUnit.SECONDS).getStatusCode();
 
     assertThat(statusCode, is(HttpURLConnection.HTTP_NOT_FOUND));
+  }
+
+  @SneakyThrows
+  protected <T> T get(CompletableFuture<T> future) {
+    return future.get(5, TimeUnit.SECONDS);
   }
 }

--- a/src/test/java/org/folio/rest/support/http/InterfaceUrls.java
+++ b/src/test/java/org/folio/rest/support/http/InterfaceUrls.java
@@ -1,9 +1,9 @@
 package org.folio.rest.support.http;
 
+import static org.folio.rest.api.StorageTestSuite.storageUrl;
+
 import java.net.MalformedURLException;
 import java.net.URL;
-
-import org.folio.rest.api.StorageTestSuite;
 
 public class InterfaceUrls {
   private InterfaceUrls() { }
@@ -15,24 +15,28 @@ public class InterfaceUrls {
   public static URL loanStorageUrl(String subPath)
     throws MalformedURLException {
 
-    return StorageTestSuite.storageUrl("/loan-storage/loans" + subPath);
+    return storageUrl("/loan-storage/loans" + subPath);
+  }
+
+  public static URL loanHistoryUrl(String subPath) throws MalformedURLException {
+    return storageUrl("/loan-storage/loan-history" + subPath);
   }
 
   public static URL patronActionSessionStorageUrl(String subPath)
     throws MalformedURLException {
 
-    return StorageTestSuite.storageUrl("/patron-action-session-storage/patron-action-sessions" + subPath);
+    return storageUrl("/patron-action-session-storage/patron-action-sessions" + subPath);
   }
 
   public static URL anonymizeLoansURL() throws MalformedURLException {
-    return StorageTestSuite.storageUrl("/anonymize-storage-loans");
+    return storageUrl("/anonymize-storage-loans");
   }
 
   public static URL checkInsStorageUrl(String subPath) throws MalformedURLException {
-    return StorageTestSuite.storageUrl("/check-in-storage/check-ins" + subPath);
+    return storageUrl("/check-in-storage/check-ins" + subPath);
   }
 
   public static URL requestExpirationUrl() throws MalformedURLException {
-    return StorageTestSuite.storageUrl("/scheduled-request-expiration");
+    return storageUrl("/scheduled-request-expiration");
   }
 }

--- a/src/test/java/org/folio/rest/support/matchers/LoanHistoryMatchers.java
+++ b/src/test/java/org/folio/rest/support/matchers/LoanHistoryMatchers.java
@@ -1,0 +1,22 @@
+package org.folio.rest.support.matchers;
+
+import org.hamcrest.Description;
+import org.hamcrest.TypeSafeDiagnosingMatcher;
+
+import io.vertx.core.json.JsonObject;
+
+public final class LoanHistoryMatchers {
+  public static TypeSafeDiagnosingMatcher<JsonObject> isAnonymized() {
+    return new TypeSafeDiagnosingMatcher<>() {
+      @Override
+      public void describeTo(Description description) {
+        description.appendText("Anonymized loan history should not have a userId");
+      }
+
+      @Override
+      protected boolean matchesSafely(JsonObject representation, Description description) {
+        return !representation.getJsonObject("loan").containsKey("userId");
+      }
+    };
+  }
+}


### PR DESCRIPTION
https://issues.folio.org/browse/CIRCSTORE-260 - Anonymize all versions of loans when anonymizing

### Changes
* Fix the SQL query so that the loan history is also anonymized.