### PR TITLE
CIRCSTORE-273 include migration for missing staff slips

### DIFF
--- a/src/main/resources/templates/db_scripts/add_staff_slips_hold_transit.sql
+++ b/src/main/resources/templates/db_scripts/add_staff_slips_hold_transit.sql
@@ -1,0 +1,15 @@
+INSERT INTO ${myuniversity}_${mymodule}.staff_slips(id, jsonb) VALUES (
+    '6a6e72f0-69da-4b4c-8254-7154679e9d88',
+    jsonb_build_object(
+        'id', '6a6e72f0-69da-4b4c-8254-7154679e9d88',
+        'name', 'Hold',
+        'active', true,
+        'template', '<p></p>')) ON CONFLICT DO NOTHING;
+
+INSERT INTO ${myuniversity}_${mymodule}.staff_slips(id, jsonb) VALUES (
+    'f838cdaf-555a-473f-abf1-f35ef6ab8ae1',
+    jsonb_build_object(
+        'id', 'f838cdaf-555a-473f-abf1-f35ef6ab8ae1',
+        'name', 'Transit',
+        'active', true,
+        'template', '<p></p>')) ON CONFLICT DO NOTHING;

--- a/src/main/resources/templates/db_scripts/schema.json
+++ b/src/main/resources/templates/db_scripts/schema.json
@@ -353,7 +353,7 @@
     {
       "run": "after",
       "snippetPath": "add_staff_slips_hold_transit.sql",
-      "fromModuleVersion": "12.2.0"
+      "fromModuleVersion": "12.3.0"
     }
   ]
 }

--- a/src/main/resources/templates/db_scripts/schema.json
+++ b/src/main/resources/templates/db_scripts/schema.json
@@ -349,6 +349,11 @@
     {
       "run": "after",
       "snippetPath": "index_dateLostItemShouldBeBilled.sql"
+    },
+    {
+      "run": "after",
+      "snippetPath": "add_staff_slips_hold_transit.sql",
+      "fromModuleVersion": "12.2.0"
     }
   ]
 }

--- a/src/test/java/org/folio/rest/api/StorageTestSuite.java
+++ b/src/test/java/org/folio/rest/api/StorageTestSuite.java
@@ -26,7 +26,7 @@ import com.github.tomakehurst.wiremock.WireMockServer;
 
 import org.folio.rest.RestVerticle;
 import org.folio.rest.api.loans.LoansAnonymizationApiTest;
-import org.folio.rest.api.migration.StaffSlipsMigrationScriptTest;
+import org.folio.rest.api.migration.StaffSlipsPickRequestMigrationScriptTest;
 import org.folio.rest.api.migration.StaffSlipsHoldTransitMigrationScriptTest;
 import org.folio.rest.persist.Criteria.Criterion;
 import org.folio.rest.persist.PostgresClient;
@@ -69,7 +69,7 @@ import io.vertx.sqlclient.RowSet;
   PatronActionSessionAPITest.class,
   RequestBatchAPITest.class,
   CheckInStorageApiTest.class,
-  StaffSlipsMigrationScriptTest.class,
+  StaffSlipsPickRequestMigrationScriptTest.class,
   StaffSlipsHoldTransitMigrationScriptTest.class,
   RequestUpdateTriggerTest.class,
   JsonPropertyWriterTest.class

--- a/src/test/java/org/folio/rest/api/StorageTestSuite.java
+++ b/src/test/java/org/folio/rest/api/StorageTestSuite.java
@@ -27,6 +27,7 @@ import com.github.tomakehurst.wiremock.WireMockServer;
 import org.folio.rest.RestVerticle;
 import org.folio.rest.api.loans.LoansAnonymizationApiTest;
 import org.folio.rest.api.migration.StaffSlipsMigrationScriptTest;
+import org.folio.rest.api.migration.StaffSlipsHoldTransitMigrationScriptTest;
 import org.folio.rest.persist.Criteria.Criterion;
 import org.folio.rest.persist.PostgresClient;
 import org.folio.rest.support.JsonResponse;
@@ -69,6 +70,7 @@ import io.vertx.sqlclient.RowSet;
   RequestBatchAPITest.class,
   CheckInStorageApiTest.class,
   StaffSlipsMigrationScriptTest.class,
+  StaffSlipsHoldTransitMigrationScriptTest.class,
   RequestUpdateTriggerTest.class,
   JsonPropertyWriterTest.class
 })

