### PR TITLE
CIRCSTORE-399: Search index fields migration script skeleton

### DIFF
--- a/src/main/java/org/folio/rest/impl/TenantRefAPI.java
+++ b/src/main/java/org/folio/rest/impl/TenantRefAPI.java
@@ -14,6 +14,7 @@ import org.folio.rest.tools.utils.TenantLoading;
 import org.folio.rest.tools.utils.TenantTool;
 import org.folio.service.PubSubRegistrationService;
 import org.folio.service.tlr.TlrDataMigrationService;
+import org.folio.service.tlr.TlrIndexFieldsMigrationService;
 
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Context;
@@ -36,6 +37,7 @@ public class TenantRefAPI extends TenantAPI {
       Map<String, String> headers, Context vertxContext) {
 
     return (new TlrDataMigrationService(attributes, vertxContext, headers).migrate())
+      .compose(f -> new TlrIndexFieldsMigrationService(attributes, vertxContext, headers).migrate())
       .compose(r -> new KafkaAdminClientService(vertxContext.owner())
         .createKafkaTopics(CirculationStorageKafkaTopic.values(), tenantId))
       .compose(r -> super.loadData(attributes, tenantId, headers, vertxContext))

--- a/src/main/java/org/folio/service/tlr/AbstractRequestMigrationService.java
+++ b/src/main/java/org/folio/service/tlr/AbstractRequestMigrationService.java
@@ -1,0 +1,101 @@
+package org.folio.service.tlr;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import io.vertx.core.Context;
+import io.vertx.core.Future;
+import io.vertx.sqlclient.Row;
+import io.vertx.sqlclient.RowSet;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.folio.okapi.common.ModuleId;
+import org.folio.okapi.common.SemVer;
+import org.folio.rest.client.OkapiClient;
+import org.folio.rest.jaxrs.model.TenantAttributes;
+import org.folio.rest.persist.PostgresClient;
+import org.folio.rest.persist.PgUtil;
+
+import static org.folio.rest.tools.utils.TenantTool.tenantId;
+import static org.folio.rest.persist.PostgresClient.convertToPsqlStandard;
+import static io.vertx.core.Future.failedFuture;
+import static io.vertx.core.Future.succeededFuture;
+import static java.lang.String.format;
+
+public class AbstractRequestMigrationService {
+  public static final Logger log = LogManager.getLogger(AbstractRequestMigrationService.class);
+
+  // safe number of UUIDs which fits into Okapi's URL length limit (4096 characters)
+  public static final int BATCH_SIZE = 80;
+
+  private static final String REQUEST_TABLE = "request";
+
+  public final TenantAttributes attributes;
+  public final OkapiClient okapiClient;
+  public final PostgresClient postgresClient;
+  public final String schemaName;
+  public final List<String> errorMessages;
+
+  public AbstractRequestMigrationService(TenantAttributes attributes, Context context,
+    Map<String, String> okapiHeaders) {
+
+    this.attributes = attributes;
+    okapiClient = new OkapiClient(context.owner(), okapiHeaders);
+    postgresClient = PgUtil.postgresClient(context, okapiHeaders);
+    schemaName = convertToPsqlStandard(tenantId(okapiHeaders));
+    errorMessages = new ArrayList<>();
+  }
+
+  public Boolean shouldMigrate(String moduleVersion) {
+    if (attributes.getModuleFrom() != null && attributes.getModuleTo() != null) {
+      SemVer migrationModuleVersion = moduleVersionToSemVer(moduleVersion);
+      SemVer moduleFromVersion = moduleVersionToSemVer(attributes.getModuleFrom());
+      SemVer moduleToVersion = moduleVersionToSemVer(attributes.getModuleTo());
+
+      if (moduleToVersion.compareTo(migrationModuleVersion) < 0) {
+        log.info("skipping migration for module version {}: should be {} or higher",
+          moduleToVersion, migrationModuleVersion);
+        return false;
+      }
+
+      if (moduleFromVersion.compareTo(migrationModuleVersion) >= 0) {
+        log.info("skipping migration for module version {}: previous version {} is already migrated",
+          moduleToVersion, moduleFromVersion);
+        return false;
+      }
+    }
+    else {
+      log.info("skipping migration - can not determine current moduleFrom or moduleTo version");
+      return false;
+    }
+
+    return true;
+  }
+
+  public Future<Integer> getBatchCount() {
+    return postgresClient.select(format("SELECT COUNT(*) FROM %s.%s", schemaName, REQUEST_TABLE))
+      .compose(this::getBatchCount);
+  }
+
+  private Future<Integer> getBatchCount(RowSet<Row> result) {
+    if (!result.iterator().hasNext()) {
+      return failedFuture("failed to get total number of requests");
+    }
+
+    Integer requestsCount = result.iterator().next().get(Integer.class, 0);
+    int batchesCount = requestsCount / BATCH_SIZE + (requestsCount % BATCH_SIZE == 0 ? 0 : 1);
+    log.info("found {} requests ({} batches)", requestsCount, batchesCount);
+
+    return succeededFuture(batchesCount);
+  }
+
+  private static SemVer moduleVersionToSemVer(String version) {
+    try {
+      return new SemVer(version);
+    } catch (IllegalArgumentException ex) {
+      return new ModuleId(version).getSemVer();
+    }
+  }
+}

--- a/src/main/java/org/folio/service/tlr/Batch.java
+++ b/src/main/java/org/folio/service/tlr/Batch.java
@@ -1,0 +1,24 @@
+package org.folio.service.tlr;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.folio.rest.persist.Conn;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@RequiredArgsConstructor
+public class Batch {
+  private final int batchNumber;
+  private final Conn connection;
+  private List<RequestMigrationContext> requestMigrationContexts = new ArrayList<>();
+
+  @Override
+  public String toString() {
+    return String.format("[batch #%d - %d requests]", batchNumber, requestMigrationContexts.size());
+  }
+}

--- a/src/main/java/org/folio/service/tlr/RequestMigrationContext.java
+++ b/src/main/java/org/folio/service/tlr/RequestMigrationContext.java
@@ -15,6 +15,9 @@ public class RequestMigrationContext {
   private final String itemId;
   private String holdingsRecordId;
   private String instanceId;
+  private String pickupServicePointId;
+  private String servicePointName;
+  private String callNumber;
 
   private static final String ID_KEY = "id";
   private static final String ITEM_ID_KEY = "itemId";
@@ -22,15 +25,5 @@ public class RequestMigrationContext {
   public static RequestMigrationContext from(JsonObject request) {
     return new RequestMigrationContext(request,
       request.getString(ID_KEY), request.getString(ITEM_ID_KEY));
-  }
-
-  @Override
-  public String toString() {
-    return "RequestMigrationContext{" +
-      "requestId='" + requestId + '\'' +
-      ", itemId='" + itemId + '\'' +
-      ", holdingsRecordId='" + holdingsRecordId + '\'' +
-      ", instanceId='" + instanceId + '\'' +
-      '}';
   }
 }

--- a/src/main/java/org/folio/service/tlr/RequestMigrationContext.java
+++ b/src/main/java/org/folio/service/tlr/RequestMigrationContext.java
@@ -1,0 +1,36 @@
+package org.folio.service.tlr;
+
+import io.vertx.core.json.JsonObject;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@RequiredArgsConstructor
+public class RequestMigrationContext {
+  private final JsonObject oldRequest;
+  private JsonObject newRequest;
+  private final String requestId;
+  private final String itemId;
+  private String holdingsRecordId;
+  private String instanceId;
+
+  private static final String ID_KEY = "id";
+  private static final String ITEM_ID_KEY = "itemId";
+
+  public static RequestMigrationContext from(JsonObject request) {
+    return new RequestMigrationContext(request,
+      request.getString(ID_KEY), request.getString(ITEM_ID_KEY));
+  }
+
+  @Override
+  public String toString() {
+    return "RequestMigrationContext{" +
+      "requestId='" + requestId + '\'' +
+      ", itemId='" + itemId + '\'' +
+      ", holdingsRecordId='" + holdingsRecordId + '\'' +
+      ", instanceId='" + instanceId + '\'' +
+      '}';
+  }
+}

--- a/src/main/java/org/folio/service/tlr/TlrDataMigrationService.java
+++ b/src/main/java/org/folio/service/tlr/TlrDataMigrationService.java
@@ -1,7 +1,6 @@
 package org.folio.service.tlr;
 
 import static io.vertx.core.Future.succeededFuture;
-import static java.lang.System.currentTimeMillis;
 import static java.util.stream.Collectors.toMap;
 import static java.util.stream.Collectors.toSet;
 import static org.folio.support.JsonPropertyWriter.write;

--- a/src/main/java/org/folio/service/tlr/TlrDataMigrationService.java
+++ b/src/main/java/org/folio/service/tlr/TlrDataMigrationService.java
@@ -43,7 +43,6 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.sqlclient.Row;
 import io.vertx.sqlclient.RowSet;
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 import lombok.Setter;
 
 /**
@@ -64,7 +63,6 @@ public class TlrDataMigrationService {
 
   private static final String ITEM_REQUEST_LEVEL = "Item";
   private static final String REQUEST_LEVEL_KEY = "requestLevel";
-  private static final String ID_KEY = "id";
   private static final String INSTANCE_ID_KEY = "instanceId";
   private static final String HOLDINGS_RECORD_ID_KEY = "holdingsRecordId";
   private static final String INSTANCE_KEY = "instance";
@@ -378,46 +376,4 @@ public class TlrDataMigrationService {
     private String id;
     private String instanceId;
   }
-
-  @Getter
-  @Setter
-  @RequiredArgsConstructor
-  public static class RequestMigrationContext {
-    private final JsonObject oldRequest;
-    private JsonObject newRequest;
-    private final String requestId;
-    private final String itemId;
-    private String holdingsRecordId;
-    private String instanceId;
-
-    public static RequestMigrationContext from(JsonObject request) {
-      return new RequestMigrationContext(request,
-        request.getString(ID_KEY), request.getString(ITEM_ID_KEY));
-    }
-
-    @Override
-    public String toString() {
-      return "RequestMigrationContext{" +
-        "requestId='" + requestId + '\'' +
-        ", itemId='" + itemId + '\'' +
-        ", holdingsRecordId='" + holdingsRecordId + '\'' +
-        ", instanceId='" + instanceId + '\'' +
-        '}';
-    }
-  }
-
-  @Getter
-  @Setter
-  @RequiredArgsConstructor
-  private static class Batch {
-    private final int batchNumber;
-    private final Conn connection;
-    private List<RequestMigrationContext> requestMigrationContexts = new ArrayList<>();
-
-    @Override
-    public String toString() {
-      return String.format("[batch #%d - %d requests]", batchNumber, requestMigrationContexts.size());
-    }
-  }
-
 }

--- a/src/main/java/org/folio/service/tlr/TlrIndexFieldsMigrationService.java
+++ b/src/main/java/org/folio/service/tlr/TlrIndexFieldsMigrationService.java
@@ -1,0 +1,84 @@
+package org.folio.service.tlr;
+
+import static io.vertx.core.Future.succeededFuture;
+import static java.util.stream.Collectors.toMap;
+import static java.util.stream.Collectors.toSet;
+import static org.folio.support.JsonPropertyWriter.write;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.folio.rest.jaxrs.model.TenantAttributes;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import io.vertx.core.Context;
+import io.vertx.core.Future;
+import io.vertx.core.json.JsonObject;
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * Data migration from item-level requests (ILR) to title-level requests (TLR)
+ */
+public class TlrIndexFieldsMigrationService extends AbstractRequestMigrationService{
+  private static final Logger log = LogManager.getLogger(TlrIndexFieldsMigrationService.class);
+
+  private static final String TLR_MIGRATION_MODULE_VERSION = "mod-circulation-storage-16.1.0";
+  private static final String ITEMS_STORAGE_URL = "/item-storage/items";
+  private static final String SERVICE_POINT_URL = "/service-points";
+
+
+  private static final String REQUEST_TABLE = "request";
+  private static final String ITEM_KEY = "item";
+  private static final String ITEM_ID_KEY = "itemId";
+
+  public TlrIndexFieldsMigrationService(TenantAttributes attributes, Context context,
+    Map<String, String> okapiHeaders) {
+      super(attributes, context, okapiHeaders, REQUEST_TABLE, TLR_MIGRATION_MODULE_VERSION);
+    }
+
+  public Future<Void> processBatch(Batch batch) {
+    log.info("{} processing started", batch);
+
+    return succeededFuture(batch)
+      .compose(this::fetchRequests)
+      .compose(this::validateRequests)
+      .compose(this::findServicePointNames)
+      .compose(this::findCallNumbers)
+      .onSuccess(this::buildNewRequests)
+      .compose(this::updateRequests)
+      .onSuccess(r -> log.info("{} processing finished successfully", batch))
+      .recover(t -> handleError(batch, t));
+  }
+
+  public Collection<String> validateRequest(RequestMigrationContext context) {
+    final JsonObject request = context.getOldRequest();
+    final String requestId = context.getRequestId();
+    final List<String> errors = new ArrayList<>();
+
+    return errors;
+  }
+
+  private Future<Batch> findServicePointNames(Batch batch) {
+
+    return succeededFuture(batch);
+ 
+  }
+
+  private Future<Batch> findCallNumbers(Batch batch) {
+
+    return succeededFuture(batch);
+
+  }
+
+  public void buildNewRequest(RequestMigrationContext context) {
+
+  }
+}


### PR DESCRIPTION
After talking to other team members about this, I decided to refactor the existing TlrDataMigrationClass so that most of the code in that class went into an abstract class-this will reduce code duplication in the new IndexFieldMigration class, since both classes will do very very similar things.  This has the added benefit of reducing the amount of code that will need to be written for the new migration service.

I left code that's specific to the migration operation inside the existing class and implemented them as abstract methods in the new abstract class.  I also had to move some internal classes out of the existing class so they could be shared between the new classes.