### PR TITLE
CIRCSTORE-412: Request does not change status when TLR settings not set

### DIFF
--- a/src/main/java/org/folio/rest/client/ConfigurationClient.java
+++ b/src/main/java/org/folio/rest/client/ConfigurationClient.java
@@ -79,8 +79,7 @@ public class ConfigurationClient extends OkapiClient {
           log.error(errorMessage);
           return failedFuture(new HttpException(GET, url, response));
         } else {
-          String body = response.bodyAsString();
-          return succeededFuture(body);
+          return succeededFuture(response.bodyAsString());
         }
     });
   }

--- a/src/main/java/org/folio/rest/client/ConfigurationClient.java
+++ b/src/main/java/org/folio/rest/client/ConfigurationClient.java
@@ -68,6 +68,7 @@ public class ConfigurationClient extends OkapiClient {
             return failedFuture(e);
           }
         }
-      });
-    }
+      }
+    );
   }
+}

--- a/src/main/java/org/folio/rest/client/ConfigurationClient.java
+++ b/src/main/java/org/folio/rest/client/ConfigurationClient.java
@@ -27,7 +27,7 @@ public class ConfigurationClient extends OkapiClient {
   private static final Logger log = LogManager.getLogger(MethodHandles.lookup().lookupClass());
   private static final String CONFIGURATIONS_URL = "/configurations/entries?query=%s";
   private static final String TLR_SETTINGS_QUERY = "module==\"SETTINGS\" and configName==\"TLR\"";
-  private static final String url = format(CONFIGURATIONS_URL, StringUtil.urlEncode(TLR_SETTINGS_QUERY));
+  private static final String URL = format(CONFIGURATIONS_URL, StringUtil.urlEncode(TLR_SETTINGS_QUERY));
 
   public ConfigurationClient(Vertx vertx, Map<String, String> okapiHeaders) {
     super(vertx, okapiHeaders);
@@ -45,7 +45,7 @@ public class ConfigurationClient extends OkapiClient {
   private Future<TlrSettingsConfiguration> getTlrSettings(
     Supplier<Future<TlrSettingsConfiguration>> otherwise) {
 
-    return okapiGet(url)
+    return okapiGet(URL)
       .compose(response -> {
         int responseStatus = response.statusCode();
         if (responseStatus != 200) {

--- a/src/main/java/org/folio/rest/client/ConfigurationClient.java
+++ b/src/main/java/org/folio/rest/client/ConfigurationClient.java
@@ -54,6 +54,7 @@ public class ConfigurationClient extends OkapiClient {
   }
 
   private Future<KvConfigurations> tryParseResponseToJson(String settings) {
+    log.info("setting string: " + settings);
     try{ 
       return succeededFuture(objectMapper.readValue(settings, KvConfigurations.class));
     } catch (JsonProcessingException e) {

--- a/src/main/java/org/folio/rest/client/ConfigurationClient.java
+++ b/src/main/java/org/folio/rest/client/ConfigurationClient.java
@@ -1,14 +1,17 @@
 package org.folio.rest.client;
 
 import static io.vertx.core.Future.failedFuture;
+import static io.vertx.core.Future.succeededFuture;
 import static io.vertx.core.http.HttpMethod.GET;
 import static java.lang.String.format;
 
 import java.lang.invoke.MethodHandles;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.folio.okapi.common.HttpResponse;
 import org.folio.rest.configuration.TlrSettingsConfiguration;
 import org.folio.rest.jaxrs.model.Config;
 import org.folio.rest.jaxrs.model.KvConfigurations;
@@ -17,22 +20,56 @@ import org.folio.util.StringUtil;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 
+import io.netty.util.concurrent.FailedFuture;
+import io.netty.util.concurrent.SucceededFuture;
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
+import io.vertx.core.impl.HAManager;
 import io.vertx.core.json.JsonObject;
 
 public class ConfigurationClient extends OkapiClient {
   private static final Logger log = LogManager.getLogger(MethodHandles.lookup().lookupClass());
   private static final String CONFIGURATIONS_URL = "/configurations/entries?query=%s";
   private static final String TLR_SETTINGS_QUERY = "module==\"SETTINGS\" and configName==\"TLR\"";
+  private static final String url = format(CONFIGURATIONS_URL, StringUtil.urlEncode(TLR_SETTINGS_QUERY));
 
   public ConfigurationClient(Vertx vertx, Map<String, String> okapiHeaders) {
     super(vertx, okapiHeaders);
   }
 
-  public Future<TlrSettingsConfiguration> getTlrSettings() {
-    String url = format(CONFIGURATIONS_URL, StringUtil.urlEncode(TLR_SETTINGS_QUERY));
+  public Future<TlrSettingsConfiguration> getTlrSettingsOrDefault() {
+    return getSettingsFromStorage(url)
+      .compose(respBody -> {
+        if (respBody.isEmpty()) {
+          return succeededFuture(new TlrSettingsConfiguration(false, false, null, null, null));
+        } else {
+          return parseSettings(respBody);
+        }
+      });
+  }
 
+  public Future<TlrSettingsConfiguration> getTlrSettings() {
+    return getSettingsFromStorage(url)
+      .compose(this::parseSettings);
+  }
+
+  private Future<TlrSettingsConfiguration> parseSettings(String settings) {
+    try {
+      return objectMapper.readValue(settings, KvConfigurations.class)
+        .getConfigs().stream()
+        .findFirst()
+        .map(Config::getValue)
+        .map(JsonObject::new)
+        .map(TlrSettingsConfiguration::from)
+        .map(Future::succeededFuture)
+        .orElseGet(() -> failedFuture("Failed to find TLR configuration"));
+      } catch (JsonProcessingException e) {
+        log.error("Failed to parse response: {}", settings);
+        return failedFuture(e);
+      }
+  }
+
+  private Future<String> getSettingsFromStorage(String url) {
     return okapiGet(url)
       .compose(response -> {
         int responseStatus = response.statusCode();
@@ -42,20 +79,9 @@ public class ConfigurationClient extends OkapiClient {
           log.error(errorMessage);
           return failedFuture(new HttpException(GET, url, response));
         } else {
-          try {
-            return objectMapper.readValue(response.bodyAsString(), KvConfigurations.class)
-              .getConfigs().stream()
-              .findFirst()
-              .map(Config::getValue)
-              .map(JsonObject::new)
-              .map(TlrSettingsConfiguration::from)
-              .map(Future::succeededFuture)
-              .orElseGet(() -> failedFuture("Failed to find TLR configuration"));
-          } catch (JsonProcessingException e) {
-            log.error("Failed to parse response: {}", response.bodyAsString());
-            return failedFuture(e);
-          }
+          String body = response.bodyAsString();
+          return succeededFuture(body);
         }
-      });
+    });
   }
 }

--- a/src/main/java/org/folio/rest/client/ConfigurationClient.java
+++ b/src/main/java/org/folio/rest/client/ConfigurationClient.java
@@ -52,7 +52,7 @@ public class ConfigurationClient extends OkapiClient {
           String errorMessage = format("Failed to find TLR configuration. Response: %d %s",
             responseStatus, response.bodyAsString());
           log.error(errorMessage);
-          return failedFuture(new HttpException(GET, url, response));
+          return failedFuture(new HttpException(GET, URL, response));
         } else {
           try {
             return objectMapper.readValue(response.bodyAsString(), KvConfigurations.class)

--- a/src/main/java/org/folio/rest/impl/RequestExpiryImpl.java
+++ b/src/main/java/org/folio/rest/impl/RequestExpiryImpl.java
@@ -29,7 +29,7 @@ public class RequestExpiryImpl implements ScheduledRequestExpiration {
       Handler<AsyncResult<Response>> handler, Context context) {
 
     Vertx vertx = context.owner();
-    new ConfigurationClient(vertx, okapiHeaders).getTlrSettings()
+    new ConfigurationClient(vertx, okapiHeaders).getTlrSettingsOrDefault()
     .compose(tlrSettings -> createRequestExpirationService(okapiHeaders, vertx, tlrSettings)
         .doRequestExpiration())
     .onSuccess(x -> handler.handle(succeededFuture(respond204())))

--- a/src/test/java/org/folio/rest/support/ApiTests.java
+++ b/src/test/java/org/folio/rest/support/ApiTests.java
@@ -13,6 +13,7 @@ import static org.hamcrest.core.Is.is;
 
 import java.net.HttpURLConnection;
 import java.net.URL;
+import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
@@ -163,6 +164,15 @@ public class ApiTests {
     StorageTestSuite.getWireMockServer().stubFor(WireMock.get(urlPathMatching(
         CONFIGURATIONS_ENTRIES_URL_PATTERN))
       .willReturn(ok().withBody("Invalid configurations response")));
+  }
+
+  protected void stubWithEmptyTlrSettings() {
+    StorageTestSuite.getWireMockServer().stubFor(WireMock.get(urlPathMatching(
+        CONFIGURATIONS_ENTRIES_URL_PATTERN))
+      .willReturn(ok().withBody(mapFrom(
+        new KvConfigurations()
+          .withConfigs(Collections.<Config>emptyList()))
+        .encodePrettily())));
   }
 
   public static <T> T waitFor(Future<T> future) {


### PR DESCRIPTION
It was decided that the best way to handle this was to create a alternate method in the configuration client that would return a default settings object if the TLR settings have not been initialized.  The default method assumes TLR should be disabled.  This will allow the expiration process to run if the settings have not been set.