### PR TITLE
added patronId b-tree index on patron_action_session table

### DIFF
--- a/src/main/resources/templates/db_scripts/schema.json
+++ b/src/main/resources/templates/db_scripts/schema.json
@@ -318,7 +318,21 @@
     {
       "tableName": "patron_action_session",
       "withMetadata": true,
-      "withAuditing": false
+      "withAuditing": false,
+      "index": [
+        {
+          "fieldName": "patronId",
+          "tOps": "ADD",
+          "caseSensitive": false,
+          "removeAccents": false
+        },
+        {
+          "fieldName": "actionType",
+          "tOps": "ADD",
+          "caseSensitive": false,
+          "removeAccents": false
+        }
+      ]
     },
     {
       "tableName": "check_in",

--- a/src/main/resources/templates/db_scripts/schema.json
+++ b/src/main/resources/templates/db_scripts/schema.json
@@ -325,12 +325,6 @@
           "tOps": "ADD",
           "caseSensitive": false,
           "removeAccents": false
-        },
-        {
-          "fieldName": "actionType",
-          "tOps": "ADD",
-          "caseSensitive": false,
-          "removeAccents": false
         }
       ]
     },


### PR DESCRIPTION
Add two b-tree indexes on the fields patronId and actionType that are missing when processing patron notices. 
