### PR TITLE
CIRCSTORE-412: Request does not change status properly when tlr settings not initialized

### DIFF
--- a/src/main/java/org/folio/rest/client/ConfigurationClient.java
+++ b/src/main/java/org/folio/rest/client/ConfigurationClient.java
@@ -1,7 +1,6 @@
 package org.folio.rest.client;
 
 import static io.vertx.core.Future.failedFuture;
-import static io.vertx.core.Future.succeededFuture;
 import static io.vertx.core.http.HttpMethod.GET;
 import static java.lang.String.format;
 
@@ -13,7 +12,6 @@ import org.apache.logging.log4j.Logger;
 import org.folio.rest.configuration.TlrSettingsConfiguration;
 import org.folio.rest.jaxrs.model.Config;
 import org.folio.rest.jaxrs.model.KvConfigurations;
-import org.folio.rest.jaxrs.model.TenantJob;
 import org.folio.support.exception.HttpException;
 import org.folio.util.StringUtil;
 
@@ -34,6 +32,7 @@ public class ConfigurationClient extends OkapiClient {
 
   public Future<TlrSettingsConfiguration> getTlrSettings() {
     String url = format(CONFIGURATIONS_URL, StringUtil.urlEncode(TLR_SETTINGS_QUERY));
+
     return okapiGet(url)
       .compose(response -> {
         int responseStatus = response.statusCode();
@@ -43,13 +42,7 @@ public class ConfigurationClient extends OkapiClient {
           log.error(errorMessage);
           return failedFuture(new HttpException(GET, url, response));
         } else {
-          JsonObject json = response.bodyAsJsonObject();
-          if (json.getInteger("totalRecords")  == 0) {
-            TlrSettingsConfiguration config = new TlrSettingsConfiguration(false, false, null, null, null);
-            return succeededFuture(config);
-          }
           try {
-            log.info("response: " + response.bodyAsString());
             return objectMapper.readValue(response.bodyAsString(), KvConfigurations.class)
               .getConfigs().stream()
               .findFirst()


### PR DESCRIPTION
Because there are other endpoints that expect to receive an error from the settings endpoint when TLR settings are not present, I located the fix within the expire code itself.  If it can't read the TLR settings for some reason, it now constructs and uses an empty settings object that defaults to TLR being disabled.  This results in request expiry jobs now succeeding and properly changing status when triggered.  I adapted one of the existing tests to check for this condition by clearing all TLR settings before the test runs.
