### PR TITLE
CIRCSTORE-363 Upgrade to RMB 35.0.0 and Vertx 4.3.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <ramlfiles_path>${basedir}/ramls</ramlfiles_path>
-    <vertx-version>4.2.7</vertx-version>
+    <vertx-version>4.3.1</vertx-version>
     <raml-module-builder-version>35.0.0</raml-module-builder-version>
     <spring.version>5.2.18.RELEASE</spring.version>
     <argLine />

--- a/pom.xml
+++ b/pom.xml
@@ -28,8 +28,8 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <ramlfiles_path>${basedir}/ramls</ramlfiles_path>
-    <vertx-version>4.2.1</vertx-version>
-    <raml-module-builder-version>34.0.0</raml-module-builder-version>
+    <vertx-version>4.3.3</vertx-version>
+    <raml-module-builder-version>35.0.0</raml-module-builder-version>
     <spring.version>5.2.18.RELEASE</spring.version>
     <argLine />
   </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <ramlfiles_path>${basedir}/ramls</ramlfiles_path>
-    <vertx-version>4.3.3</vertx-version>
+    <vertx-version>4.2.1</vertx-version>
     <raml-module-builder-version>35.0.0</raml-module-builder-version>
     <spring.version>5.2.18.RELEASE</spring.version>
     <argLine />
@@ -80,7 +80,7 @@
     <dependency>
       <groupId>org.folio</groupId>
       <artifactId>folio-kafka-wrapper</artifactId>
-      <version>2.4.0</version>
+      <version>2.6.0</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <ramlfiles_path>${basedir}/ramls</ramlfiles_path>
-    <vertx-version>4.2.1</vertx-version>
+    <vertx-version>4.2.7</vertx-version>
     <raml-module-builder-version>35.0.0</raml-module-builder-version>
     <spring.version>5.2.18.RELEASE</spring.version>
     <argLine />


### PR DESCRIPTION
Upgrading to Vertx > 4.3.1 breaks KafkaAdminClientServiceTest
[CIRCSTORE-363](https://issues.folio.org/browse/CIRCSTORE-363)
