### PR TITLE
CIRCSTORE-378: Remove userId full text index in loan table

### DIFF
--- a/src/main/resources/templates/db_scripts/schema.json
+++ b/src/main/resources/templates/db_scripts/schema.json
@@ -127,7 +127,7 @@
       "fullTextIndex": [
         {
           "fieldName": "userId",
-          "tOps": "ADD",
+          "tOps": "DELETE",
           "caseSensitive": false,
           "removeAccents": true
         }


### PR DESCRIPTION
A full text index for an id field is never needed.

Use "tOps": "DELETE" to trigger RMB's index removal.