### PR TITLE
CIRCSTORE-391: /scheduled-request-expiration hangs on invalid URL

### DIFF
--- a/src/main/java/org/folio/rest/client/ConfigurationClient.java
+++ b/src/main/java/org/folio/rest/client/ConfigurationClient.java
@@ -33,8 +33,7 @@ public class ConfigurationClient extends OkapiClient {
   public Future<TlrSettingsConfiguration> getTlrSettings() {
     String url = format(CONFIGURATIONS_URL, StringUtil.urlEncode(TLR_SETTINGS_QUERY));
 
-    return okapiGetAbs(url)
-      .send()
+    return okapiGet(url)
       .compose(response -> {
         int responseStatus = response.statusCode();
         if (responseStatus != 200) {

--- a/src/test/java/org/folio/rest/client/OkapiClientTest.java
+++ b/src/test/java/org/folio/rest/client/OkapiClientTest.java
@@ -1,0 +1,38 @@
+package org.folio.rest.client;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.instanceOf;
+
+import io.vertx.core.Vertx;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import java.net.MalformedURLException;
+import java.util.List;
+import java.util.Map;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(VertxUnitRunner.class)
+public class OkapiClientTest {
+
+  @Test
+  public void noOkapiUrl(TestContext context) {
+    new OkapiClient(Vertx.vertx(), Map.of())
+    .get("/foo", "cql.allRecords=1", 10)
+    .onComplete(context.asyncAssertFailure(e -> {
+      assertThat(e.getCause(), is(instanceOf(MalformedURLException.class)));
+    }));
+  }
+
+  @Test
+  public void unknownHost(TestContext context) {
+    new OkapiClient(Vertx.vertx(), Map.of("x-okapi-url", "http://www.invalid"))
+    .get("/foo", List.of("1"), "foo", Object.class)
+    .onComplete(context.asyncAssertFailure(e -> {
+      assertThat(e.getClass().getName(), containsString("UnknownHost"));
+    }));
+  }
+
+}


### PR DESCRIPTION
Code in RequestExpiryImpl: onComplete should be called after compose, but it is called within compose. If getTlrSettings() returns a failed Future no 500 response is generated and the request hangs forever.

In addition getTlrSettings() may throw an exception that is not caught, this also makes the request hang forever. The exception origins from OkapiClient.