### PR TITLE
CIRCSTORE-326 Define missed permission in perm set

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -837,8 +837,8 @@
     },
     {
       "permissionName": "patron-action-session-storage.expired-session-patron-ids.collection.get",
-      "displayName": "Circulation storage - get expired session patrons ids collection",
-      "description": "Get expired session patrons ids collection from storage"
+      "displayName": "Circulation storage - get expired session patron ids collection",
+      "description": "Get expired session patron ids collection from storage"
     },
     {
       "permissionName": "circulation-storage.all",


### PR DESCRIPTION
##Purpose: 
Define missed permission in permission set

Resolves: [CIRCSTORE-326](https://issues.folio.org/browse/CIRCSTORE-326) 