### PR TITLE
CIRCTSTORE-339: Expiration notice not being sent when template selected in TLR settings

### DIFF
--- a/ramls/patron-notice-policy.json
+++ b/ramls/patron-notice-policy.json
@@ -259,7 +259,8 @@
                   "Paging request",
                   "Available",
                   "Hold expiration",
-                  "Request cancellation"
+                  "Request cancellation",
+                  "Title level request expiration"
                 ]
               },
               "sendBy": {

--- a/ramls/patron-notice-policy.json
+++ b/ramls/patron-notice-policy.json
@@ -259,8 +259,7 @@
                   "Paging request",
                   "Available",
                   "Hold expiration",
-                  "Request cancellation",
-                  "Title level request expiration"
+                  "Request cancellation"
                 ]
               },
               "sendBy": {

--- a/ramls/scheduled-notice.json
+++ b/ramls/scheduled-notice.json
@@ -44,7 +44,8 @@
         "Aged to lost",
         "Aged to lost - fine charged",
         "Aged to lost & item returned - fine adjusted",
-        "Aged to lost & item replaced - fine adjusted"
+        "Aged to lost & item replaced - fine adjusted",
+        "Title level request expiration"
       ]
     },
     "noticeConfig": {

--- a/src/test/java/org/folio/rest/api/ScheduledNoticesAPITest.java
+++ b/src/test/java/org/folio/rest/api/ScheduledNoticesAPITest.java
@@ -57,7 +57,8 @@ public class ScheduledNoticesAPITest extends ApiTests {
     "Aged to lost",
     "Aged to lost - fine charged",
     "Aged to lost & item returned - fine adjusted",
-    "Aged to lost & item replaced - fine adjusted"
+    "Aged to lost & item replaced - fine adjusted",
+    "Title level request expiration"
   );
 
   private static final RecurringPeriod ONE_DAY_PERIOD = new RecurringPeriod()
@@ -117,8 +118,8 @@ public class ScheduledNoticesAPITest extends ApiTests {
     JsonResponse response = getCompleted.get(5, SECONDS);
     ScheduledNotices scheduledNotices = response.getJson().mapTo(ScheduledNotices.class);
 
-    assertThat(scheduledNotices.getScheduledNotices().size(), is(9));
-    assertThat(scheduledNotices.getTotalRecords(), is(9));
+    assertThat(scheduledNotices.getScheduledNotices().size(), is(ALL_TRIGGERING_EVENTS.size()));
+    assertThat(scheduledNotices.getTotalRecords(), is(ALL_TRIGGERING_EVENTS.size()));
   }
 
   private void createScheduledNotice(String triggeringEvent)


### PR DESCRIPTION
[CIRCSTORE-339](https://issues.folio.org/browse/CIRCSTORE-339) 

### Purpose

Title Level Request  expiration should be created 

Approach

    TITLE_REQUEST_EXPIRATION is added as an element 

Learning

Learned the way deeper how scheduler and notices work.