### PR TITLE
CIRCSTORE-411: Slow response for CQL searching - requests

### DIFF
--- a/src/main/resources/templates/db_scripts/schema.json
+++ b/src/main/resources/templates/db_scripts/schema.json
@@ -164,6 +164,30 @@
       ],
       "ginIndex": [
         {
+          "fieldName": "item.barcode",
+          "tOps": "DELETE",
+          "caseSensitive": false,
+          "removeAccents": true
+        },
+        {
+          "fieldName": "instanceId",
+          "tOps": "DELETE",
+          "caseSensitive": false,
+          "removeAccents": true
+        },
+        {
+          "fieldName": "instance.title",
+          "tOps": "DELETE",
+          "caseSensitive": false,
+          "removeAccents": true
+        },
+        {
+          "fieldName": "requester.barcode",
+          "tOps": "DELETE",
+          "caseSensitive": false,
+          "removeAccents": true
+        },
+        {
           "fieldName": "itemId",
           "tOps": "DELETE",
           "caseSensitive": false,


### PR DESCRIPTION
From looking at the schema file, it *looks* like this is the way to add gindexes to fields in the module tables.  Let me know if not-the only other way I know of to do this would be a database script.