### PR TITLE
CIRCSTORE-447 Cannot create Actual cost record without Expiration date

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -333,7 +333,7 @@
     },
     {
       "id": "actual-cost-record-storage",
-      "version": "0.7",
+      "version": "0.8",
       "handlers": [
         {
           "methods": ["GET"],

--- a/ramls/actual-cost-record.json
+++ b/ramls/actual-cost-record.json
@@ -325,7 +325,6 @@
   "required": [
     "lossType",
     "lossDate",
-    "expirationDate",
     "user",
     "loan",
     "item",


### PR DESCRIPTION
Covers [CIRCSTORE-447](https://issues.folio.org/browse/CIRCSTORE-447)

**Purpose**
Goal of this PR is to allow creation of Actual cost records with no Expiration date if in "Lost Item policy" option "For lost items not charged a fee/fine, close the loan after" not set.

**Approach**
expirationDate field removed from required fields