### PR TITLE
CIRCSTORE-342 Expire requests for only the tenant the job is being called for

### DIFF
--- a/src/main/java/org/folio/rest/impl/Headers.java
+++ b/src/main/java/org/folio/rest/impl/Headers.java
@@ -1,7 +1,7 @@
 package org.folio.rest.impl;
 
-class Headers {
+public class Headers {
   private Headers() {}
 
-  static final String TENANT_HEADER = "x-okapi-tenant";
+  public static final String TENANT_HEADER = "x-okapi-tenant";
 }

--- a/src/main/java/org/folio/rest/impl/RequestExpiryImpl.java
+++ b/src/main/java/org/folio/rest/impl/RequestExpiryImpl.java
@@ -2,6 +2,7 @@
 package org.folio.rest.impl;
 
 import static io.vertx.core.Future.succeededFuture;
+import static org.folio.rest.impl.Headers.TENANT_HEADER;
 import static org.folio.rest.jaxrs.resource.ScheduledRequestExpiration.ScheduledRequestExpirationResponse.respond204;
 import static org.folio.rest.jaxrs.resource.ScheduledRequestExpiration.ScheduledRequestExpirationResponse.respond500WithTextPlain;
 import static org.folio.support.ExpirationTool.doRequestExpirationForTenant;
@@ -23,7 +24,8 @@ public class RequestExpiryImpl implements ScheduledRequestExpiration {
   public void expireRequests(Map<String, String> okapiHeaders,
                              Handler<AsyncResult<Response>> asyncResultHandler, Context context) {
 
-    context.runOnContext(v -> doRequestExpirationForTenant(okapiHeaders, context.owner())
+    context.runOnContext(v -> doRequestExpirationForTenant(okapiHeaders, context.owner(),
+      okapiHeaders.get(TENANT_HEADER))
       .onComplete(result -> {
         if (result.succeeded()) {
           asyncResultHandler.handle(succeededFuture(respond204()));

--- a/src/main/java/org/folio/rest/impl/RequestExpiryImpl.java
+++ b/src/main/java/org/folio/rest/impl/RequestExpiryImpl.java
@@ -2,7 +2,6 @@
 package org.folio.rest.impl;
 
 import static io.vertx.core.Future.succeededFuture;
-import static org.folio.rest.impl.Headers.TENANT_HEADER;
 import static org.folio.rest.jaxrs.resource.ScheduledRequestExpiration.ScheduledRequestExpirationResponse.respond204;
 import static org.folio.rest.jaxrs.resource.ScheduledRequestExpiration.ScheduledRequestExpirationResponse.respond500WithTextPlain;
 import static org.folio.support.ExpirationTool.doRequestExpirationForTenant;
@@ -24,8 +23,7 @@ public class RequestExpiryImpl implements ScheduledRequestExpiration {
   public void expireRequests(Map<String, String> okapiHeaders,
                              Handler<AsyncResult<Response>> asyncResultHandler, Context context) {
 
-    context.runOnContext(v -> doRequestExpirationForTenant(okapiHeaders, context.owner(),
-      okapiHeaders.get(TENANT_HEADER))
+    context.runOnContext(v -> doRequestExpirationForTenant(okapiHeaders, context.owner())
       .onComplete(result -> {
         if (result.succeeded()) {
           asyncResultHandler.handle(succeededFuture(respond204()));

--- a/src/main/java/org/folio/rest/impl/RequestExpiryImpl.java
+++ b/src/main/java/org/folio/rest/impl/RequestExpiryImpl.java
@@ -4,7 +4,7 @@ package org.folio.rest.impl;
 import static io.vertx.core.Future.succeededFuture;
 import static org.folio.rest.jaxrs.resource.ScheduledRequestExpiration.ScheduledRequestExpirationResponse.respond204;
 import static org.folio.rest.jaxrs.resource.ScheduledRequestExpiration.ScheduledRequestExpirationResponse.respond500WithTextPlain;
-import static org.folio.support.ExpirationTool.doRequestExpiration;
+import static org.folio.support.ExpirationTool.doRequestExpirationForTenant;
 
 import java.util.Map;
 
@@ -23,7 +23,7 @@ public class RequestExpiryImpl implements ScheduledRequestExpiration {
   public void expireRequests(Map<String, String> okapiHeaders,
                              Handler<AsyncResult<Response>> asyncResultHandler, Context context) {
 
-    context.runOnContext(v -> doRequestExpiration(okapiHeaders, context.owner())
+    context.runOnContext(v -> doRequestExpirationForTenant(okapiHeaders, context.owner())
       .onComplete(result -> {
         if (result.succeeded()) {
           asyncResultHandler.handle(succeededFuture(respond204()));

--- a/src/main/java/org/folio/service/EventPublisherService.java
+++ b/src/main/java/org/folio/service/EventPublisherService.java
@@ -5,7 +5,6 @@ import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
 import io.vertx.core.json.JsonObject;
 import org.folio.support.EventType;
-import org.folio.support.JsonPropertyWriter;
 import org.folio.support.LogEventPayloadField;
 import org.folio.support.exception.LogEventType;
 

--- a/src/main/java/org/folio/support/ExpirationTool.java
+++ b/src/main/java/org/folio/support/ExpirationTool.java
@@ -33,7 +33,6 @@ import java.util.stream.Collectors;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.folio.okapi.common.GenericCompositeFuture;
 import org.folio.rest.jaxrs.model.Request;
 import org.folio.rest.persist.PostgresClient;
 import org.folio.rest.persist.SQLConnection;

--- a/src/main/java/org/folio/support/ExpirationTool.java
+++ b/src/main/java/org/folio/support/ExpirationTool.java
@@ -5,6 +5,7 @@ import static java.lang.String.format;
 import static java.util.Collections.emptyList;
 import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toSet;
+import static org.folio.rest.impl.Headers.TENANT_HEADER;
 import static org.folio.rest.jaxrs.model.Request.Status.CLOSED_PICKUP_EXPIRED;
 import static org.folio.rest.jaxrs.model.Request.Status.CLOSED_UNFILLED;
 import static org.folio.rest.jaxrs.model.Request.Status.OPEN_AWAITING_DELIVERY;
@@ -33,6 +34,7 @@ import java.util.stream.Collectors;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.folio.rest.impl.Headers;
 import org.folio.rest.jaxrs.model.Request;
 import org.folio.rest.persist.PostgresClient;
 import org.folio.rest.persist.SQLConnection;
@@ -54,9 +56,10 @@ public class ExpirationTool {
     //do nothing
   }
 
-  public static Future<Void> doRequestExpirationForTenant(Map<String, String> okapiHeaders, Vertx vertx,
-    String tenant) {
+  public static Future<Void> doRequestExpirationForTenant(Map<String, String> okapiHeaders, Vertx vertx) {
     Promise<Void> promise = Promise.promise();
+
+    String tenant = okapiHeaders.get(TENANT_HEADER);
 
     PostgresClient pgClient = PostgresClient.getInstance(vertx, tenant);
 

--- a/src/main/java/org/folio/support/ExpirationTool.java
+++ b/src/main/java/org/folio/support/ExpirationTool.java
@@ -34,7 +34,6 @@ import java.util.stream.Collectors;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.folio.rest.impl.Headers;
 import org.folio.rest.jaxrs.model.Request;
 import org.folio.rest.persist.PostgresClient;
 import org.folio.rest.persist.SQLConnection;
@@ -275,10 +274,4 @@ public class ExpirationTool {
     return promise.future().map(ur -> null);
   }
 
-  private static String getTenant(String nsTenant) {
-
-    String suffix = "_mod_circulation_storage";
-    int suffixLength = nsTenant.length() - suffix.length();
-    return nsTenant.substring(0, suffixLength);
-  }
 }

--- a/src/main/java/org/folio/support/ExpirationTool.java
+++ b/src/main/java/org/folio/support/ExpirationTool.java
@@ -54,10 +54,10 @@ public class ExpirationTool {
     //do nothing
   }
 
-  public static Future<Void> doRequestExpirationForTenant(Map<String, String> okapiHeaders, Vertx vertx) {
+  public static Future<Void> doRequestExpirationForTenant(Map<String, String> okapiHeaders, Vertx vertx,
+    String tenant) {
     Promise<Void> promise = Promise.promise();
 
-    String tenant = okapiHeaders.get("X-Okapi-Tenant");
     PostgresClient pgClient = PostgresClient.getInstance(vertx, tenant);
 
     List<JsonObject> context = new ArrayList<>();

--- a/src/main/java/org/folio/support/ExpirationTool.java
+++ b/src/main/java/org/folio/support/ExpirationTool.java
@@ -55,24 +55,10 @@ public class ExpirationTool {
     //do nothing
   }
 
-  public static Future<Void> doRequestExpiration(Map<String, String> okapiHeaders, Vertx vertx) {
-    final Promise<RowSet<Row>> promise = Promise.promise();
-    PostgresClient pgClient = PostgresClient.getInstance(vertx);
-
-    String tenantQuery = "select nspname from pg_catalog.pg_namespace where nspname LIKE '%_mod_circulation_storage';";
-
-    pgClient.select(tenantQuery, promise);
-
-    return promise.future()
-      .compose(rs -> GenericCompositeFuture.all(rowSetToStream(rs)
-        .map(row -> doRequestExpirationForTenant(okapiHeaders, vertx, getTenant(row.getString("nspname"))))
-        .collect(toList()))
-        .map(all -> null));
-  }
-
-  private static Future<Void> doRequestExpirationForTenant(Map<String, String> okapiHeaders, Vertx vertx, String tenant) {
+  public static Future<Void> doRequestExpirationForTenant(Map<String, String> okapiHeaders, Vertx vertx) {
     Promise<Void> promise = Promise.promise();
 
+    String tenant = okapiHeaders.get("X-Okapi-Tenant");
     PostgresClient pgClient = PostgresClient.getInstance(vertx, tenant);
 
     List<JsonObject> context = new ArrayList<>();

--- a/src/test/java/org/folio/rest/api/RequestExpirationApiTest.java
+++ b/src/test/java/org/folio/rest/api/RequestExpirationApiTest.java
@@ -47,6 +47,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import io.vertx.core.json.JsonObject;
+import static org.hamcrest.core.IsNull.*;
 
 public class RequestExpirationApiTest extends ApiTests {
 
@@ -834,7 +835,7 @@ public class RequestExpirationApiTest extends ApiTests {
 
     JsonObject requestFromDummyTenant = getById(requestStorageUrl(String.format("/" + secondRequestId)), dummyTenant);
     assertThat(requestFromDummyTenant.getString("status"), is(CLOSED_PICKUP_EXPIRED));
-    assertThat(requestFromDummyTenant.getInteger("position"), IsNull.nullValue());
+    assertThat(requestFromDummyTenant.getInteger("position"), nullValue());
   }
 
   @SneakyThrows

--- a/src/test/java/org/folio/rest/api/RequestExpirationApiTest.java
+++ b/src/test/java/org/folio/rest/api/RequestExpirationApiTest.java
@@ -827,12 +827,12 @@ public class RequestExpirationApiTest extends ApiTests {
       requestStorageUrl(), dummyTenant);
     expireRequestsForTenant(dummyTenant);
 
-    JsonObject requestFromDefaultTenant = getById(requestStorageUrl(String.format("/%s", firstRequestId)));
+    JsonObject requestFromDefaultTenant = getById(requestStorageUrl("/" + firstRequestId));
 
     assertThat(requestFromDefaultTenant.getString("status"), is(OPEN_AWAITING_PICKUP));
     assertThat(requestFromDefaultTenant.getInteger("position"), is(1));
 
-    JsonObject requestFromDummyTenant = getById(requestStorageUrl(String.format("/%s", secondRequestId)), dummyTenant);
+    JsonObject requestFromDummyTenant = getById(requestStorageUrl(String.format("/" + secondRequestId)), dummyTenant);
     assertThat(requestFromDummyTenant.getString("status"), is(CLOSED_PICKUP_EXPIRED));
     assertThat(requestFromDummyTenant.getInteger("position"), IsNull.nullValue());
   }

--- a/src/test/java/org/folio/rest/api/RequestExpirationApiTest.java
+++ b/src/test/java/org/folio/rest/api/RequestExpirationApiTest.java
@@ -793,7 +793,7 @@ public class RequestExpirationApiTest extends ApiTests {
 
   @Test
   @SneakyThrows
-  public void shouldExpireRequestWithAwaitingPickupExpiredFieldWhenExpirationJobIsCalledForTwoTenantsSimultaneously() {
+  public void shouldOnlyExpireRequestsForSpecifiedTenant() {
 
     UUID id = UUID.randomUUID();
     UUID itemId = UUID.randomUUID();

--- a/src/test/java/org/folio/rest/api/StorageTestSuite.java
+++ b/src/test/java/org/folio/rest/api/StorageTestSuite.java
@@ -300,7 +300,7 @@ public class StorageTestSuite {
     deploymentComplete.get(30, TimeUnit.SECONDS);
   }
 
-  static private void prepareTenant(String tenantId, boolean loadSample) {
+  static protected void prepareTenant(String tenantId, boolean loadSample) {
     prepareTenant(tenantId, null, "mod-circulation-storage-1.0.0", loadSample);
   }
 

--- a/src/test/java/org/folio/rest/support/ApiTests.java
+++ b/src/test/java/org/folio/rest/support/ApiTests.java
@@ -55,7 +55,7 @@ public class ApiTests {
     }
   }
 
-  protected IndividualResource createEntity(JsonObject entity, URL url)
+  protected IndividualResource createEntity(JsonObject entity, URL url, String tenantId)
     throws InterruptedException,
     ExecutionException,
     TimeoutException {
@@ -63,7 +63,7 @@ public class ApiTests {
     CompletableFuture<JsonResponse> createCompleted = new CompletableFuture<>();
 
     client.post(url,
-      entity, StorageTestSuite.TENANT_ID,
+      entity, tenantId,
       ResponseHandler.json(createCompleted));
 
     JsonResponse postResponse = createCompleted.get(5, TimeUnit.SECONDS);
@@ -74,14 +74,22 @@ public class ApiTests {
     return new IndividualResource(postResponse);
   }
 
-  protected JsonObject getById(URL url)
+  protected IndividualResource createEntity(JsonObject entity, URL url)
+    throws InterruptedException,
+    ExecutionException,
+    TimeoutException {
+
+    return createEntity(entity, url, StorageTestSuite.TENANT_ID);
+  }
+
+  protected JsonObject getById(URL url, String tenantId)
     throws InterruptedException,
     ExecutionException,
     TimeoutException {
 
     CompletableFuture<JsonResponse> getCompleted = new CompletableFuture<>();
 
-    client.get(url, StorageTestSuite.TENANT_ID,
+    client.get(url, tenantId,
       ResponseHandler.json(getCompleted));
 
     JsonResponse getResponse = getCompleted.get(5, TimeUnit.SECONDS);
@@ -90,6 +98,11 @@ public class ApiTests {
       getResponse.getStatusCode(), is(HttpURLConnection.HTTP_OK));
 
     return getResponse.getJson();
+  }
+
+  @SneakyThrows
+  protected JsonObject getById(URL url) {
+    return getById(url, StorageTestSuite.TENANT_ID);
   }
 
   protected void checkNotFound(URL url)


### PR DESCRIPTION
The expiration job is being called for all of the tenants, and so when the timer is being fired for okapi for two tenants simultaneously two update transactions are executed at the same time and unrepeatable read phenomena occurs. This can be fixed by running the job just for a specific tenant.
Resolves: https://issues.folio.org/browse/CIRCSTORE-342.