--- a/src/test/java/org/folio/rest/api/migration/StaffSlipsHoldTransitMigrationScriptTest.java
+++ b/src/test/java/org/folio/rest/api/migration/StaffSlipsHoldTransitMigrationScriptTest.java
@@ -1,11 +1,12 @@
 package org.folio.rest.api.migration;
 
-import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 
-import io.vertx.core.json.JsonArray;
-import io.vertx.core.json.JsonObject;
-import org.apache.commons.lang3.StringUtils;
+import java.net.HttpURLConnection;
+import java.net.MalformedURLException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+
 import org.folio.rest.api.StorageTestSuite;
 import org.folio.rest.support.JsonResponse;
 import org.folio.rest.support.ResponseHandler;
@@ -13,16 +14,12 @@ import org.hamcrest.core.Is;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.net.HttpURLConnection;
-import java.net.MalformedURLException;
-import java.net.URL;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.TimeUnit;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
 
-public class StaffSlipsHoldTransitMigrationScriptTest extends MigrationTestBase {
+public class StaffSlipsHoldTransitMigrationScriptTest extends StaffSlipsMigrationTestBase {
   public static final String HOLD_ID = "6a6e72f0-69da-4b4c-8254-7154679e9d88";
   public static final String TRANSIT_ID = "f838cdaf-555a-473f-abf1-f35ef6ab8ae1";
-  public static final String TEMPLATE = "<p></p>";
   private static final String MIGRATION_SCRIPT = loadScript("add_staff_slips_hold_transit.sql");
 
   @Before
@@ -48,25 +45,5 @@ public class StaffSlipsHoldTransitMigrationScriptTest extends MigrationTestBase 
 
     assertStaffSlip(hold, HOLD_ID, "Hold");
     assertStaffSlip(transit, TRANSIT_ID, "Transit");
-  }
-
-  private JsonObject getRecordById(JsonArray collection, String id) {
-    return collection.stream()
-      .map(index -> (JsonObject) index)
-      .filter(request -> StringUtils.equals(request.getString("id"), id))
-      .findFirst().orElse(null);
-  }
-
-  private void assertStaffSlip(JsonObject staffSlip, String expectedId,
-    String expectedName) {
-
-    assertThat(staffSlip.getString("id"), is(expectedId));
-    assertThat(staffSlip.getString("name"), is(expectedName));
-    assertThat(staffSlip.getBoolean("active"), is(true));
-    assertThat(staffSlip.getString("template"), is(TEMPLATE));
-  }
-
-  private URL staffSlipsStorageUrl(String subPath) throws MalformedURLException {
-    return StorageTestSuite.storageUrl("/staff-slips-storage/staff-slips" + subPath);
   }
 }

