### PR TITLE
CIRCSTORE-402 Add b-tree indexes to DB schema

### DIFF
--- a/src/main/resources/templates/db_scripts/schema.json
+++ b/src/main/resources/templates/db_scripts/schema.json
@@ -225,6 +225,12 @@
           "tOps": "ADD",
           "caseSensitive": false,
           "removeAccents": false
+        },
+        {
+          "fieldName": "instanceId",
+          "tOps": "ADD",
+          "caseSensitive": false,
+          "removeAccents": false
         }
       ],
       "customSnippetPath": "requestUpdateTrigger.sql"
@@ -419,6 +425,12 @@
           "tOps": "ADD",
           "caseSensitive": false,
           "removeAccents": true
+        },
+        {
+          "fieldName": "expirationDate",
+          "tOps": "ADD",
+          "caseSensitive": false,
+          "removeAccents": false
         }
       ],
       "fullTextIndex" : [


### PR DESCRIPTION
## Purpose
This should improve check-in performance when TLR feature is enabled.

Resolves: [CIRCSTORE-402](https://issues.folio.org/browse/CIRCSTORE-402)
## Approach
- add 'instanceId' and 'expirationDate' b-tree indexes;
- update 'pickupServicePointId' index with "removeAccents": true flag;