### PR TITLE
CIRCSTORE-304: RMB 33.1.1, Vert.x 4.2.1, Spring 5.2.18, PubSub 2.4.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,6 +24,16 @@
     </pluginRepository>
   </pluginRepositories>
 
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+    <ramlfiles_path>${basedir}/ramls</ramlfiles_path>
+    <vertx-version>4.2.1</vertx-version>
+    <raml-module-builder-version>33.1.1</raml-module-builder-version>
+    <spring.version>5.2.18.RELEASE</spring.version>
+    <argLine />
+  </properties>
+
   <dependencyManagement>
     <dependencies>
       <dependency>
@@ -32,16 +42,6 @@
         <version>${vertx-version}</version>
         <type>pom</type>
         <scope>import</scope>
-      </dependency>
-      <dependency>
-        <groupId>io.vertx</groupId>
-        <artifactId>vertx-sql-client</artifactId>
-        <version>${vertx-version}-FOLIO</version>
-      </dependency>
-      <dependency>
-        <groupId>io.vertx</groupId>
-        <artifactId>vertx-pg-client</artifactId>
-        <version>${vertx-version}-FOLIO</version>
       </dependency>
     </dependencies>
   </dependencyManagement>
@@ -129,7 +129,7 @@
     <dependency>
       <groupId>org.folio</groupId>
       <artifactId>mod-pubsub-client</artifactId>
-      <version>2.3.0</version>
+      <version>2.4.0</version>
       <exclusions>
         <exclusion>
           <groupId>org.hamcrest</groupId>
@@ -166,16 +166,6 @@
       <version>1.7.13</version>
     </dependency>
   </dependencies>
-
-  <properties>
-    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <ramlfiles_path>${basedir}/ramls</ramlfiles_path>
-    <vertx-version>4.1.0.CR1</vertx-version>
-    <raml-module-builder-version>33.0.0</raml-module-builder-version>
-    <spring.version>5.2.7.RELEASE</spring.version>
-    <argLine />
-  </properties>
 
   <distributionManagement>
     <repository>


### PR DESCRIPTION
Fixes loan.userId index usage in CQL query.

Update RMB from to 33.1.1.
Update Vert.x from 4.1.0.CR1 to 4.2.1.
Update Spring from 5.2.7 to 5.2.18.
Update mod-pubsub-client from 2.3.0 to 2.4.0.

Move <properties> section to top of pom.xml for readability.

Remove FOLIO forks of vertx-sql-client and vertx-pg-client,
they are no longer needed: https://github.com/folio-org/raml-module-builder/blob/master/doc/upgrading.md#version-331

Updating RMB fixes the loan.userId query because of
https://issues.folio.org/browse/RMB-864 "Ignore deleted index in schema.json".