### PR TITLE
CIRCSTORE-357: Support holdings-storage 6.0, item-storage 10.0

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -4,11 +4,11 @@
   "requires": [
     {
       "id": "item-storage",
-      "version": "5.0 6.0 7.0 8.2 9.0"
+      "version": "5.0 6.0 7.0 8.2 9.0 10.0"
     },
     {
       "id": "holdings-storage",
-      "version": "1.3 2.0 3.0 4.0 5.0"
+      "version": "1.3 2.0 3.0 4.0 5.0 6.0"
     },
     {
       "id": "pubsub-event-types",


### PR DESCRIPTION
mod-inventory-storage has new major interface versions:

instance-storage 9.0
holdings-storage 6.0
item-storage 10.0

mod-circulation-storage uses holdings-storage and item-storage APIs, but not instance-storage API.

mod-circulation-storage is not affected because the incompatible change is in the DELETE all records APIs only that is not used by mod-circulation-storage.

Only the okapiInterfaces need to be bumped in "requires" section of ModuleDescriptor-template.json