### PR TITLE
Upgrade to RMB 33.0.0 CIRCSTORE-280

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,9 @@
-## 12.3.0 IN-PROGRESS
+## 13.0.0 IN-PROGRESS
 
 * Use normalization for request.item.identifiers (for search requests by ISBN) (CIRCSTORE-186)
+* `embed_postgres` command line option is no longer supported (CIRCSTORE-280)
+* Upgrades to RAML Module Builder 33.0.0 (CIRCSTORE-280)
+* Upgrades to 4.1.0.CR1 (CIRCSTORE-280)
 
 ## 12.2.0 2021-03-09
 

--- a/pom.xml
+++ b/pom.xml
@@ -14,8 +14,15 @@
       <id>folio-nexus</id>
       <name>FOLIO Maven repository</name>
       <url>https://repository.folio.org/repository/maven-folio</url>
-    </repository>
+  </repository>
   </repositories>
+  <pluginRepositories>
+    <pluginRepository>
+      <id>folio-nexus</id>
+      <name>FOLIO Maven repository</name>
+      <url>https://repository.folio.org/repository/maven-folio</url>
+    </pluginRepository>
+  </pluginRepositories>
 
   <dependencyManagement>
     <dependencies>
@@ -165,7 +172,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <ramlfiles_path>${basedir}/ramls</ramlfiles_path>
     <vertx-version>4.0.0</vertx-version>
-    <raml-module-builder-version>32.2.0</raml-module-builder-version>
+    <raml-module-builder-version>33.0.0</raml-module-builder-version>
     <spring.version>5.2.7.RELEASE</spring.version>
     <argLine />
   </properties>
@@ -211,26 +218,15 @@
         </configuration>
       </plugin>
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>exec-maven-plugin</artifactId>
-        <version>3.0.0</version>
+        <groupId>org.folio</groupId>
+        <artifactId>domain-models-maven-plugin</artifactId>
+        <version>${raml-module-builder-version}</version>
         <executions>
           <execution>
             <id>generate_interfaces</id>
-            <phase>generate-sources</phase>
             <goals>
               <goal>java</goal>
             </goals>
-            <configuration>
-              <mainClass>org.folio.rest.tools.GenerateRunner</mainClass>
-              <cleanupDaemonThreads>false</cleanupDaemonThreads>
-              <systemProperties>
-                <systemProperty>
-                  <key>raml_files</key>
-                  <value>${ramlfiles_path}</value>
-                </systemProperty>
-              </systemProperties>
-            </configuration>
           </execution>
         </executions>
       </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <artifactId>mod-circulation-storage</artifactId>
   <groupId>org.folio</groupId>
-  <version>12.3.0-SNAPSHOT</version>
+  <version>13.0.0-SNAPSHOT</version>
   <licenses>
     <license>
       <name>Apache License 2.0</name>

--- a/pom.xml
+++ b/pom.xml
@@ -171,7 +171,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <ramlfiles_path>${basedir}/ramls</ramlfiles_path>
-    <vertx-version>4.0.0</vertx-version>
+    <vertx-version>4.1.0.CR1</vertx-version>
     <raml-module-builder-version>33.0.0</raml-module-builder-version>
     <spring.version>5.2.7.RELEASE</spring.version>
     <argLine />

--- a/pom.xml
+++ b/pom.xml
@@ -129,7 +129,7 @@
     <dependency>
       <groupId>org.folio</groupId>
       <artifactId>mod-pubsub-client</artifactId>
-      <version>2.0.2</version>
+      <version>2.2.0</version>
       <exclusions>
         <exclusion>
           <groupId>org.hamcrest</groupId>

