### PR TITLE
CIRCSTORE-383: Spring 5.2.22 (Spring4Shell RCE), scala 2.13.10 (RCE)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,6 @@
     <ramlfiles_path>${basedir}/ramls</ramlfiles_path>
     <vertx-version>4.3.1</vertx-version>
     <raml-module-builder-version>35.0.0</raml-module-builder-version>
-    <spring.version>5.3.23</spring.version>
     <argLine />
   </properties>
 
@@ -40,6 +39,13 @@
         <groupId>io.vertx</groupId>
         <artifactId>vertx-stack-depchain</artifactId>
         <version>${vertx-version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.springframework</groupId>
+        <artifactId>spring-framework-bom</artifactId>
+        <version>5.2.22.RELEASE</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -127,21 +133,23 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
+      <groupId>org.scala-lang</groupId>
+      <artifactId>scala-library</artifactId>
+      <version>2.13.10</version>
+    </dependency>
+    <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-core</artifactId>
-      <version>${spring.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-context</artifactId>
-      <version>${spring.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-test</artifactId>
-      <version>${spring.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
This is for 2022-R3 Nolana Bug Fix/Hot Fix for branch b15.0.
(For master branch upgrade see https://issues.folio.org/browse/CIRCSTORE-371 = PR #365 )

Upgrade Spring to 5.2.22.RELEASE. This upgrades the spring-core runtime dependency from 5.2.8.RELEASE to 5.2.22.RELEASE fixing Spring4Shell Remote Code Execution:
https://nvd.nist.gov/vuln/detail/CVE-2022-22965
https://issues.folio.org/browse/FOLIO-3466 "Spring4Shell: spring-beans RCE Vulnerability (CVE-2022-22965)"

Upgrade scala-library from 2.13.1 to 2.13.10 fixing Remote Code Execution (RCE):
https://nvd.nist.gov/vuln/detail/CVE-2022-36944

Before the fix:
```
$ mvn dependency:tree -Dincludes=org.springframework,org.scala-lang -Dverbose

[INFO] org.folio:mod-circulation-storage:jar:15.1.0-SNAPSHOT
[INFO] +- org.springframework:spring-core:jar:5.2.18.RELEASE:test (scope not updated to compile)
[INFO] |  \- org.springframework:spring-jcl:jar:5.2.18.RELEASE:test
[INFO] +- org.springframework:spring-context:jar:5.2.18.RELEASE:test (scope not updated to compile)
[INFO] |  +- org.springframework:spring-aop:jar:5.2.18.RELEASE:test
[INFO] |  |  +- (org.springframework:spring-beans:jar:5.2.18.RELEASE:test - omitted for duplicate)
[INFO] |  |  \- (org.springframework:spring-core:jar:5.2.18.RELEASE:test - omitted for duplicate)
[INFO] |  +- org.springframework:spring-beans:jar:5.2.18.RELEASE:test
[INFO] |  |  \- (org.springframework:spring-core:jar:5.2.18.RELEASE:test - omitted for duplicate)
[INFO] |  +- (org.springframework:spring-core:jar:5.2.18.RELEASE:test - omitted for duplicate)
[INFO] |  \- org.springframework:spring-expression:jar:5.2.18.RELEASE:test
[INFO] |     \- (org.springframework:spring-core:jar:5.2.18.RELEASE:test - omitted for duplicate)
[INFO] +- org.springframework:spring-test:jar:5.2.18.RELEASE:test
[INFO] |  \- (org.springframework:spring-core:jar:5.2.18.RELEASE:test - omitted for duplicate)
[INFO] \- org.folio:mod-pubsub-client:jar:2.4.0:compile
[INFO]    +- org.folio:folio-di-support:jar:1.2.0:compile
[INFO]    |  +- (org.springframework:spring-core:jar:5.2.8.RELEASE:compile - omitted for conflict with 5.2.18.RELEASE)
[INFO]    |  \- (org.springframework:spring-context:jar:5.2.8.RELEASE:compile - omitted for conflict with 5.2.18.RELEASE)
[INFO]    \- org.scala-lang:scala-library:jar:2.13.1:compile
```

After the fix:
```
$ mvn dependency:tree -Dincludes=org.springframework,org.scala-lang -Dverbose

[INFO] org.folio:mod-circulation-storage:jar:15.1.0-SNAPSHOT
[INFO] +- org.scala-lang:scala-library:jar:2.13.10:compile
[INFO] +- org.springframework:spring-core:jar:5.2.22.RELEASE:test (scope not updated to compile)
[INFO] |  \- org.springframework:spring-jcl:jar:5.2.22.RELEASE:test
[INFO] +- org.springframework:spring-context:jar:5.2.22.RELEASE:test (scope not updated to compile)
[INFO] |  +- org.springframework:spring-aop:jar:5.2.22.RELEASE:test
[INFO] |  |  +- (org.springframework:spring-beans:jar:5.2.22.RELEASE:test - omitted for duplicate)
[INFO] |  |  \- (org.springframework:spring-core:jar:5.2.22.RELEASE:test - omitted for duplicate)
[INFO] |  +- org.springframework:spring-beans:jar:5.2.22.RELEASE:test
[INFO] |  |  \- (org.springframework:spring-core:jar:5.2.22.RELEASE:test - omitted for duplicate)
[INFO] |  +- (org.springframework:spring-core:jar:5.2.22.RELEASE:test - omitted for duplicate)
[INFO] |  \- org.springframework:spring-expression:jar:5.2.22.RELEASE:test
[INFO] |     \- (org.springframework:spring-core:jar:5.2.22.RELEASE:test - omitted for duplicate)
[INFO] +- org.springframework:spring-test:jar:5.2.22.RELEASE:test
[INFO] |  \- (org.springframework:spring-core:jar:5.2.22.RELEASE:test - omitted for duplicate)
[INFO] \- org.folio:mod-pubsub-client:jar:2.4.0:compile
[INFO]    +- org.folio:folio-di-support:jar:1.2.0:compile
[INFO]    |  +- (org.springframework:spring-core:jar:5.2.22.RELEASE:compile - version managed from 5.2.8.RELEASE; omitted for duplicate)
[INFO]    |  \- (org.springframework:spring-context:jar:5.2.22.RELEASE:compile - version managed from 5.2.8.RELEASE; omitted for duplicate)
[INFO]    \- (org.scala-lang:scala-library:jar:2.13.1:compile - omitted for conflict with 2.13.10)
```