### PR TITLE
[CIRCSTORE-359] Use new RMB readonly APIs

### DIFF
--- a/src/main/java/org/folio/service/migration/AbstractRequestMigrationService.java
+++ b/src/main/java/org/folio/service/migration/AbstractRequestMigrationService.java
@@ -123,7 +123,7 @@ abstract class AbstractRequestMigrationService<T extends RequestMigrationContext
       .compose(this::getBatchCount);
   }
 
-  public Future<RowSet<Row>> selectRead(String sql) {
+  private Future<RowSet<Row>> selectRead(String sql) {
     return Future.future(promise -> postgresClient.selectRead(sql, 0, promise));
   }
 

--- a/src/main/java/org/folio/service/migration/AbstractRequestMigrationService.java
+++ b/src/main/java/org/folio/service/migration/AbstractRequestMigrationService.java
@@ -128,7 +128,7 @@ abstract class AbstractRequestMigrationService<T extends RequestMigrationContext
   }
 
   public Future<Void> migrateRequests(int batchCount) {
-    return postgresClient.withReadTrans(conn ->
+    return postgresClient.withTrans(conn ->
       chainFutures(buildBatches(batchCount, conn), this::processBatch)
         .compose(r -> failIfErrorsOccurred())
     );

--- a/src/main/java/org/folio/support/PgClientFutureAdapter.java
+++ b/src/main/java/org/folio/support/PgClientFutureAdapter.java
@@ -25,7 +25,7 @@ public class PgClientFutureAdapter {
 
   public Future<RowSet<Row>> select(String sql) {
     final Promise<RowSet<Row>> promise = Promise.promise();
-    client.select(sql, promise);
+    client.selectRead(sql, 0, promise);
     return promise.future();
   }
 

--- a/src/test/java/org/folio/rest/api/StorageTestSuite.java
+++ b/src/test/java/org/folio/rest/api/StorageTestSuite.java
@@ -274,7 +274,7 @@ public class StorageTestSuite {
       "SELECT null FROM %s_%s.%s" + " WHERE CAST(id AS VARCHAR(50)) != jsonb->>'id'",
       tenantId, "mod_circulation_storage", tableName);
 
-    postgresClient.select(sql, result -> {
+    postgresClient.selectRead(sql, 0, result -> {
       if (result.succeeded()) {
         selectCompleted.complete(result.result());
       } else {

--- a/src/test/java/org/folio/rest/api/TenantRefApiTests.java
+++ b/src/test/java/org/folio/rest/api/TenantRefApiTests.java
@@ -427,7 +427,7 @@ public class TenantRefApiTests {
   }
 
   private static void assertThatNoRequestsWereUpdatedByTlrMigration(TestContext context) {
-    postgresClient.select("SELECT COUNT(*) " +
+    selectRead("SELECT COUNT(*) " +
         "FROM " + REQUEST_TABLE + " " +
         "WHERE jsonb->>'requestLevel' IS NOT null")
       .onFailure(context::fail)
@@ -435,7 +435,7 @@ public class TenantRefApiTests {
   }
 
   private static void assertThatNoRequestsWereUpdatedByRequestSearchMigration(TestContext context) {
-    postgresClient.select("SELECT COUNT(*) " +
+    selectRead("SELECT COUNT(*) " +
         "FROM " + REQUEST_TABLE + " " +
         "WHERE jsonb->>'searchIndex' IS NOT null")
       .onFailure(context::fail)
@@ -443,10 +443,14 @@ public class TenantRefApiTests {
   }
 
   private static Future<List<JsonObject>> getAllRequestsAsJson() {
-    return postgresClient.select("SELECT * FROM " + REQUEST_TABLE)
+    return selectRead("SELECT * FROM " + REQUEST_TABLE)
       .map(rowSet -> StreamSupport.stream(rowSet.spliterator(), false)
         .map(row -> row.getJsonObject("jsonb"))
         .collect(toList()));
+  }
+
+  private static Future<RowSet<Row>> selectRead(String sql) {
+    return Future.future(promise -> postgresClient.selectRead(sql, 0, promise));
   }
 
   private static Future<JsonObject> getRequestAsJson(String requestId) {


### PR DESCRIPTION
## Purpose:
- Update calling existing RMB "Read" methods to use new RMB Readonly APIs

Resolves: [CIRCSTORE-359](https://issues.folio.org/browse/CIRCSTORE-359)