### PR TITLE
[CIRCSTORE-377] Remove schema name from from SQL-function body

### DIFF
--- a/src/main/resources/templates/db_scripts/createIsbnFunctions.sql
+++ b/src/main/resources/templates/db_scripts/createIsbnFunctions.sql
@@ -1,8 +1,8 @@
 -- Usage: SELECT normalize_isbns(jsonb->'identifiers') FROM instance
 -- This takes each ISBN, normalizes it using RMB's normalize_digits(text),
 -- and concatenates the results using a space as separator.
-CREATE OR REPLACE FUNCTION ${myuniversity}_${mymodule}.normalize_isbns(jsonb_array jsonb) RETURNS text AS $$
-  SELECT string_agg(${myuniversity}_${mymodule}.normalize_digits(identifiers->>'value'), ' ')
+CREATE OR REPLACE FUNCTION normalize_isbns(jsonb_array jsonb) RETURNS text AS $$
+  SELECT string_agg(normalize_digits(identifiers->>'value'), ' ')
   FROM jsonb_array_elements($1) as identifiers
   WHERE identifiers->>'identifierTypeId' = '8261054f-be78-422d-bd51-4ed9f33c3422';
 $$ LANGUAGE sql IMMUTABLE PARALLEL SAFE STRICT;

--- a/src/test/java/org/folio/rest/api/TenantRefApiTests.java
+++ b/src/test/java/org/folio/rest/api/TenantRefApiTests.java
@@ -618,11 +618,11 @@ public class TenantRefApiTests {
       .withParameters(Collections.singletonList(loadReferenceParameter));
   }
 
-  protected static Future<List<String>> loadRequests() throws Exception {
+  protected static Future<RowSet<Row>> loadRequests() throws Exception {
     InputStream tableInput = TenantRefApiTests.class.getClassLoader().getResourceAsStream(
       "mocks/TlrDataMigrationTestData.sql");
     String sqlFile = IOUtils.toString(Objects.requireNonNull(tableInput), StandardCharsets.UTF_8);
-    return postgresClient.runSQLFile(sqlFile, true);
+    return postgresClient.execute(sqlFile);
   }
 
   private static String generateToken() {


### PR DESCRIPTION
Remove schema name from SQL-function body. See [this comment](https://issues.folio.org/browse/MODINVSTOR-993?focusedCommentId=149374&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-149374) for justification.
Resolves [CIRCSTORE-377](https://issues.folio.org/browse/CIRCSTORE-377).

This change brakes test `CancellationReasonsApiTest#canDeleteCancellationRequest`, which should be fixed by [this fix in RMB](https://github.com/folio-org/raml-module-builder/pull/1125) once it is released.
