### PR TITLE
Circstore 410

### DIFF
--- a/ramls/circulation-rules.json
+++ b/ramls/circulation-rules.json
@@ -11,6 +11,11 @@
     "rulesAsText": {
       "description": "Circulation rules represented in text using the bespoke format",
       "type": "string"
+    },
+    "metadata": {
+      "description": "Metadata about creation and changes to loan, provided by the server (client should not provide)",
+      "type": "object",
+      "$ref": "raml-util/schemas/metadata.schema"
     }
   },
   "additionalProperties": false,

--- a/src/main/java/org/folio/rest/impl/CirculationRulesAPI.java
+++ b/src/main/java/org/folio/rest/impl/CirculationRulesAPI.java
@@ -10,7 +10,6 @@ import org.folio.rest.annotations.Validate;
 import org.folio.rest.jaxrs.model.CirculationRules;
 import org.folio.rest.jaxrs.resource.CirculationRulesStorage;
 import org.folio.rest.persist.Criteria.Criterion;
-import org.folio.rest.persist.Criteria.UpdateSection;
 import org.folio.rest.persist.PostgresClient;
 import org.folio.rest.tools.utils.TenantTool;
 
@@ -88,10 +87,7 @@ public class CirculationRulesAPI implements CirculationRulesStorage {
         try {
           PostgresClient postgresClient = PostgresClient.getInstance(
               vertxContext.owner(), TenantTool.tenantId(okapiHeaders));
-          UpdateSection updateSection = new UpdateSection().addField("rulesAsText");
-          updateSection.setValue(entity.getRulesAsText());
-
-          postgresClient.update(CIRCULATION_RULES_TABLE, updateSection, (Criterion)null, true, update -> {
+          postgresClient.update(CIRCULATION_RULES_TABLE, entity, new Criterion(), true, update -> {
               try {
                 if (update.failed()) {
                   internalErrorPut(asyncResultHandler, update.cause());

--- a/src/main/resources/templates/db_scripts/schema.json
+++ b/src/main/resources/templates/db_scripts/schema.json
@@ -315,7 +315,8 @@
     },
     {
       "tableName": "circulation_rules",
-      "withMetadata": false,
+      "fromModuleVersion": "16.1.0",
+      "withMetadata": true,
       "withAuditing": false,
       "customSnippetPath": "insertEmptyCirculationRulesRecord.sql"
     },

--- a/src/main/resources/templates/db_scripts/schema.json
+++ b/src/main/resources/templates/db_scripts/schema.json
@@ -315,7 +315,6 @@
     },
     {
       "tableName": "circulation_rules",
-      "fromModuleVersion": "16.1.0",
       "withMetadata": true,
       "withAuditing": false,
       "customSnippetPath": "insertEmptyCirculationRulesRecord.sql"

--- a/src/test/java/org/folio/rest/api/CirculationRulesApiTest.java
+++ b/src/test/java/org/folio/rest/api/CirculationRulesApiTest.java
@@ -1,7 +1,6 @@
 package org.folio.rest.api;
 
 import io.vertx.core.json.JsonObject;
-
 import org.folio.rest.jaxrs.model.CirculationRules;
 import org.folio.rest.support.ApiTests;
 import org.folio.rest.support.JsonResponse;
@@ -19,7 +18,9 @@ import static org.folio.rest.support.matchers.OkapiResponseStatusCodeMatchers.ma
 import static org.folio.rest.support.matchers.OkapiResponseStatusCodeMatchers.matchesOk;
 import static org.folio.rest.support.matchers.OkapiResponseStatusCodeMatchers.matchesUnprocessableEntity;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.core.Is.is;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.CoreMatchers.nullValue;
 
 @FixMethodOrder(MethodSorters.NAME_ASCENDING)
 public class CirculationRulesApiTest extends ApiTests {
@@ -77,9 +78,13 @@ public class CirculationRulesApiTest extends ApiTests {
   }
 
   public void putAndGet(CirculationRules circulationRules) throws Exception {
+    var oldUpdatedDate = get().getJsonObject("metadata").getString("updatedDate");
     put204(circulationRules);
     JsonObject json = get();
     assertThat(json.getString("rulesAsText"), is(circulationRules.getRulesAsText()));
+    var metadata = json.getJsonObject("metadata");
+    assertThat(metadata.getString("updatedByUserId"), is(not(nullValue())));
+    assertThat(metadata.getString("updatedDate"), is(not(oldUpdatedDate)));
   }
 
   @Test


### PR DESCRIPTION
CIRCSTORE-410 (https://issues.folio.org/browse/CIRCSTORE-410)

## Purpose :
When I save the circulation rules in Settings > Circulation > Circulation rules, I want the associated metadata object to be updated with the logged in user info for last update date and last update by.

## Approach:
1. Metadata added in schema.json 
2. Code updated 
3. Test case updated 

Output : 

![image](https://github.com/folio-org/mod-circulation-storage/assets/103935659/5da9f560-6e24-46b5-ae3f-d192d9e7f8b2)
