### PR TITLE
[CIRCSTORE-285] Update mod-pubsub-client to v2.3.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -129,7 +129,7 @@
     <dependency>
       <groupId>org.folio</groupId>
       <artifactId>mod-pubsub-client</artifactId>
-      <version>2.2.0</version>
+      <version>2.3.0</version>
       <exclusions>
         <exclusion>
           <groupId>org.hamcrest</groupId>


### PR DESCRIPTION
Update `mod-pubsub-client` dependency to v2.3.0. Resolves [CIRCSTORE-285](https://issues.folio.org/browse/CIRCSTORE-285).