### PR TITLE
CIRCSTORE-421 Add sessionId to scheduled notice and patron action session

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -507,7 +507,7 @@
     },
     {
       "id": "patron-action-session-storage",
-      "version": "0.2",
+      "version": "0.3",
       "handlers": [
         {
           "methods": ["GET"],

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -395,7 +395,7 @@
     },
     {
       "id": "scheduled-notice-storage",
-      "version": "0.4",
+      "version": "0.5",
       "handlers": [
         {
           "methods": ["GET"],

--- a/ramls/patron-action-session.json
+++ b/ramls/patron-action-session.json
@@ -7,17 +7,22 @@
     "id": {
       "type": "string",
       "description": "Patron action session id, UUID",
-      "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$"
+      "$ref": "raml-util/schemas/uuid.schema"
+    },
+    "sessionId": {
+      "type": "string",
+      "description": "UUID which is the same for all patron action sessions generated in scope of the same check-in/check-out session",
+      "$ref": "raml-util/schemas/uuid.schema"
     },
     "patronId": {
       "type": "string",
       "description": "Patron id",
-      "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$"
+      "$ref": "raml-util/schemas/uuid.schema"
     },
     "loanId": {
       "type": "string",
       "description": "Loan id",
-      "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$"
+      "$ref": "raml-util/schemas/uuid.schema"
     },
     "actionType": {
       "type": "string",

--- a/ramls/patron-action-session.raml
+++ b/ramls/patron-action-session.raml
@@ -1,6 +1,6 @@
 #%RAML 1.0
 title: Patron Action Session
-version: v0.2
+version: v0.3
 protocols: [ HTTP, HTTPS ]
 baseUri: http://localhost:9130
 

--- a/ramls/scheduled-notice-storage.raml
+++ b/ramls/scheduled-notice-storage.raml
@@ -1,6 +1,6 @@
 #%RAML 1.0
 title: Scheduled Notice Storage
-version: v0.4
+version: v0.5
 protocols: [ HTTP, HTTPS ]
 baseUri: http://localhost:9130
 

--- a/ramls/scheduled-notice.json
+++ b/ramls/scheduled-notice.json
@@ -27,6 +27,11 @@
       "description": "Id of the user to whom this notice should be sent to",
       "$ref": "raml-util/schemas/uuid.schema"
     },
+    "sessionId": {
+      "type": "string",
+      "description": "UUID which is the same for all notices generated in scope of the same check-in/check-out session",
+      "$ref": "raml-util/schemas/uuid.schema"
+    },
     "nextRunTime": {
       "type": "string",
       "format": "date-time",

--- a/src/test/java/org/folio/rest/api/PatronActionSessionAPITest.java
+++ b/src/test/java/org/folio/rest/api/PatronActionSessionAPITest.java
@@ -1,11 +1,10 @@
 package org.folio.rest.api;
 
+import static org.folio.rest.api.StorageTestSuite.TENANT_ID;
+import static org.folio.rest.support.matchers.HttpResponseStatusCodeMatchers.isOk;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.junit.MatcherAssert.assertThat;
-
-import static org.folio.rest.api.StorageTestSuite.TENANT_ID;
-import static org.folio.rest.support.matchers.HttpResponseStatusCodeMatchers.isOk;
 
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -17,18 +16,8 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.stream.Collectors;
 
-import io.vertx.core.json.JsonArray;
-import io.vertx.core.json.JsonObject;
-import io.vertx.sqlclient.Row;
-import io.vertx.sqlclient.RowSet;
-
-import org.joda.time.DateTime;
-import org.joda.time.format.ISODateTimeFormat;
-import org.junit.Before;
-import org.junit.Test;
-
-import org.folio.rest.persist.PostgresClient;
 import org.folio.rest.persist.Criteria.Criterion;
+import org.folio.rest.persist.PostgresClient;
 import org.folio.rest.support.ApiTests;
 import org.folio.rest.support.IndividualResource;
 import org.folio.rest.support.JsonResponse;
@@ -38,7 +27,20 @@ import org.folio.rest.support.TextResponse;
 import org.folio.rest.support.builders.LoanRequestBuilder;
 import org.folio.rest.support.http.AssertingRecordClient;
 import org.folio.rest.support.http.InterfaceUrls;
+import org.joda.time.DateTime;
+import org.joda.time.format.ISODateTimeFormat;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
 
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import io.vertx.sqlclient.Row;
+import io.vertx.sqlclient.RowSet;
+import junitparams.JUnitParamsRunner;
+import junitparams.Parameters;
+
+@RunWith(JUnitParamsRunner.class)
 public class PatronActionSessionAPITest extends ApiTests {
 
   private static final String PATRON_ACTION_SESSION = "patron_action_session";
@@ -260,11 +262,12 @@ public class PatronActionSessionAPITest extends ApiTests {
   }
 
   @Test
-  public void canSaveAndRetrieveSessionWithSessionId() throws InterruptedException,
-    MalformedURLException,TimeoutException, ExecutionException {
+  @Parameters({"Check-in", "Check-out"})
+  public void canSaveAndRetrieveSessionWithSessionId(String actionType)
+    throws InterruptedException, MalformedURLException,TimeoutException, ExecutionException {
 
     String sessionId = UUID.randomUUID().toString();
-    JsonObject session = createPatronActionSession("Check-out")
+    JsonObject session = createPatronActionSession(actionType)
       .put("sessionId", sessionId);
 
     assertRecordClient.create(session);
@@ -279,6 +282,7 @@ public class PatronActionSessionAPITest extends ApiTests {
       .orElseThrow();
 
     assertThat(retrievedSession.getString("sessionId"), is(sessionId));
+    assertThat(retrievedSession.getString("actionType"), is(actionType));
   }
 
   private JsonObject createPatronActionSession(String actionType) {

--- a/src/test/java/org/folio/rest/api/PatronActionSessionAPITest.java
+++ b/src/test/java/org/folio/rest/api/PatronActionSessionAPITest.java
@@ -259,6 +259,28 @@ public class PatronActionSessionAPITest extends ApiTests {
       is("Date cannot be parsed"));
   }
 
+  @Test
+  public void canSaveAndRetrieveSessionWithSessionId() throws InterruptedException,
+    MalformedURLException,TimeoutException, ExecutionException {
+
+    String sessionId = UUID.randomUUID().toString();
+    JsonObject session = createPatronActionSession("Check-out")
+      .put("sessionId", sessionId);
+
+    assertRecordClient.create(session);
+    MultipleRecords<JsonObject> sessions = assertRecordClient.getAll();
+
+    assertThat(sessions.getTotalRecords(), is(1));
+    assertThat(sessions.getRecords().size(), is(1));
+
+    JsonObject retrievedSession = sessions.getRecords()
+      .stream()
+      .findFirst()
+      .orElseThrow();
+
+    assertThat(retrievedSession.getString("sessionId"), is(sessionId));
+  }
+
   private JsonObject createPatronActionSession(String actionType) {
     JsonObject jsonObject = new JsonObject()
       .put("id", UUID.randomUUID().toString())

--- a/src/test/java/org/folio/rest/api/ScheduledNoticesAPITest.java
+++ b/src/test/java/org/folio/rest/api/ScheduledNoticesAPITest.java
@@ -88,9 +88,11 @@ public class ScheduledNoticesAPITest extends ApiTests {
       .put("format", "Email");
 
     DateTime nextRunTime = new DateTime(UTC);
+    String sessionId = randomId();
     JsonObject scheduledNotice = new JsonObject()
       .put("nextRunTime", nextRunTime.toString())
       .put("noticeConfig", noticeConfig)
+      .put("sessionId", sessionId)
       .put("triggeringEvent", "Request expiration");
 
     String createdNoticeId = postScheduledNotice(scheduledNotice).getJson().getString("id");
@@ -99,6 +101,7 @@ public class ScheduledNoticesAPITest extends ApiTests {
     JsonObject createdConfig = createdNotice.getJsonObject("noticeConfig");
 
     assertThat(createdNotice.getString("triggeringEvent"), is("Request expiration"));
+    assertThat(createdNotice.getString("sessionId"), is(sessionId));
     assertThat(DateTime.parse(createdNotice.getString("nextRunTime")), is(nextRunTime));
     assertThat(createdConfig.getString("timing"), is("Upon At"));
     assertThat(createdConfig.getString("templateId"), is(templateId));


### PR DESCRIPTION
Support new functionality introduced in [CIRC-1726](https://issues.folio.org/browse/CIRC-1726) by adding an optional UUID property `sessionId` to both scheduled notice and patron action session schema.

Resolves [CIRCSTORE-421](https://issues.folio.org/browse/CIRCSTORE-421)