### PR TITLE
[CIRCSTORE-431] Modify circulation dtos to include source field.

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -235,7 +235,7 @@
     },
     {
       "id" : "cancellation-reason-storage",
-      "version": "1.1",
+      "version": "1.2",
       "handlers": [
         {
           "methods": ["GET"],

--- a/ramls/cancellation-reason.json
+++ b/ramls/cancellation-reason.json
@@ -18,7 +18,7 @@
       "type": "boolean"
     },
     "source": {
-      "description": "Origin of the cancellation reason record, i.e. 'System' or 'User'",
+      "description": "Origin of the cancellation reason record, i.e. 'System', 'User', 'Consortium' etc.",
       "type": "string"
     },
     "metadata": {

--- a/ramls/cancellation-reason.json
+++ b/ramls/cancellation-reason.json
@@ -18,7 +18,7 @@
       "type": "boolean"
     },
     "source": {
-      "description": "origin of the cancellation reason record, i.e. 'System' or 'User'",
+      "description": "Origin of the cancellation reason record, i.e. 'System' or 'User'",
       "type": "string"
     },
     "metadata": {

--- a/ramls/cancellation-reason.json
+++ b/ramls/cancellation-reason.json
@@ -18,7 +18,7 @@
       "type": "boolean"
     },
     "source": {
-      "description": "Origin of the cancellation reason record, i.e. 'System', 'User', 'Consortium' etc.",
+      "description": "Origin of the cancellation reason record, e.g. 'System', 'User', 'Consortium' etc.",
       "type": "string"
     },
     "metadata": {

--- a/ramls/cancellation-reason.json
+++ b/ramls/cancellation-reason.json
@@ -17,6 +17,10 @@
     "requiresAdditionalInformation": {
       "type": "boolean"
     },
+    "source": {
+      "description": "origin of the cancellation reason record, i.e. 'System' or 'User'",
+      "type": "string"
+    },
     "metadata": {
       "$ref": "raml-util/schemas/metadata.schema",
       "readonly": true

--- a/ramls/cancellation-reason.raml
+++ b/ramls/cancellation-reason.raml
@@ -1,6 +1,6 @@
 #%RAML 1.0
 title: Cancellation Reasons
-version: v1.1
+version: v1.2
 protocols: [ HTTP, HTTPS ]
 baseUri: http://localhost:9130
 

--- a/ramls/examples/cancellation-reason.json
+++ b/ramls/examples/cancellation-reason.json
@@ -3,6 +3,7 @@
   "name": "Not available",
   "description": "The item is no longer available",
   "publicDescription": "The item status is unknown",
-  "requiresAdditionalInformation": false
+  "requiresAdditionalInformation": false,
+  "source": "System"
 }
 

--- a/ramls/examples/cancellation-reasons.json
+++ b/ramls/examples/cancellation-reasons.json
@@ -1,12 +1,13 @@
 {
-  "cancellationReasons" : [
+  "cancellationReasons": [
     {
       "id": "5aace7aa-a741-4d69-9741-46737da78f7f",
       "name": "Not available",
       "description": "The item is no longer available",
       "publicDescription": "The item status is unknown",
-      "requiresAdditionalInformation": false
-        }
+      "requiresAdditionalInformation": false,
+      "source": "System"
+    }
   ],
   "totalRecords": 1
 }

--- a/src/test/java/org/folio/rest/api/CancellationReasonsApiTest.java
+++ b/src/test/java/org/folio/rest/api/CancellationReasonsApiTest.java
@@ -183,7 +183,8 @@ public class CancellationReasonsApiTest extends ApiTests {
     JsonObject request = new JsonObject()
         .put("name", "cosmicrays")
         .put("description", "Excess solar radiation has destroyed the item")
-        .put("publicDescription", "The item has been destroyed");
+        .put("publicDescription", "The item has been destroyed")
+        .put("source", "System");
     assertCreateCancellationReason(request);
   }
 
@@ -198,10 +199,12 @@ public class CancellationReasonsApiTest extends ApiTests {
         .put("name", "slime")
         .put("id", id)
         .put("description", "Item slimed")
-        .put("requiresAdditionalInformation", true);
+        .put("requiresAdditionalInformation", true)
+        .put("source", "System");
     assertCreateCancellationReason(request);
     IndividualResource reason = assertGetCancellationReason(id);
     assertEquals("slime", reason.getJson().getString("name"));
+    assertEquals("System", reason.getJson().getString("source"));
   }
 
   @Test


### PR DESCRIPTION
Resolves: [CIRCSTORE-431](https://issues.folio.org/browse/CIRCSTORE-431) Modify circulation dtos to include source field.

This table describes what setting we are going to implement in Consortium Manager:
https://wiki.folio.org/display/FOLIJET/Consortium+manager+settings
So for _mod-circulation-storage_ it is _cancellation reason_.
Setting created in Consortium Manager will have value _'Consortium'_ and we will add validation to prevent updating them