### PR TITLE
CIRCSTORE-263: Broken logging for mod-circulation-storage

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -258,7 +258,7 @@
         <configuration>
           <verbose>true</verbose>
           <showWeaveInfo>false</showWeaveInfo>
-          <complianceLevel>1.8</complianceLevel>
+          <complianceLevel>11</complianceLevel>
           <includes>
             <include>**/impl/*.java</include>
             <include>**/*.aj</include>
@@ -284,12 +284,12 @@
           <dependency>
             <groupId>org.aspectj</groupId>
             <artifactId>aspectjrt</artifactId>
-            <version>1.9.5</version>
+            <version>1.9.6</version>
           </dependency>
           <dependency>
             <groupId>org.aspectj</groupId>
             <artifactId>aspectjtools</artifactId>
-            <version>1.9.5</version>
+            <version>1.9.6</version>
           </dependency>
         </dependencies>
       </plugin>
@@ -422,6 +422,16 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
         <version>2.3</version>
+         <configuration>
+          <filters>
+            <filter>
+              <artifact>*:*</artifact>
+              <excludes>
+                <exclude>**/Log4j2Plugins.dat</exclude>
+              </excludes>
+            </filter>
+          </filters>
+        </configuration>
         <executions>
           <execution>
             <phase>package</phase>
@@ -434,6 +444,7 @@
                   <manifestEntries>
                     <Main-Class>org.folio.rest.RestLauncher</Main-Class>
                     <Main-Verticle>org.folio.rest.RestVerticle</Main-Verticle>
+                    <Multi-Release>true</Multi-Release>
                   </manifestEntries>
                 </transformer>
               </transformers>

--- a/src/test/java/org/folio/rest/api/LoansApiTest.java
+++ b/src/test/java/org/folio/rest/api/LoansApiTest.java
@@ -1370,7 +1370,7 @@ public class LoansApiTest extends ApiTests {
   public void canSearchByLoanAgedToLostBillingDate() throws Exception {
     final DateTime today = DateTime.now();
     final DateTime yesterday = today.minusDays(1);
-    final DateTime tomorrow = yesterday.plusDays(1);
+    final DateTime tomorrow = today.plusDays(1);
 
     loansClient.create(new LoanRequestBuilder()
         .withAgedToLostDelayedBilling(true, yesterday, DateTime.now()));
@@ -1379,11 +1379,11 @@ public class LoansApiTest extends ApiTests {
       new LoanRequestBuilder().withAgedToLostDelayedBilling(false, tomorrow, DateTime.now()));
 
     final List<String> filteredLoans = loansClient.getMany(
-      String.format("agedToLostDelayedBilling.dateLostItemShouldBeBilled > \"%s\"", yesterday))
+      String.format("agedToLostDelayedBilling.dateLostItemShouldBeBilled > \"%s\"", today))
       .getRecords().stream()
       .map(json -> json.getString("id"))
       .collect(Collectors.toList());
-
+    
     assertThat(filteredLoans, hasSize(1));
     assertThat(filteredLoans, hasItem(loanToBillTomorrow.getId()));
   }


### PR DESCRIPTION
I went through the document linked in the description of this issue
and applied all the noted changes.  Most of them had already been done,
i just added a few things that seem to have been missed.  Despite the
name of this issue, the fixes for logging seem to be in version 32,
so I'm not sure this will actually impact any problems this module
is having with logging.

I also had a test failing on build.  It looked to me like the date
generation for the two loans in this test were a bit screwy-the date
labeled "tomorrow" was actually today.  I tweaked this test a bit
so that one loan was indeed set with a date one day from the present
and the other a date one day in the past, then set it to look for
anything with a date greater than the present day.  That seems to
work.

refs: https://issues.folio.org/browse/CIRCSTORE-263