### PR TITLE
CIRCSTORE-325: Replace slf4j-log4j12/slf4j-api by log4j-slf4j-impl

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,6 +50,13 @@
         <type>pom</type>
         <scope>import</scope>
       </dependency>
+      <dependency>
+        <groupId>org.apache.logging.log4j</groupId>
+        <artifactId>log4j-bom</artifactId>
+        <version>2.17.2</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 
@@ -173,14 +180,8 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-api</artifactId>
-      <version>1.7.30</version>
-    </dependency>
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-log4j12</artifactId>
-      <version>1.7.13</version>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-slf4j-impl</artifactId>
     </dependency>
     <dependency>
       <groupId>org.testcontainers</groupId>


### PR DESCRIPTION
mod-circulation-storage uses both log4j implementation and slf4j implementation for logging.

RMB based modules use log4j for logging. Therefore slf4j-log4j12/slf4j-api should be replaced by log4j-slf4j-impl so that only log4j implementation is used for logging while providing both interfaces (log4j and slf4j).

mod-circulation-storage uses org.slf4j:slf4j-log4j12@1.7.13 that requires log4j:log4j@1.2.17 that has many security vulnerabilities; after a rough skim I don't see that mod-circulation-storage is affected, but using recent versions of logging libraries stops security scanners from reporting false positives.

Known issues of log4j:log4j@1.2.17:

* https://nvd.nist.gov/vuln/detail/CVE-2022-23307
* https://nvd.nist.gov/vuln/detail/CVE-2022-23305
* https://nvd.nist.gov/vuln/detail/CVE-2022-23302
* https://nvd.nist.gov/vuln/detail/CVE-2021-4104
* https://nvd.nist.gov/vuln/detail/CVE-2020-9488
* https://nvd.nist.gov/vuln/detail/CVE-2019-17571