### PR TITLE
CIRCSTORE-349 add expirationDate to actualCostRecord

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -333,7 +333,7 @@
     },
     {
       "id": "actual-cost-record-storage",
-      "version": "0.1",
+      "version": "0.2",
       "handlers": [
         {
           "methods": ["GET"],

--- a/ramls/actual-cost-record-storage.raml
+++ b/ramls/actual-cost-record-storage.raml
@@ -1,6 +1,6 @@
 #%RAML 1.0
 title: Actual Cost Record Storage
-version: v0.1
+version: v0.2
 protocols: [ HTTP, HTTPS ]
 baseUri: http://localhost:9130
 

--- a/ramls/actual-cost-record.json
+++ b/ramls/actual-cost-record.json
@@ -118,6 +118,11 @@
       "description": "Fee/fine type name",
       "type": "string"
     },
+    "expirationDate": {
+      "description": "Expiration date and time for items that were lost with actual cost",
+      "type": "string",
+      "format": "date-time"
+    },
     "metadata": {
       "description": "Metadata about creation and changes, provided by the server (client should not provide)",
       "type": "object",

--- a/ramls/actual-cost-record.json
+++ b/ramls/actual-cost-record.json
@@ -119,7 +119,7 @@
       "type": "string"
     },
     "expirationDate": {
-      "description": "Expiration date and time for items that were lost with actual cost",
+      "description": "Expiration date and time of actual cost record",
       "type": "string",
       "format": "date-time"
     },

--- a/ramls/examples/actual-cost-record.json
+++ b/ramls/examples/actual-cost-record.json
@@ -23,5 +23,6 @@
   "feeFineOwnerId": "88805c06-dbdb-4aa0-9695-d4d19c733221",
   "feeFineOwner": "Main circ desk",
   "feeFineTypeId": "88805c06-dbdb-4aa0-9695-d4d19c733221",
-  "feeFineType": "Lost Item fee (actual cost)"
+  "feeFineType": "Lost Item fee (actual cost)",
+  "expirationDate": "2022-02-01T23:59:59Z"
 }

--- a/src/test/java/org/folio/rest/api/ActualCostRecordAPITest.java
+++ b/src/test/java/org/folio/rest/api/ActualCostRecordAPITest.java
@@ -124,7 +124,8 @@ public class ActualCostRecordAPITest extends ApiTests {
       .withFeeFineOwnerId(UUID.randomUUID().toString())
       .withFeeFineOwner("Main circ desk")
       .withFeeFineTypeId(UUID.randomUUID().toString())
-      .withFeeFineType("Lost Item fee (actual cost)");
+      .withFeeFineType("Lost Item fee (actual cost)")
+      .withExpirationDate(new DateTime(DateTimeZone.UTC).toDate());
   }
 
 


### PR DESCRIPTION
## Purpose 
- Add expirationDate field (date-time), not required.

It'll be used by a timer in mod-circulation that will close loans for items that were aged to lost or declared lost with actual cost in the policy, but Lost Item Fee wasn't charged during a period specified in the policy.

Resolves: [CIRCSTORE-349](https://issues.folio.org/browse/CIRCSTORE-349)