--- a/src/test/java/org/folio/rest/api/migration/StaffSlipsHoldTransitMigrationScriptTest.java
+++ b/src/test/java/org/folio/rest/api/migration/StaffSlipsHoldTransitMigrationScriptTest.java
@@ -1,0 +1,89 @@
+package org.folio.rest.api.migration;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import org.apache.commons.lang3.StringUtils;
+import org.folio.rest.api.StorageTestSuite;
+import org.folio.rest.support.JsonResponse;
+import org.folio.rest.support.ResponseHandler;
+import org.hamcrest.core.Is;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.net.HttpURLConnection;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+/*
+
+INSERT INTO ${myuniversity}_${mymodule}.staff_slips(id, jsonb) VALUES (
+    '6a6e72f0-69da-4b4c-8254-7154679e9d88',
+    jsonb_build_object(
+        'id', '6a6e72f0-69da-4b4c-8254-7154679e9d88',
+        'name', 'Hold',
+        'active', true,
+        'template', '<p></p>')) ON CONFLICT DO NOTHING;
+
+INSERT INTO ${myuniversity}_${mymodule}.staff_slips(id, jsonb) VALUES (
+    'f838cdaf-555a-473f-abf1-f35ef6ab8ae1',
+    jsonb_build_object(
+        'id', 'f838cdaf-555a-473f-abf1-f35ef6ab8ae1',
+        'name', 'Transit',
+        'active', true,
+        'template', '<p></p>')) ON CONFLICT DO NOTHING;
+*/
+public class StaffSlipsMigrationScriptTest extends MigrationTestBase {
+  public static final String HOLD_ID = "6a6e72f0-69da-4b4c-8254-7154679e9d88";
+  public static final String TRANSIT_ID = "f838cdaf-555a-473f-abf1-f35ef6ab8ae1";
+  public static final String TEMPLATE = "<p></p>";
+  private static final String MIGRATION_SCRIPT = loadScript("add_staff_slips_hold_transit.sql");
+
+  @Before
+  public void beforeEach() throws MalformedURLException {
+    StorageTestSuite.deleteAll(staffSlipsStorageUrl(""));
+  }
+
+  @Test
+  public void canMigrateStaffSlips() throws Exception {
+
+    executeMultipleSqlStatements(MIGRATION_SCRIPT);
+
+    CompletableFuture<JsonResponse> getCompleted = new CompletableFuture<>();
+    client.get(staffSlipsStorageUrl(""), StorageTestSuite.TENANT_ID, ResponseHandler.json(getCompleted));
+    JsonResponse getResponse = getCompleted.get(5, TimeUnit.SECONDS);
+
+    assertThat(getResponse.getStatusCode(), Is.is(HttpURLConnection.HTTP_OK));
+
+    JsonArray slipsJsonArray = getResponse.getJson().getJsonArray("staffSlips");
+
+    JsonObject hold = getRecordById(slipsJsonArray, HOLD_ID);
+    JsonObject transit = getRecordById(slipsJsonArray, TRANSIT_ID);
+
+    assertStaffSlip(hold, HOLD_ID, "Hold");
+    assertStaffSlip(transit, TRANSIT_ID, "Transit");
+  }
+
+  private JsonObject getRecordById(JsonArray collection, String id) {
+    return collection.stream()
+      .map(index -> (JsonObject) index)
+      .filter(request -> StringUtils.equals(request.getString("id"), id))
+      .findFirst().orElse(null);
+  }
+
+  private void assertStaffSlip(JsonObject staffSlip, String expectedId,
+    String expectedName) {
+
+    assertThat(staffSlip.getString("id"), is(expectedId));
+    assertThat(staffSlip.getString("name"), is(expectedName));
+    assertThat(staffSlip.getBoolean("active"), is(true));
+    assertThat(staffSlip.getString("template"), is(TEMPLATE));
+  }
+
+  private URL staffSlipsStorageUrl(String subPath) throws MalformedURLException {
+    return StorageTestSuite.storageUrl("/staff-slips-storage/staff-slips" + subPath);
+  }
+}

