### PR TITLE
CIRCSTOR-412: Request cannot be expired properly when TLR settings not set

### DIFF
--- a/src/main/java/org/folio/rest/client/ConfigurationClient.java
+++ b/src/main/java/org/folio/rest/client/ConfigurationClient.java
@@ -1,7 +1,6 @@
 package org.folio.rest.client;
 
 import static io.vertx.core.Future.failedFuture;
-import static io.vertx.core.Future.succeededFuture;
 import static io.vertx.core.http.HttpMethod.GET;
 import static java.lang.String.format;
 
@@ -13,7 +12,6 @@ import org.apache.logging.log4j.Logger;
 import org.folio.rest.configuration.TlrSettingsConfiguration;
 import org.folio.rest.jaxrs.model.Config;
 import org.folio.rest.jaxrs.model.KvConfigurations;
-import org.folio.rest.jaxrs.model.TenantJob;
 import org.folio.support.exception.HttpException;
 import org.folio.util.StringUtil;
 
@@ -34,6 +32,7 @@ public class ConfigurationClient extends OkapiClient {
 
   public Future<TlrSettingsConfiguration> getTlrSettings() {
     String url = format(CONFIGURATIONS_URL, StringUtil.urlEncode(TLR_SETTINGS_QUERY));
+
     return okapiGet(url)
       .compose(response -> {
         int responseStatus = response.statusCode();
@@ -43,13 +42,7 @@ public class ConfigurationClient extends OkapiClient {
           log.error(errorMessage);
           return failedFuture(new HttpException(GET, url, response));
         } else {
-          JsonObject json = response.bodyAsJsonObject();
-          if (json.getInteger("totalRecords")  == 0) {
-            TlrSettingsConfiguration config = new TlrSettingsConfiguration(false, false, null, null, null);
-            return succeededFuture(config);
-          }
           try {
-            log.info("response: " + response.bodyAsString());
             return objectMapper.readValue(response.bodyAsString(), KvConfigurations.class)
               .getConfigs().stream()
               .findFirst()

--- a/src/main/java/org/folio/rest/impl/RequestExpiryImpl.java
+++ b/src/main/java/org/folio/rest/impl/RequestExpiryImpl.java
@@ -31,20 +31,18 @@ public class RequestExpiryImpl implements ScheduledRequestExpiration {
 
     Vertx vertx = context.owner();
     new ConfigurationClient(vertx, okapiHeaders).getTlrSettings()
-      .onSuccess(tlrSettings -> {
-        doExpiration(tlrSettings, handler, okapiHeaders, vertx);
-      })
-      .onFailure(r -> {
-        TlrSettingsConfiguration emptyConfig = new TlrSettingsConfiguration(false, false, null, null, null);
-        doExpiration(emptyConfig, handler, okapiHeaders, vertx);
-      });
+      .onSuccess(tlrSettings -> doExpiration(tlrSettings, handler, okapiHeaders, vertx))
+      .onFailure(t -> doExpiration(new TlrSettingsConfiguration(false, false, null, null, null), 
+        handler, okapiHeaders, vertx));
   }
 
-  private void doExpiration(TlrSettingsConfiguration tlrSettings, Handler<AsyncResult<Response>> handler, Map<String, String> okapiHeaders, Vertx vertx) {
+  private void doExpiration(TlrSettingsConfiguration tlrSettings,
+    Handler<AsyncResult<Response>> handler, Map<String, String> okapiHeaders, Vertx vertx) {
+    
     createRequestExpirationService(okapiHeaders, vertx, tlrSettings)
-        .doRequestExpiration()
-    .onSuccess(x -> handler.handle(succeededFuture(respond204())))
-    .onFailure(e -> handler.handle(succeededFuture(respond500WithTextPlain(e.getMessage()))));
+      .doRequestExpiration()
+        .onSuccess(x -> handler.handle(succeededFuture(respond204())))
+        .onFailure(e -> handler.handle(succeededFuture(respond500WithTextPlain(e.getMessage()))));
   }
 
   private RequestExpirationService createRequestExpirationService(Map<String, String> okapiHeaders,

--- a/src/main/java/org/folio/rest/impl/RequestExpiryImpl.java
+++ b/src/main/java/org/folio/rest/impl/RequestExpiryImpl.java
@@ -6,7 +6,6 @@ import static org.folio.rest.jaxrs.resource.ScheduledRequestExpiration.Scheduled
 import static org.folio.rest.jaxrs.resource.ScheduledRequestExpiration.ScheduledRequestExpirationResponse.respond500WithTextPlain;
 
 import java.util.Map;
-import java.util.concurrent.CompletableFuture;
 
 import javax.ws.rs.core.Response;
 

--- a/src/test/java/org/folio/rest/api/RequestExpirationApiTest.java
+++ b/src/test/java/org/folio/rest/api/RequestExpirationApiTest.java
@@ -131,9 +131,9 @@ public class RequestExpirationApiTest extends ApiTests {
   }
 
   @Test
-  public void canExpireRequestWhenTlrSettingsNotSet() throws InterruptedException,
+  public void canExpireRequestWhenTlrSettingsNotReadable() throws InterruptedException,
     MalformedURLException, TimeoutException, ExecutionException {
-    StorageTestSuite.deleteAll(requestStorageUrl());
+    stubWithInvalidTlrSettings();
     
     UUID id = UUID.randomUUID();
     UUID itemId = UUID.randomUUID();

--- a/src/test/java/org/folio/rest/api/RequestExpirationApiTest.java
+++ b/src/test/java/org/folio/rest/api/RequestExpirationApiTest.java
@@ -133,6 +133,7 @@ public class RequestExpirationApiTest extends ApiTests {
   @Test
   public void canExpireRequestWhenTlrSettingsNotReadable() throws InterruptedException,
     MalformedURLException, TimeoutException, ExecutionException {
+    
     stubWithInvalidTlrSettings();
     
     UUID id = UUID.randomUUID();


### PR DESCRIPTION
Because there are other endpoints that expect to get errors from the settings when TLR settings are not set, I located the fix for this within the expiry code.  If it cannot read the TLR settings from the back end (which is the case when the settings are empty), it creates a dummy set of settings that treat TLR as if it's disabled.  This allows the expiry process to properly expire requests even when TLR settings are not initialized.