### PR TITLE
CIRCSTORE-361 Make actual cost record id optional

### DIFF
--- a/ramls/actual-cost-record.json
+++ b/ramls/actual-cost-record.json
@@ -247,7 +247,6 @@
   },
   "additionalProperties": false,
   "required": [
-    "id",
     "lossType",
     "lossDate",
     "expirationDate",

--- a/src/test/java/org/folio/rest/api/ActualCostRecordAPITest.java
+++ b/src/test/java/org/folio/rest/api/ActualCostRecordAPITest.java
@@ -109,7 +109,6 @@ public class ActualCostRecordAPITest extends ApiTests {
 
   private ActualCostRecord createActualCostRecord() {
     return new ActualCostRecord()
-      .withId(randomId())
       .withLossType(ActualCostRecord.LossType.AGED_TO_LOST)
       .withLossDate(new DateTime(DateTimeZone.UTC).toDate())
       .withExpirationDate(new DateTime(DateTimeZone.UTC).toDate())


### PR DESCRIPTION
mod-circulation attempts to create Actual Cost Records without and ID, which is required according to its schema. This violation of schema's requirements causes [CIRC-1622](https://issues.folio.org/browse/CIRC-1622) and [CIRC-1623](https://issues.folio.org/browse/CIRC-1623). One way to fix this issue is to change the schema to make the ID optional, since it is added to all stored records automatically.

[CIRCSTORE-361](https://issues.folio.org/browse/CIRCSTORE-361)