### PR TITLE
CIRCSTORE-265 - Pickup expired not showing in Circulation log

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -122,7 +122,7 @@
     <dependency>
       <groupId>org.folio</groupId>
       <artifactId>mod-pubsub-client</artifactId>
-      <version>2.0.0</version>
+      <version>2.0.2</version>
       <exclusions>
         <exclusion>
           <groupId>org.hamcrest</groupId>


### PR DESCRIPTION
[CIRCSTORE-265](https://issues.folio.org/browse/CIRCSTORE-265) - Pickup expired not showing in Circulation log

* Updated pubsub client to 2.0.2