### PR TITLE
[CIRCSTORE-340] use valid default UUID

### DIFF
--- a/src/main/java/org/folio/service/tlr/TlrDataMigrationService.java
+++ b/src/main/java/org/folio/service/tlr/TlrDataMigrationService.java
@@ -51,7 +51,8 @@ import lombok.Setter;
  */
 public class TlrDataMigrationService {
   private static final Logger log = LogManager.getLogger(TlrDataMigrationService.class);
-  private static final String DEFAULT_UUID = "00000000-0000-0000-0000-000000000000";
+  // valid UUID version 4 variant 1
+  private static final String DEFAULT_UUID = "00000000-0000-4000-8000-000000000000";
 
   // safe number of UUIDs which fits into Okapi's URL length limit (4096 characters)
   private static final int BATCH_SIZE = 80;

--- a/src/test/java/org/folio/rest/api/TenantRefApiTests.java
+++ b/src/test/java/org/folio/rest/api/TenantRefApiTests.java
@@ -81,7 +81,7 @@ public class TenantRefApiTests {
   private static final String ANY_URL_PARAMS_REGEX_TEMPLATE = "\\?.*";
   private static final String FAIL_SECOND_CALL_SCENARIO = "Test scenario";
   private static final String FIRST_CALL_MADE_SCENARIO_STATE = "First call made";
-  private static final String DEFAULT_UUID = "00000000-0000-0000-0000-000000000000";
+  private static final String DEFAULT_UUID = "00000000-0000-4000-8000-000000000000";
 
   private static StubMapping itemStorageStub;
   private static StubMapping holdingsStorageStub;


### PR DESCRIPTION
Use valid default UUID (version 4, variant 1) compliant with `uuid.schema`.

https://issues.folio.org/browse/CIRCSTORE-340