### PR TITLE
CIRCSTORE-355: Allow compile and build on ARM64 machine

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
       <dependency>
         <groupId>org.testcontainers</groupId>
         <artifactId>testcontainers-bom</artifactId>
-        <version>1.15.1</version>
+        <version>1.17.3</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/src/test/java/org/folio/rest/api/StorageTestSuite.java
+++ b/src/test/java/org/folio/rest/api/StorageTestSuite.java
@@ -97,7 +97,7 @@ public class StorageTestSuite {
   private static final WireMockServer wireMockServer = new WireMockServer(PROXY_PORT);
 
   private static final KafkaContainer kafkaContainer
-    = new KafkaContainer(DockerImageName.parse("confluentinc/cp-kafka:5.4.3"));
+    = new KafkaContainer(DockerImageName.parse("confluentinc/cp-kafka:7.2.0"));
 
   /**
    * Return a URL for the path and the parameters.


### PR DESCRIPTION
Update `testcontainer` and `confluentinc/cp-kafka` so it can build on arm64 machine.

[CIRCSTORE-355](https://issues.folio.org/browse/CIRCSTORE-355)