### PR TITLE
CIRCSTORE-387: RequestExpirationService hangs on publish exception

### DIFF
--- a/src/main/java/org/folio/service/RequestExpirationService.java
+++ b/src/main/java/org/folio/service/RequestExpirationService.java
@@ -60,6 +60,7 @@ public class RequestExpirationService {
     eventPublisherService = new EventPublisherService(vertx, okapiHeaders);
   }
 
+  @SuppressWarnings("java:S1905")  // suppress false positive "Remove this unnecessary cast to Void"
   public Future<Void> doRequestExpiration() {
     List<JsonObject> context = new ArrayList<>();
 


### PR DESCRIPTION
In RequestExpirationService.java:

If eventPublisherService.publishLogRecord throws an exception the promise is neither failed nor completed and the request to /scheduled-request-expiration will never get any response.

Approach:

Replace deprecated (and error-prone) PostgresClient.startTx with PostgresClient.withTrans that automatically either commits or rolls back the transaction.