### PR TITLE
[CIRCSTORE-321] Create likeIndex for itemId to improve performance of Items In Transit Report

### DIFF
--- a/src/main/resources/templates/db_scripts/schema.json
+++ b/src/main/resources/templates/db_scripts/schema.json
@@ -21,6 +21,14 @@
           "whereClause": "WHERE lower(f_unaccent((jsonb->'status'->>'name'))) LIKE 'open'"
         }
       ],
+      "likeIndex": [
+        {
+          "fieldName": "itemId",
+          "tOps": "ADD",
+          "caseSensitive": false,
+          "removeAccents": true
+        }
+      ],
       "ginIndex": [
         {
           "fieldName": "userId",


### PR DESCRIPTION
Resolves [CIRCSTORE-321](https://issues.folio.org/browse/CIRCSTORE-321).

In order to build Items In Transit Report mod-circulation needs to find loans with `"itemStatus": "In transit"` by a list of `itemId`'s:
```
/loan-storage/loans?query=itemId==("b047195f-31b4-43e6-bf80-9bb2e37ce06a" or "6717378c-5808-4c04-a777-ad84690da568" or [... more ids here ...] or "9ac35413-a6bd-4569-a141-e6718c57b830") and itemStatus=="In transit"&limit=2147483647
```
which is then transformed into a DB query within mod-circulation-storage:
```
EXPLAIN ANALYZE SELECT jsonb,id FROM diku_mod_circulation_storage.loan
WHERE (((((((((((((((((((((((((((((((((((((((((((((((((
 (lower(diku_mod_circulation_storage.f_unaccent(loan.jsonb->>'itemId')) LIKE lower(diku_mod_circulation_storage.f_unaccent('b047195f-31b4-43e6-bf80-9bb2e37ce06a'))) OR 
 (lower(diku_mod_circulation_storage.f_unaccent(loan.jsonb->>'itemId')) LIKE lower(diku_mod_circulation_storage.f_unaccent('6717378c-5808-4c04-a777-ad84690da568')))) OR 

[... more ids here ...]

  OR (lower(diku_mod_circulation_storage.f_unaccent(loan.jsonb->>'itemId')) LIKE lower(diku_mod_circulation_storage.f_unaccent('9ac35413-a6bd-4569-a141-e6718c57b830'))))
 AND (CASE
 WHEN length(lower(diku_mod_circulation_storage.f_unaccent('In transit'))) <= 600
 THEN left(lower(diku_mod_circulation_storage.f_unaccent(loan.jsonb->>'itemStatus')),600) LIKE lower(diku_mod_circulation_storage.f_unaccent('In transit'))
 ELSE left(lower(diku_mod_circulation_storage.f_unaccent(loan.jsonb->>'itemStatus')),600) LIKE left(lower(diku_mod_circulation_storage.f_unaccent('In transit')),600)
 AND lower(diku_mod_circulation_storage.f_unaccent(loan.jsonb->>'itemStatus')) LIKE lower(diku_mod_circulation_storage.f_unaccent('In transit')) END) LIMIT 2147483647 OFFSET 0
```

which, when executed, makes use of index by `itemStatus`, but does not use the existing index by `itemId` since this index requires that the expression is wrapped in `left(... , 600)`:
```
CREATE INDEX loan_itemid_idx
    ON diku_mod_circulation_storage.loan USING btree
    ("left"(lower(diku_mod_circulation_storage.f_unaccent(jsonb ->> 'itemId'::text)), 600) COLLATE pg_catalog."default" ASC NULLS LAST)
    TABLESPACE pg_default;
```
One way to improve the performance of the query is to create a `likeIndex` which does not require this truncation.