### PR TITLE
CIRC-1778 Actual cost records with "Open" status become "Expired"

### DIFF
--- a/ramls/actual-cost-record.json
+++ b/ramls/actual-cost-record.json
@@ -325,7 +325,6 @@
   "required": [
     "lossType",
     "lossDate",
-    "expirationDate",
     "user",
     "loan",
     "item",


### PR DESCRIPTION
Covers [CIRC-1778](https://issues.folio.org/browse/CIRC-1778)

**Purpose**
Goal of this PR is to allow creation of Actual cost records with no Expiration date if in "Lost Item policy" option "For lost items not charged a fee/fine, close the loan after" not set.

**Approach**
Make expirationDate field in ActualCostRecord nullable