--- a/src/test/java/org/folio/rest/api/migration/StaffSlipsHoldTransitMigrationScriptTest.java
+++ b/src/test/java/org/folio/rest/api/migration/StaffSlipsHoldTransitMigrationScriptTest.java
@@ -19,7 +19,7 @@ import java.net.URL;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 
-public class StaffSlipsMigrationScriptTest extends MigrationTestBase {
+public class StaffSlipsHoldTransitMigrationScriptTest extends MigrationTestBase {
   public static final String HOLD_ID = "6a6e72f0-69da-4b4c-8254-7154679e9d88";
   public static final String TRANSIT_ID = "f838cdaf-555a-473f-abf1-f35ef6ab8ae1";
   public static final String TEMPLATE = "<p></p>";

--- a/src/test/java/org/folio/rest/api/migration/StaffSlipsHoldTransitMigrationScriptTest.java
+++ b/src/test/java/org/folio/rest/api/migration/StaffSlipsHoldTransitMigrationScriptTest.java
@@ -18,24 +18,7 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
-/*
 
-INSERT INTO ${myuniversity}_${mymodule}.staff_slips(id, jsonb) VALUES (
-    '6a6e72f0-69da-4b4c-8254-7154679e9d88',
-    jsonb_build_object(
-        'id', '6a6e72f0-69da-4b4c-8254-7154679e9d88',
-        'name', 'Hold',
-        'active', true,
-        'template', '<p></p>')) ON CONFLICT DO NOTHING;
-
-INSERT INTO ${myuniversity}_${mymodule}.staff_slips(id, jsonb) VALUES (
-    'f838cdaf-555a-473f-abf1-f35ef6ab8ae1',
-    jsonb_build_object(
-        'id', 'f838cdaf-555a-473f-abf1-f35ef6ab8ae1',
-        'name', 'Transit',
-        'active', true,
-        'template', '<p></p>')) ON CONFLICT DO NOTHING;
-*/
 public class StaffSlipsMigrationScriptTest extends MigrationTestBase {
   public static final String HOLD_ID = "6a6e72f0-69da-4b4c-8254-7154679e9d88";
   public static final String TRANSIT_ID = "f838cdaf-555a-473f-abf1-f35ef6ab8ae1";

--- a/src/test/java/org/folio/rest/api/migration/StaffSlipsMigrationTestBase.java
+++ b/src/test/java/org/folio/rest/api/migration/StaffSlipsMigrationTestBase.java
@@ -1,0 +1,37 @@
+package org.folio.rest.api.migration;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+
+import org.apache.commons.lang3.StringUtils;
+import org.folio.rest.api.StorageTestSuite;
+
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+
+public class StaffSlipsMigrationTestBase extends MigrationTestBase {
+  public static final String TEMPLATE = "<p></p>";
+
+  JsonObject getRecordById(JsonArray collection, String id) {
+    return collection.stream()
+      .map(index -> (JsonObject) index)
+      .filter(request -> StringUtils.equals(request.getString("id"), id))
+      .findFirst().orElse(null);
+  }
+
+  void assertStaffSlip(JsonObject staffSlip, String expectedId,
+    String expectedName) {
+
+    assertThat(staffSlip.getString("id"), is(expectedId));
+    assertThat(staffSlip.getString("name"), is(expectedName));
+    assertThat(staffSlip.getBoolean("active"), is(true));
+    assertThat(staffSlip.getString("template"), is(TEMPLATE));
+  }
+
+  URL staffSlipsStorageUrl(String subPath) throws MalformedURLException {
+    return StorageTestSuite.storageUrl("/staff-slips-storage/staff-slips" + subPath);
+  }
+}

--- a/src/test/java/org/folio/rest/api/migration/StaffSlipsPickRequestMigrationScriptTest.java
+++ b/src/test/java/org/folio/rest/api/migration/StaffSlipsPickRequestMigrationScriptTest.java
@@ -1,11 +1,12 @@
 package org.folio.rest.api.migration;
 
-import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 
-import io.vertx.core.json.JsonArray;
-import io.vertx.core.json.JsonObject;
-import org.apache.commons.lang3.StringUtils;
+import java.net.HttpURLConnection;
+import java.net.MalformedURLException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+
 import org.folio.rest.api.StorageTestSuite;
 import org.folio.rest.support.JsonResponse;
 import org.folio.rest.support.ResponseHandler;
@@ -13,16 +14,12 @@ import org.hamcrest.core.Is;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.net.HttpURLConnection;
-import java.net.MalformedURLException;
-import java.net.URL;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.TimeUnit;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
 
-public class StaffSlipsMigrationScriptTest extends MigrationTestBase {
+public class StaffSlipsPickRequestMigrationScriptTest extends StaffSlipsMigrationTestBase {
   public static final String PICK_SLIPS_ID = "8812bae1-2738-442c-bc20-fe4bb38a11f8";
   public static final String REQUEST_DELIVERY_ID = "1ed55c5c-64d9-40eb-8b80-7438a262288b";
-  public static final String TEMPLATE = "<p></p>";
   private static final String MIGRATION_SCRIPT = loadScript("add_staff_slips.sql");
 
   @Before
@@ -48,25 +45,5 @@ public class StaffSlipsMigrationScriptTest extends MigrationTestBase {
 
     assertStaffSlip(pickSlips, PICK_SLIPS_ID, "Pick slip");
     assertStaffSlip(requestDelivery, REQUEST_DELIVERY_ID, "Request delivery");
-  }
-
-  private JsonObject getRecordById(JsonArray collection, String id) {
-    return collection.stream()
-      .map(index -> (JsonObject) index)
-      .filter(request -> StringUtils.equals(request.getString("id"), id))
-      .findFirst().orElse(null);
-  }
-
-  private void assertStaffSlip(JsonObject staffSlip, String expectedId,
-    String expectedName) {
-
-    assertThat(staffSlip.getString("id"), is(expectedId));
-    assertThat(staffSlip.getString("name"), is(expectedName));
-    assertThat(staffSlip.getBoolean("active"), is(true));
-    assertThat(staffSlip.getString("template"), is(TEMPLATE));
-  }
-
-  private URL staffSlipsStorageUrl(String subPath) throws MalformedURLException {
-    return StorageTestSuite.storageUrl("/staff-slips-storage/staff-slips" + subPath);
   }
 }


### PR DESCRIPTION
The reference data includes four slips (hold, pick-slip,
request-delivery, and transit) but only two (pick-slip,
request-delivery) were included in migrations. This meant new tenants
would have all four slips available but tenants migrated from previous
releases would only have two.

Refs [CIRCSTORE-273](https://issues.folio.org/browse/CIRCSTORE-273)