### PR TITLE
CIRCSTORE-370 Add fields to action cost record

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -333,7 +333,7 @@
     },
     {
       "id": "actual-cost-record-storage",
-      "version": "0.4",
+      "version": "0.5",
       "handlers": [
         {
           "methods": ["GET"],

--- a/ramls/actual-cost-record.json
+++ b/ramls/actual-cost-record.json
@@ -264,6 +264,24 @@
         "type"
       ]
     },
+    "status": {
+      "description": "Status of the actual cost record",
+      "type": "string",
+      "enum": [
+        "Open",
+        "Billed",
+        "Cancelled",
+        "Expired"
+      ]
+    },
+    "additionalInfoForStaff": {
+      "description": "Additional information for staff",
+      "type": "string"
+    },
+    "additionalInfoForPatron": {
+      "description": "Additional information for a patron",
+      "type": "string"
+    },
     "metadata": {
       "description": "Metadata about creation and changes, provided by the server (client should not provide)",
       "type": "object",
@@ -279,6 +297,7 @@
     "loan",
     "item",
     "instance",
-    "feeFine"
+    "feeFine",
+    "status"
   ]
 }

--- a/ramls/examples/actual-cost-record.json
+++ b/ramls/examples/actual-cost-record.json
@@ -52,6 +52,9 @@
     "typeId": "92ef9706-f1af-430d-9edd-78035689efa2",
     "type": "Overdue fine"
   },
+  "status": "Billed",
+  "additionalInformationForStaff": "Additional information for staff",
+  "additionalInformationForPatron": "Additional information for a patron",
   "metadata": {
     "createdDate": "2022-09-19T14:09:41.284+00:00",
     "createdByUserId": "5bcadcf1-2608-4cd3-b4e2-947ffe58d15f",

--- a/src/test/java/org/folio/rest/api/ActualCostRecordAPITest.java
+++ b/src/test/java/org/folio/rest/api/ActualCostRecordAPITest.java
@@ -152,7 +152,10 @@ public class ActualCostRecordAPITest extends ApiTests {
         .withOwnerId(randomId())
         .withOwner("fee/fine owner")
         .withTypeId(randomId())
-        .withType("Lost Item fee (actual cost)"));
+        .withType("Lost Item fee (actual cost)"))
+      .withStatus(ActualCostRecord.Status.OPEN)
+      .withAdditionalInfoForStaff("Test information for staff")
+      .withAdditionalInfoForPatron("Test information for patron");
   }
 
   private static String randomId() {


### PR DESCRIPTION
## Purpose 
Add fields to actual cost record schema:
"status": enum("Open", "Billed", "Cancelled", "Expired"),
"additionalInfoForStaff": string,
"additionalInfoForPatron": string,

Resolves: [CIRCSTORE-370](https://issues.folio.org/browse/CIRCSTORE-370)