--- a/src/main/java/org/folio/rest/impl/CancellationReasonsAPI.java
+++ b/src/main/java/org/folio/rest/impl/CancellationReasonsAPI.java
@@ -48,7 +48,7 @@ public class CancellationReasonsAPI implements CancellationReasonStorage {
     try {
       String tenantId = okapiHeaders.get(TENANT_HEADER);
       String deleteAllQuery = String.format("DELETE FROM %s_%s.%s", tenantId,
-          PomReader.INSTANCE.getModuleName(), TABLE_NAME);
+          PomReader.getModuleName(), TABLE_NAME);
       PostgresClient.getInstance(vertxContext.owner(), tenantId).execute(deleteAllQuery,
           mutateReply -> {
         if(mutateReply.failed()) {

--- a/src/main/java/org/folio/rest/impl/CancellationReasonsAPI.java
+++ b/src/main/java/org/folio/rest/impl/CancellationReasonsAPI.java
@@ -12,7 +12,8 @@ import org.folio.rest.jaxrs.model.CancellationReasons;
 import org.folio.rest.jaxrs.resource.CancellationReasonStorage;
 import org.folio.rest.persist.PgUtil;
 import org.folio.rest.persist.PostgresClient;
-import org.folio.rest.tools.PomReader;
+import org.folio.rest.tools.utils.ModuleName;
+
 import javax.ws.rs.core.Response;
 import java.util.Map;
 import static org.folio.rest.impl.Headers.TENANT_HEADER;
@@ -48,7 +49,7 @@ public class CancellationReasonsAPI implements CancellationReasonStorage {
     try {
       String tenantId = okapiHeaders.get(TENANT_HEADER);
       String deleteAllQuery = String.format("DELETE FROM %s_%s.%s", tenantId,
-          PomReader.getModuleName(), TABLE_NAME);
+          ModuleName.getModuleName(), TABLE_NAME);
       PostgresClient.getInstance(vertxContext.owner(), tenantId).execute(deleteAllQuery,
           mutateReply -> {
         if(mutateReply.failed()) {

--- a/src/main/java/org/folio/rest/impl/FixedDueDateSchedulesAPI.java
+++ b/src/main/java/org/folio/rest/impl/FixedDueDateSchedulesAPI.java
@@ -9,7 +9,6 @@ import org.folio.rest.jaxrs.model.FixedDueDateSchedule;
 import org.folio.rest.jaxrs.model.FixedDueDateSchedules;
 import org.folio.rest.jaxrs.model.Schedule;
 import org.folio.rest.jaxrs.resource.FixedDueDateScheduleStorage;
-import org.folio.rest.persist.MyPgUtil;
 import org.folio.rest.persist.PgUtil;
 import org.folio.rest.persist.PostgresClient;
 import org.folio.rest.tools.PomReader;
@@ -49,7 +48,7 @@ public class FixedDueDateSchedulesAPI implements FixedDueDateScheduleStorage {
 
         postgresClient.execute(
             String.format("DELETE FROM %s_%s.%s", tenantId,
-              PomReader.INSTANCE.getModuleName(), FIXED_SCHEDULE_TABLE), reply -> {
+              PomReader.getModuleName(), FIXED_SCHEDULE_TABLE), reply -> {
                 if(reply.succeeded()){
                   asyncResultHandler.handle(io.vertx.core.Future.succeededFuture(
                     FixedDueDateScheduleStorage

--- a/src/main/java/org/folio/rest/impl/FixedDueDateSchedulesAPI.java
+++ b/src/main/java/org/folio/rest/impl/FixedDueDateSchedulesAPI.java
@@ -9,9 +9,10 @@ import org.folio.rest.jaxrs.model.FixedDueDateSchedule;
 import org.folio.rest.jaxrs.model.FixedDueDateSchedules;
 import org.folio.rest.jaxrs.model.Schedule;
 import org.folio.rest.jaxrs.resource.FixedDueDateScheduleStorage;
+import org.folio.rest.persist.MyPgUtil;
 import org.folio.rest.persist.PgUtil;
 import org.folio.rest.persist.PostgresClient;
-import org.folio.rest.tools.PomReader;
+import org.folio.rest.tools.utils.ModuleName;
 import org.folio.rest.tools.utils.TenantTool;
 import org.folio.rest.tools.utils.ValidationHelper;
 import org.folio.support.UUIDValidation;
@@ -48,7 +49,7 @@ public class FixedDueDateSchedulesAPI implements FixedDueDateScheduleStorage {
 
         postgresClient.execute(
             String.format("DELETE FROM %s_%s.%s", tenantId,
-              PomReader.getModuleName(), FIXED_SCHEDULE_TABLE), reply -> {
+              ModuleName.getModuleName(), FIXED_SCHEDULE_TABLE), reply -> {
                 if(reply.succeeded()){
                   asyncResultHandler.handle(io.vertx.core.Future.succeededFuture(
                     FixedDueDateScheduleStorage

--- a/src/main/java/org/folio/service/PubSubPublishingService.java
+++ b/src/main/java/org/folio/service/PubSubPublishingService.java
@@ -34,7 +34,7 @@ class PubSubPublishingService {
       .toString())
       .withEventType(eventType)
       .withEventPayload(payload)
-      .withEventMetadata(new EventMetadata().withPublishedBy(PubSubClientUtils.constructModuleName())
+      .withEventMetadata(new EventMetadata().withPublishedBy(PubSubClientUtils.getModuleId())
         .withTenantId(okapiHeaders.get(OKAPI_TENANT_HEADER))
         .withEventTTL(1));
 

--- a/src/main/java/org/folio/service/PubSubRegistrationService.java
+++ b/src/main/java/org/folio/service/PubSubRegistrationService.java
@@ -47,7 +47,7 @@ public class PubSubRegistrationService {
     try {
       for (EventType eventType : EventType.values()) {
         CompletableFuture<Boolean> future = new CompletableFuture<>();
-        client.deletePubsubEventTypesPublishersByEventTypeName(eventType.name(), PubSubClientUtils.constructModuleName(), ar -> {
+        client.deletePubsubEventTypesPublishersByEventTypeName(eventType.name(), PubSubClientUtils.getModuleId(), ar -> {
           if (ar.result().statusCode() == HTTP_NO_CONTENT.toInt()) {
             future.complete(true);
           } else {

--- a/src/main/java/org/folio/service/PubSubRegistrationService.java
+++ b/src/main/java/org/folio/service/PubSubRegistrationService.java
@@ -1,22 +1,14 @@
 package org.folio.service;
 
-import static java.util.concurrent.CompletableFuture.allOf;
-import static org.folio.HttpStatus.HTTP_NO_CONTENT;
-
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
-import org.folio.rest.client.PubsubClient;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.folio.rest.util.OkapiConnectionParams;
-import org.folio.support.EventType;
-import org.folio.support.exception.ModulePubSubUnregisteringException;
 import org.folio.util.pubsub.PubSubClientUtils;
 
 import io.vertx.core.Vertx;
-import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.LogManager;
 
 public class PubSubRegistrationService {
   private static final Logger logger = LogManager.getLogger();
@@ -36,35 +28,4 @@ public class PubSubRegistrationService {
         }
       });
   }
-
-  public static CompletableFuture<Boolean> unregisterModule(Map<String, String> headers, Vertx vertx) {
-
-    List<CompletableFuture<Boolean>> list = new ArrayList<>();
-
-    OkapiConnectionParams params = new OkapiConnectionParams(headers, vertx);
-    PubsubClient client = new PubsubClient(params.getOkapiUrl(), params.getTenantId(), params.getToken());
-
-    try {
-      for (EventType eventType : EventType.values()) {
-        CompletableFuture<Boolean> future = new CompletableFuture<>();
-        client.deletePubsubEventTypesPublishersByEventTypeName(eventType.name(), PubSubClientUtils.getModuleId(), ar -> {
-          if (ar.result().statusCode() == HTTP_NO_CONTENT.toInt()) {
-            future.complete(true);
-          } else {
-            ModulePubSubUnregisteringException exception = new ModulePubSubUnregisteringException(
-                String.format("Module's publisher for event type %s was not unregistered from PubSub. HTTP status: %s",
-                    eventType.name(), ar.result().statusCode()));
-            logger.error(exception);
-            future.completeExceptionally(exception);
-          }
-        });
-        list.add(future);
-      }
-    } catch (Exception exception) {
-      logger.error("Module's publishers were not unregistered from PubSub.", exception);
-    }
-
-    return allOf(list.toArray(new CompletableFuture[0])).thenApply(r -> true);
-  }
-
 }

--- a/src/test/java/org/folio/rest/api/AnonymizeLoansApiTest.java
+++ b/src/test/java/org/folio/rest/api/AnonymizeLoansApiTest.java
@@ -83,10 +83,12 @@ public class AnonymizeLoansApiTest extends ApiTests {
     assertThat(loansClient.getById(firstLoanId).getJson(), isAnonymized());
     assertThat(loansClient.getById(secondLoanId).getJson(), isAnonymized());
 
+    // Check out, check in and anonymize entries for two loans
+    assertThat(getLoanHistoryForLoans().size(), is(6));
+
     // assert that history also anonymized
-    assertThat(getLoanHistoryForLoans(),
-      // Check out, check in and anonymize entries for two loans
-      allOf(iterableWithSize(6), everyItem(LoanHistoryMatchers.isAnonymized())));
+    assertThat(getLoanHistoryForLoans(), everyItem(LoanHistoryMatchers.isAnonymized()));
+
   }
 
   @Test

--- a/src/test/java/org/folio/rest/api/RequestsApiTest.java
+++ b/src/test/java/org/folio/rest/api/RequestsApiTest.java
@@ -268,8 +268,6 @@ public class RequestsApiTest extends ApiTests {
 
     assertThat(String.format("Should not create request: %s", response.getBody()),
       response.getStatusCode(), is(HttpURLConnection.HTTP_BAD_REQUEST));
-
-    assertThat(response.getBody(), containsString("Json content error"));
   }
 
   @Test

--- a/src/test/java/org/folio/rest/api/StorageTestSuite.java
+++ b/src/test/java/org/folio/rest/api/StorageTestSuite.java
@@ -179,8 +179,6 @@ public class StorageTestSuite {
     });
 
     undeploymentComplete.get(20, TimeUnit.SECONDS);
-
-    PostgresClient.stopEmbeddedPostgres();
   }
 
   public static boolean isNotInitialised() {

--- a/src/test/java/org/folio/support/MockServer.java
+++ b/src/test/java/org/folio/support/MockServer.java
@@ -19,9 +19,9 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
-import static org.assertj.core.api.Fail.fail;
 import static org.folio.HttpStatus.HTTP_CREATED;
 import static org.folio.HttpStatus.HTTP_NO_CONTENT;
+import static org.junit.Assert.fail;
 
 public class MockServer extends AbstractVerticle {
 


### PR DESCRIPTION
* Upgrades to RMB 33.0.0 and Vert.x 4.1.0.CR1
* Upgrades the pub-sub client as it needs to use the same version of RMB (2.x includes breaking changes, so code needed to be changed)
* The `unregisterModule` method is unused so has been removed
* Removing the `embed_postgres` command line parameter makes this a breaking compatibility change
