### PR TITLE
Remove code owners CIRCSTORE-289

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,0 @@
-* @folio-org/circulation-backend-code-owners


### PR DESCRIPTION
As the module is maintained by multiple teams the review requests generated by the code owners definition leads to unnecessary notifications that slow down the review process as folks start to ignore them