### PR TITLE
CIRCSTORE-382: RMB 35.0.4, Vert.x 4.3.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,8 +28,8 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <ramlfiles_path>${basedir}/ramls</ramlfiles_path>
-    <vertx-version>4.3.4</vertx-version>
-    <raml-module-builder-version>35.0.0</raml-module-builder-version>
+    <vertx-version>4.3.5</vertx-version>
+    <raml-module-builder-version>35.0.4</raml-module-builder-version>
     <spring.version>5.3.23</spring.version>
     <argLine />
   </properties>


### PR DESCRIPTION
Upgrade RMB from 35.0.0 to 35.0.4. This fixes
https://issues.folio.org/browse/RMB-955 (Set search_path when doing "SET ROLE" for shared pool connection)
that probably causes the priority P1 issue
https://issues.folio.org/browse/CIRC-1668 (cross-tenant policy id causing 500 errors during circ. transactions).

RMB 35.0.4 comes with Vert.x 4.3.5 so we need to bump Vert.x from 4.3.4 to 4.3.5 as well.