### PR TITLE
CIRCSTORE-429: Validate allowed service points on POST and PUT

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -315,10 +315,18 @@
         }, {
           "methods": ["POST"],
           "pathPattern": "/request-policy-storage/request-policies",
+          "modulePermissions": [
+            "inventory-storage.service-points.item.get",
+            "inventory-storage.service-points.collection.get"
+          ],
           "permissionsRequired": ["circulation-storage.request-policies.item.post"]
         }, {
           "methods": ["PUT"],
           "pathPattern": "/request-policy-storage/request-policies/{id}",
+          "modulePermissions": [
+            "inventory-storage.service-points.item.get",
+            "inventory-storage.service-points.collection.get"
+          ],
           "permissionsRequired": ["circulation-storage.request-policies.item.put"]
         }, {
           "methods": ["DELETE"],

--- a/ramls/request-policy-storage.raml
+++ b/ramls/request-policy-storage.raml
@@ -11,6 +11,8 @@ documentation:
 types:
   request-policy: !include request-policy.json
   request-policies: !include request-policies.json
+  servicepoint: !include service-point.json
+  servicepoints: !include service-points.json
   errors: !include raml-util/schemas/errors.schema
 
 traits:
@@ -49,6 +51,11 @@ resourceTypes:
           body:
             application/json:
               type: request-policy
+        422:
+          description: "Request policy validation failure"
+          body:
+            application/json:
+              type: errors
         500:
            description: "General errors"
            body:
@@ -94,6 +101,11 @@ resourceTypes:
         responses:
           204:
             description: "Request policy successfully updated"
+          422:
+            description: "Request policy validation failure"
+            body:
+              application/json:
+                type: errors
           501:
             description: "Not implemented yet"
           500:

--- a/ramls/service-point.json
+++ b/ramls/service-point.json
@@ -1,0 +1,85 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "description": "A service point",
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": "string",
+      "description": "Id of service-point object"
+    },
+    "name": {
+      "type": "string",
+      "description" : "service-point name, a required field"
+    },
+    "code": {
+      "type": "string",
+      "description" : "service-point code, a required field"
+    },
+    "discoveryDisplayName": {
+      "type": "string",
+      "description": "display name, a required field"
+    },
+    "description": {
+      "type": "string",
+      "description" : "description of the service-point"
+    },
+    "shelvingLagTime": {
+      "type": "integer",
+      "description": "shelving lag time"
+    },
+    "pickupLocation": {
+      "type": "boolean",
+      "description": "indicates whether or not the service point is a pickup location"
+    },
+    "holdShelfExpiryPeriod" :{
+      "type": "object",
+      "$ref": "time-period.json",
+      "description": "expiration period for items on the hold shelf at the service point"
+    },
+    "holdShelfClosedLibraryDateManagement": {
+      "type": "string",
+      "description": "enum for closedLibraryDateManagement associated with hold shelf",
+      "enum":[
+        "Keep_the_current_due_date",
+        "Move_to_the_end_of_the_previous_open_day",
+        "Move_to_the_end_of_the_next_open_day",
+        "Keep_the_current_due_date_time",
+        "Move_to_end_of_current_service_point_hours",
+        "Move_to_beginning_of_next_open_service_point_hours"
+      ],
+      "default" : "Keep_the_current_due_date"
+    },
+    "staffSlips": {
+      "type": "array",
+      "description": "List of staff slips for this service point",
+      "items": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$",
+            "description": "The ID of the staff slip"
+          },
+          "printByDefault": {
+            "type": "boolean",
+            "description": "Whether or not to print the staff slip by default"
+          }
+        },
+        "required": [
+          "id",
+          "printByDefault"
+        ]
+      }
+    },
+    "metadata": {
+      "type": "object",
+      "$ref": "raml-util/schemas/metadata.schema",
+      "readonly": true
+    }
+  },
+  "required": [
+    "name",
+    "code",
+    "discoveryDisplayName"
+  ]
+}

--- a/ramls/service-points.json
+++ b/ramls/service-points.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "description": "A collection of service points",
+  "type": "object",
+  "properties": {
+    "servicepoints": {
+      "description": "List of service points",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "$ref": "service-point.json"
+      }
+    },
+    "totalRecords": {
+      "description": "Estimated or exact total number of records",
+      "type": "integer"
+    }
+  },
+  "required": [
+    "servicepoints",
+    "totalRecords"
+  ]
+}

--- a/ramls/time-period.json
+++ b/ramls/time-period.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "description" : "schema for time-period, which contains time interval 'duration' and the time unit",
+  "properties": {
+    "duration": {
+      "type": "integer",
+      "description": "Duration interval"
+    },
+    "intervalId": {
+      "type": "string",
+      "description": "Unit of time for the duration",
+      "enum":[
+        "Minutes",
+        "Hours",
+        "Days",
+        "Weeks",
+        "Months"
+      ],
+      "default" : "Days"
+    }
+  },
+  "required": [
+    "duration",
+    "intervalId"
+  ]
+}

--- a/src/main/java/org/folio/rest/client/InventoryStorageClient.java
+++ b/src/main/java/org/folio/rest/client/InventoryStorageClient.java
@@ -1,0 +1,23 @@
+package org.folio.rest.client;
+
+import java.util.Collection;
+import java.util.Map;
+
+import org.folio.rest.jaxrs.model.Servicepoint;
+
+import io.vertx.core.Future;
+import io.vertx.core.Vertx;
+
+public class InventoryStorageClient extends OkapiClient {
+  private static final String SERVICE_POINTS_URL = "/service-points";
+  private static final String SERVICE_POINTS_COLLECTION_NAME = "servicepoints";
+
+  public InventoryStorageClient(Vertx vertx, Map<String, String> okapiHeaders) {
+    super(vertx, okapiHeaders);
+  }
+
+  public Future<Collection<Servicepoint>> getServicePoints(Collection<String> ids) {
+    return get(SERVICE_POINTS_URL, ids, SERVICE_POINTS_COLLECTION_NAME, Servicepoint.class);
+  }
+
+}

--- a/src/main/java/org/folio/rest/client/OkapiClient.java
+++ b/src/main/java/org/folio/rest/client/OkapiClient.java
@@ -2,20 +2,27 @@ package org.folio.rest.client;
 
 import static io.vertx.core.Future.failedFuture;
 import static io.vertx.core.Future.succeededFuture;
-import static java.lang.String.format;
-import static java.util.stream.Collectors.joining;
+import static io.vertx.core.http.HttpMethod.GET;
+import static java.lang.System.currentTimeMillis;
 import static java.util.stream.Collectors.toList;
+import static java.util.stream.Collectors.toSet;
 import static javax.ws.rs.core.HttpHeaders.ACCEPT;
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 import static org.folio.rest.RestVerticle.OKAPI_HEADER_TENANT;
 import static org.folio.rest.RestVerticle.OKAPI_HEADER_TOKEN;
 import static org.folio.util.StringUtil.urlEncode;
 
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.commons.collections4.ListUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.folio.support.exception.HttpException;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
@@ -27,8 +34,9 @@ import io.vertx.ext.web.client.HttpResponse;
 import io.vertx.ext.web.client.WebClient;
 
 public class OkapiClient {
-  protected static final Logger log = LoggerFactory.getLogger(OkapiClient.class);
+  protected static final Logger log = LogManager.getLogger(OkapiClient.class);
   private static final String OKAPI_URL_HEADER = "x-okapi-url";
+  private static final int ID_BATCH_SIZE = 88;
   protected static final ObjectMapper objectMapper = new ObjectMapper();
 
   private final WebClient webClient;
@@ -44,57 +52,95 @@ public class OkapiClient {
   }
 
   Future<HttpResponse<Buffer>> okapiGet(String path) {
+    log.debug("okapiGet:: path: {}", path);
+
     try {
       return webClient.getAbs(okapiUrl + path)
         .putHeader(OKAPI_HEADER_TENANT, tenant)
         .putHeader(OKAPI_URL_HEADER, okapiUrl)
         .putHeader(OKAPI_HEADER_TOKEN, token)
         .putHeader(ACCEPT, APPLICATION_JSON)
-        .send();
+        .send()
+        .onSuccess(r -> log.debug("okapiGet:: GET request success: {}{}", okapiUrl, path))
+        .onFailure(t -> log.warn("okapiGet:: GET request failed: {}{}", okapiUrl, path, t));
     } catch (Exception e) {
-      log.error("GET {}{}: {}", okapiUrl, path, e.getMessage());
+      log.warn("okapiGet:: GET request failed: {}{}", okapiUrl, path, e);
       return Future.failedFuture(e);
     }
   }
 
-  public <T> Future<Collection<T>> get(String resourcePath, Collection<String> ids,
-    String collectionName, Class<T> objectType) {
+  public <T> Future<Collection<T>> get(String path, Collection<String> ids, String collectionName,
+    Class<T> objectType) {
 
-    String query = ids.stream()
-      .distinct()
-      .map(id -> "id==" + id)
-      .collect(joining(" OR "));
+    if (log.isDebugEnabled()) {
+      log.debug("get:: path: {}, ids: {} items, objectType: {}, collectionName: {}",
+        path, ids.size(), collectionName, objectType.getSimpleName());
+    }
 
-    return getAsJson(resourcePath, query, ids.size())
-      .map(responseJson -> responseJson.getJsonArray(collectionName)
-        .stream()
-        .map(JsonObject.class::cast)
-        .map(json -> json.mapTo(objectType))
-        .collect(toList())
-      );
+    final Collection<T> results = new ArrayList<>();
+
+    Set<String> filteredIds = ids.stream()
+      .filter(StringUtils::isNotBlank)
+      .collect(toSet());
+
+    if (filteredIds.isEmpty()) {
+      log.info("get:: no IDs to fetch");
+      return succeededFuture(results);
+    }
+
+    log.info("get:: fetching {} {} by IDs", ids.size(), objectType.getSimpleName());
+
+    return ListUtils.partition(new ArrayList<>(filteredIds), ID_BATCH_SIZE)
+      .stream()
+      .map(batch -> fetchBatch(path, batch, objectType, collectionName).onSuccess(results::addAll))
+      .reduce(succeededFuture(), (f1, f2) -> f1.compose(r -> f2))
+      .map(results);
   }
 
-  public Future<JsonObject> getAsJson(String resourcePath, String query, int limit) {
-    return get(resourcePath, query, limit)
-      .map(HttpResponse::bodyAsJsonObject);
+  private <T> Future<Collection<T>> fetchBatch(String resourcePath, List<String> batch,
+    Class<T> objectType, String collectionName) {
+
+    if (log.isDebugEnabled()) {
+      log.debug("fetchBatch:: fetching batch of {} {}", batch.size(), objectType.getSimpleName());
+    }
+
+    String query = String.format("id==(%s)", String.join(" or ", batch));
+
+    return get(resourcePath, query, objectType, collectionName, batch.size());
   }
 
-  public Future<HttpResponse<Buffer>> get(String resourcePath, String query, int limit) {
-    return get(String.format("%s?limit=%d&query=%s", resourcePath, limit, urlEncode(query)));
-  }
+  public <T> Future<Collection<T>> get(String resourcePath, String query, Class<T> objectType,
+    String collectionName, int limit) {
 
-  private Future<HttpResponse<Buffer>> get(String url) {
-    log.debug("Calling GET {}", url);
+    if (log.isDebugEnabled()) {
+      log.debug("get:: resourcePath: {}, query: {}, objectType: {}, collectionName: {}, limit: {}",
+        resourcePath, query, objectType.getSimpleName(), collectionName, limit);
+    }
 
-    return okapiGet(url)
+    String path = String.format("%s?query=%s&limit=%d", resourcePath, urlEncode(query), limit);
+
+    final long startTimeMillis = log.isDebugEnabled() ? -1L : currentTimeMillis();
+
+    return okapiGet(path)
       .compose(response -> {
-        if (response.statusCode() == 200) {
-          return succeededFuture(response);
+        int responseStatus = response.statusCode();
+        if (log.isDebugEnabled()) {
+          log.debug("get:: [{}] [{} ms] GET {}", responseStatus,
+            currentTimeMillis() - startTimeMillis, resourcePath);
         }
-        final String errorMessage = format("Request failed: GET %s. Response: [%s] %s",
-          url, response.statusCode(), response.bodyAsString());
-        log.error(errorMessage);
-        return failedFuture(errorMessage);
+        if (responseStatus != 200) {
+          HttpException exception = new HttpException(GET, path, response);
+          log.warn("get:: GET by query failed: {}", path, exception);
+          return failedFuture(exception);
+        }
+        return succeededFuture(
+          response.bodyAsJsonObject()
+            .getJsonArray(collectionName)
+            .stream()
+            .map(JsonObject::mapFrom)
+            .map(json -> json.mapTo(objectType))
+            .collect(toList())
+        );
       });
   }
 }

--- a/src/main/java/org/folio/rest/impl/RequestPoliciesAPI.java
+++ b/src/main/java/org/folio/rest/impl/RequestPoliciesAPI.java
@@ -2,13 +2,13 @@ package org.folio.rest.impl;
 
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Context;
-import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
 
 import org.folio.cql2pgjson.CQL2PgJSON;
 import org.folio.rest.annotations.Validate;
+import org.folio.rest.jaxrs.model.Errors;
 import org.folio.rest.jaxrs.model.RequestPolicies;
 import org.folio.rest.jaxrs.model.RequestPolicy;
 import org.folio.rest.jaxrs.resource.RequestPolicyStorage;
@@ -18,11 +18,15 @@ import org.folio.rest.persist.PostgresClient;
 import org.folio.rest.persist.cql.CQLWrapper;
 import org.folio.rest.tools.utils.OutStream;
 import org.folio.rest.tools.utils.TenantTool;
+import org.folio.service.policy.RequestPolicyValidationService;
+import org.folio.support.exception.ValidationException;
+
 import javax.ws.rs.core.Response;
 
 import java.util.Map;
 import java.util.UUID;
 
+import static io.vertx.core.Future.succeededFuture;
 import static org.folio.rest.impl.Headers.TENANT_HEADER;
 
 public class RequestPoliciesAPI implements RequestPolicyStorage {
@@ -41,7 +45,10 @@ public class RequestPoliciesAPI implements RequestPolicyStorage {
 
   @Validate
   @Override
-  public void postRequestPolicyStorageRequestPolicies(String lang, RequestPolicy entity, Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
+  public void postRequestPolicyStorageRequestPolicies(String lang, RequestPolicy entity,
+    Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler,
+    Context vertxContext) {
+
     // TODO: replace by PgUtil.post once RMB >= 25.0.2 gets released with this fix:
     // https://issues.folio.org/browse/RMB-401 "PgUtil.post: Object or POJO type for entity parameter of respond201WithApplicationJson"
     // https://github.com/folio-org/raml-module-builder/pull/444
@@ -59,43 +66,58 @@ public class RequestPoliciesAPI implements RequestPolicyStorage {
             entity.setId(UUID.randomUUID().toString());
           }
 
-          postgresClient.save(REQUEST_POLICY_TABLE, entity.getId(), entity,
-            reply -> {
-              try {
-                if(reply.succeeded()) {
-                  OutStream stream = new OutStream();
-                  stream.setData(entity);
-
-                  asyncResultHandler.handle(
-                    io.vertx.core.Future.succeededFuture(
-                      RequestPolicyStorage.PostRequestPolicyStorageRequestPoliciesResponse
-                        .respond201WithApplicationJson(entity,
-                          RequestPolicyStorage.PostRequestPolicyStorageRequestPoliciesResponse.headersFor201().withLocation(reply.result()))));
-                }
-                else {
-                  asyncResultHandler.handle(
-                    io.vertx.core.Future.succeededFuture(
-                      RequestPolicyStorage.PostRequestPolicyStorageRequestPoliciesResponse
-                        .respond500WithTextPlain(reply.cause().toString())));
-                }
-              } catch (Exception e) {
-                log.error(e);
-                asyncResultHandler.handle(
-                  io.vertx.core.Future.succeededFuture(
-                    RequestPolicyStorage.PostRequestPolicyStorageRequestPoliciesResponse
-                      .respond500WithTextPlain(e.getMessage())));
+          new RequestPolicyValidationService(vertxContext.owner(), okapiHeaders)
+            .validate(entity)
+            .onFailure(throwable -> {
+              if (throwable instanceof ValidationException e) {
+                asyncResultHandler.handle(succeededFuture(RequestPolicyStorage
+                  .PostRequestPolicyStorageRequestPoliciesResponse
+                  .respond422WithApplicationJson(new Errors().withErrors(e.getErrors()))));
+              } else {
+                asyncResultHandler.handle(succeededFuture(RequestPolicyStorage
+                  .PostRequestPolicyStorageRequestPoliciesResponse
+                  .respond500WithTextPlain(throwable.getMessage())));
               }
+            })
+            .onSuccess(ignored -> {
+              postgresClient.save(REQUEST_POLICY_TABLE, entity.getId(), entity,
+                reply -> {
+                  try {
+                    if(reply.succeeded()) {
+                      OutStream stream = new OutStream();
+                      stream.setData(entity);
+
+                      asyncResultHandler.handle(
+                        succeededFuture(
+                          RequestPolicyStorage.PostRequestPolicyStorageRequestPoliciesResponse
+                            .respond201WithApplicationJson(entity,
+                              RequestPolicyStorage.PostRequestPolicyStorageRequestPoliciesResponse.headersFor201().withLocation(reply.result()))));
+                    }
+                    else {
+                      asyncResultHandler.handle(
+                        succeededFuture(
+                          RequestPolicyStorage.PostRequestPolicyStorageRequestPoliciesResponse
+                            .respond500WithTextPlain(reply.cause().toString())));
+                    }
+                  } catch (Exception e) {
+                    log.error(e);
+                    asyncResultHandler.handle(
+                      succeededFuture(
+                        RequestPolicyStorage.PostRequestPolicyStorageRequestPoliciesResponse
+                          .respond500WithTextPlain(e.getMessage())));
+                  }
+                });
             });
         } catch (Exception e) {
           log.error(e);
-          asyncResultHandler.handle(io.vertx.core.Future.succeededFuture(
+          asyncResultHandler.handle(succeededFuture(
             RequestPolicyStorage.PostRequestPolicyStorageRequestPoliciesResponse
               .respond500WithTextPlain(e.getMessage())));
         }
       });
     } catch (Exception e) {
       log.error(e);
-      asyncResultHandler.handle(io.vertx.core.Future.succeededFuture(
+      asyncResultHandler.handle(succeededFuture(
         RequestPolicyStorage.PostRequestPolicyStorageRequestPoliciesResponse
           .respond500WithTextPlain(e.getMessage())));
     }
@@ -116,11 +138,11 @@ public class RequestPoliciesAPI implements RequestPolicyStorage {
         CQLWrapper cql = new CQLWrapper(cql2pgJson, null);
 
         postgresClient.delete(REQUEST_POLICY_TABLE, cql,
-          reply -> asyncResultHandler.handle(Future.succeededFuture(
+          reply -> asyncResultHandler.handle(succeededFuture(
             DeleteRequestPolicyStorageRequestPoliciesResponse.respond204())));
       }
       catch(Exception e) {
-        asyncResultHandler.handle(io.vertx.core.Future.succeededFuture(
+        asyncResultHandler.handle(succeededFuture(
           RequestPolicyStorage.DeleteRequestPolicyStorageRequestPoliciesResponse
             .respond500WithTextPlain(e.getMessage())));
       }
@@ -136,10 +158,27 @@ public class RequestPoliciesAPI implements RequestPolicyStorage {
 
   @Validate
   @Override
-  public void putRequestPolicyStorageRequestPoliciesByRequestPolicyId(String requestPolicyId, String lang, RequestPolicy entity, Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
-    // TODO: on insert return 201, not 204
-    MyPgUtil.putUpsert204(REQUEST_POLICY_TABLE, entity, requestPolicyId, okapiHeaders, vertxContext,
-        PutRequestPolicyStorageRequestPoliciesByRequestPolicyIdResponse.class, asyncResultHandler);
+  public void putRequestPolicyStorageRequestPoliciesByRequestPolicyId(String requestPolicyId,
+    String lang, RequestPolicy entity, Map<String, String> okapiHeaders,
+    Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
+
+    new RequestPolicyValidationService(vertxContext.owner(), okapiHeaders)
+      .validate(entity)
+      .onFailure(throwable -> {
+        if (throwable instanceof ValidationException e) {
+          asyncResultHandler.handle(succeededFuture(RequestPolicyStorage
+            .PutRequestPolicyStorageRequestPoliciesByRequestPolicyIdResponse
+            .respond422WithApplicationJson(new Errors().withErrors(e.getErrors()))));
+        } else {
+          asyncResultHandler.handle(succeededFuture(RequestPolicyStorage
+            .PutRequestPolicyStorageRequestPoliciesByRequestPolicyIdResponse
+            .respond500WithTextPlain(throwable.getMessage())));
+        }
+      })
+      .onSuccess(ignored ->
+        // TODO: on insert return 201, not 204
+        MyPgUtil.putUpsert204(REQUEST_POLICY_TABLE, entity, requestPolicyId, okapiHeaders, vertxContext,
+        PutRequestPolicyStorageRequestPoliciesByRequestPolicyIdResponse.class, asyncResultHandler));
   }
 
   @Validate

--- a/src/main/java/org/folio/rest/impl/RequestPoliciesAPI.java
+++ b/src/main/java/org/folio/rest/impl/RequestPoliciesAPI.java
@@ -79,11 +79,11 @@ public class RequestPoliciesAPI implements RequestPolicyStorage {
                   .respond500WithTextPlain(throwable.getMessage())));
               }
             })
-            .onSuccess(ignored -> {
+            .onSuccess(ignored ->
               postgresClient.save(REQUEST_POLICY_TABLE, entity.getId(), entity,
                 reply -> {
                   try {
-                    if(reply.succeeded()) {
+                    if (reply.succeeded()) {
                       OutStream stream = new OutStream();
                       stream.setData(entity);
 
@@ -91,9 +91,9 @@ public class RequestPoliciesAPI implements RequestPolicyStorage {
                         succeededFuture(
                           RequestPolicyStorage.PostRequestPolicyStorageRequestPoliciesResponse
                             .respond201WithApplicationJson(entity,
-                              RequestPolicyStorage.PostRequestPolicyStorageRequestPoliciesResponse.headersFor201().withLocation(reply.result()))));
-                    }
-                    else {
+                              RequestPolicyStorage.PostRequestPolicyStorageRequestPoliciesResponse.headersFor201()
+                                .withLocation(reply.result()))));
+                    } else {
                       asyncResultHandler.handle(
                         succeededFuture(
                           RequestPolicyStorage.PostRequestPolicyStorageRequestPoliciesResponse
@@ -106,8 +106,8 @@ public class RequestPoliciesAPI implements RequestPolicyStorage {
                         RequestPolicyStorage.PostRequestPolicyStorageRequestPoliciesResponse
                           .respond500WithTextPlain(e.getMessage())));
                   }
-                });
-            });
+                })
+            );
         } catch (Exception e) {
           log.error(e);
           asyncResultHandler.handle(succeededFuture(

--- a/src/main/java/org/folio/service/policy/RequestPolicyValidationService.java
+++ b/src/main/java/org/folio/service/policy/RequestPolicyValidationService.java
@@ -2,6 +2,7 @@ package org.folio.service.policy;
 
 import static io.vertx.core.Future.failedFuture;
 import static io.vertx.core.Future.succeededFuture;
+import static java.lang.Boolean.TRUE;
 import static java.util.Collections.emptySet;
 import static java.util.Collections.singletonList;
 import static java.util.function.Function.identity;
@@ -76,15 +77,9 @@ public class RequestPolicyValidationService {
     for (String id : allowedServicePointIds) {
       Servicepoint servicePoint = servicePointsById.get(id);
       if (servicePoint == null) {
-        errors.add(new Error()
-          .withMessage(String.format("Service point %s does not exist", id))
-          .withParameters(singletonList(new Parameter().withKey("servicePointId").withValue(id)))
-          .withCode(ErrorCode.INVALID_ALLOWED_SERVICE_POINT.name()));
-      } else if (servicePoint.getPickupLocation() == null || !servicePoint.getPickupLocation()) {
-        errors.add(new Error()
-          .withMessage(String.format("Service point %s is not a pickup location", id))
-          .withParameters(singletonList(new Parameter().withKey("servicePointId").withValue(id)))
-          .withCode(ErrorCode.INVALID_ALLOWED_SERVICE_POINT.name()));
+        errors.add(buildError("Service point does not exist", id));
+      } else if (servicePoint.getPickupLocation() != TRUE) {
+        errors.add(buildError("Service point is not a pickup location", id));
       }
     }
 
@@ -97,6 +92,13 @@ public class RequestPolicyValidationService {
       () -> errors.stream().map(Error::getMessage).toList());
 
     return failedFuture(new ValidationException(errors));
+  }
+
+  private static Error buildError(String errorMessage, String servicePointId) {
+    return new Error()
+      .withMessage(errorMessage)
+      .withParameters(singletonList(new Parameter().withKey("servicePointId").withValue(servicePointId)))
+      .withCode(ErrorCode.INVALID_ALLOWED_SERVICE_POINT.name());
   }
 
 }

--- a/src/main/java/org/folio/service/policy/RequestPolicyValidationService.java
+++ b/src/main/java/org/folio/service/policy/RequestPolicyValidationService.java
@@ -23,6 +23,7 @@ import org.folio.rest.jaxrs.model.Error;
 import org.folio.rest.jaxrs.model.Parameter;
 import org.folio.rest.jaxrs.model.RequestPolicy;
 import org.folio.rest.jaxrs.model.Servicepoint;
+import org.folio.support.ErrorCode;
 import org.folio.support.exception.ValidationException;
 
 import io.vertx.core.Future;
@@ -77,11 +78,13 @@ public class RequestPolicyValidationService {
       if (servicePoint == null) {
         errors.add(new Error()
           .withMessage(String.format("Service point %s does not exist", id))
-          .withParameters(singletonList(new Parameter().withKey("servicePointId").withValue(id))));
+          .withParameters(singletonList(new Parameter().withKey("servicePointId").withValue(id)))
+          .withCode(ErrorCode.INVALID_ALLOWED_SERVICE_POINT.name()));
       } else if (servicePoint.getPickupLocation() == null || !servicePoint.getPickupLocation()) {
         errors.add(new Error()
           .withMessage(String.format("Service point %s is not a pickup location", id))
-          .withParameters(singletonList(new Parameter().withKey("servicePointId").withValue(id))));
+          .withParameters(singletonList(new Parameter().withKey("servicePointId").withValue(id)))
+          .withCode(ErrorCode.INVALID_ALLOWED_SERVICE_POINT.name()));
       }
     }
 

--- a/src/main/java/org/folio/service/policy/RequestPolicyValidationService.java
+++ b/src/main/java/org/folio/service/policy/RequestPolicyValidationService.java
@@ -1,0 +1,100 @@
+package org.folio.service.policy;
+
+import static io.vertx.core.Future.failedFuture;
+import static io.vertx.core.Future.succeededFuture;
+import static java.util.Collections.emptySet;
+import static java.util.Collections.singletonList;
+import static java.util.function.Function.identity;
+import static java.util.stream.Collectors.toList;
+
+import java.lang.invoke.MethodHandles;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.folio.rest.client.InventoryStorageClient;
+import org.folio.rest.jaxrs.model.AllowedServicePoints;
+import org.folio.rest.jaxrs.model.Error;
+import org.folio.rest.jaxrs.model.Parameter;
+import org.folio.rest.jaxrs.model.RequestPolicy;
+import org.folio.rest.jaxrs.model.Servicepoint;
+import org.folio.support.exception.ValidationException;
+
+import io.vertx.core.Future;
+import io.vertx.core.Vertx;
+
+public class RequestPolicyValidationService {
+  private static final Logger log = LogManager.getLogger(MethodHandles.lookup().lookupClass());
+  private final InventoryStorageClient inventoryStorageClient;
+
+  public RequestPolicyValidationService(Vertx vertx, Map<String, String> okapiHeaders) {
+    this.inventoryStorageClient = new InventoryStorageClient(vertx, okapiHeaders);
+  }
+
+  public Future<Void> validate(RequestPolicy requestPolicy) {
+    String requestPolicyId = requestPolicy.getId();
+    log.info("validate:: validating request policy {}", requestPolicyId);
+
+    Collection<String> allowedServicePointIds = extractServicePointIds(requestPolicy);
+
+    if (allowedServicePointIds.isEmpty()) {
+      log.info("validate:: request policy {} has no allowed service points", requestPolicyId);
+      return succeededFuture();
+    }
+
+    return inventoryStorageClient.getServicePoints(allowedServicePointIds)
+      .compose(servicePoints -> validateServicePoints(allowedServicePointIds, servicePoints));
+  }
+
+  private static Collection<String> extractServicePointIds(RequestPolicy requestPolicy) {
+    AllowedServicePoints servicePoints = requestPolicy.getAllowedServicePoints();
+
+    if (servicePoints == null) {
+      log.info("extractServicePointIds:: request policy has no allowed service points configured");
+      return emptySet();
+    }
+
+    return Stream.of(servicePoints.getPage(), servicePoints.getHold(), servicePoints.getRecall())
+      .filter(Objects::nonNull)
+      .flatMap(Collection::stream)
+      .collect(Collectors.toSet());
+  }
+
+  private static Future<Void> validateServicePoints(
+    Collection<String> allowedServicePointIds, Collection<Servicepoint> servicePoints) {
+
+    List<Error> errors = new ArrayList<>();
+    Map<String, Servicepoint> servicePointsById = servicePoints.stream()
+      .collect(Collectors.toMap(Servicepoint::getId, identity()));
+
+    for (String id : allowedServicePointIds) {
+      Servicepoint servicePoint = servicePointsById.get(id);
+      if (servicePoint == null) {
+        errors.add(new Error()
+          .withMessage(String.format("Service point %s does not exist", id))
+          .withParameters(singletonList(new Parameter().withKey("servicePointId").withValue(id))));
+      } else if (servicePoint.getPickupLocation() == null || !servicePoint.getPickupLocation()) {
+        errors.add(new Error()
+          .withMessage(String.format("Service point %s is not a pickup location", id))
+          .withParameters(singletonList(new Parameter().withKey("servicePointId").withValue(id))));
+      }
+    }
+
+    if (errors.isEmpty()) {
+      log.info("validateServicePoints:: request policy is valid");
+      return succeededFuture();
+    }
+
+    log.error("validateServicePoints:: request policy validation failed: {}",
+      () -> errors.stream().map(Error::getMessage).collect(toList()));
+
+    return failedFuture(new ValidationException(errors));
+  }
+
+}

--- a/src/main/java/org/folio/service/policy/RequestPolicyValidationService.java
+++ b/src/main/java/org/folio/service/policy/RequestPolicyValidationService.java
@@ -5,7 +5,6 @@ import static io.vertx.core.Future.succeededFuture;
 import static java.util.Collections.emptySet;
 import static java.util.Collections.singletonList;
 import static java.util.function.Function.identity;
-import static java.util.stream.Collectors.toList;
 
 import java.lang.invoke.MethodHandles;
 import java.util.ArrayList;
@@ -92,7 +91,7 @@ public class RequestPolicyValidationService {
     }
 
     log.error("validateServicePoints:: request policy validation failed: {}",
-      () -> errors.stream().map(Error::getMessage).collect(toList()));
+      () -> errors.stream().map(Error::getMessage).toList());
 
     return failedFuture(new ValidationException(errors));
   }

--- a/src/main/java/org/folio/support/AsyncUtils.java
+++ b/src/main/java/org/folio/support/AsyncUtils.java
@@ -1,0 +1,28 @@
+package org.folio.support;
+
+import static io.vertx.core.Future.succeededFuture;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.function.Function;
+
+import io.vertx.core.Future;
+
+public class AsyncUtils {
+
+  public static <E, R> Future<Collection<R>> mapSequentially(
+    Collection<E> collection, Function<E, Future<R>> mapper) {
+
+    final List<R> results = new ArrayList<>();
+    Future<R> future = succeededFuture();
+
+    for (E element : collection) {
+      future = future.compose(ignored -> mapper.apply(element)
+        .onSuccess(results::add));
+    }
+
+    return future.map(results);
+  }
+
+}

--- a/src/main/java/org/folio/support/AsyncUtils.java
+++ b/src/main/java/org/folio/support/AsyncUtils.java
@@ -11,6 +11,10 @@ import io.vertx.core.Future;
 
 public class AsyncUtils {
 
+  private AsyncUtils() {
+    throw new UnsupportedOperationException("Utility class, do not instantiate");
+  }
+
   public static <E, R> Future<Collection<R>> mapSequentially(
     Collection<E> collection, Function<E, Future<R>> mapper) {
 

--- a/src/main/java/org/folio/support/ErrorCode.java
+++ b/src/main/java/org/folio/support/ErrorCode.java
@@ -1,0 +1,5 @@
+package org.folio.support;
+
+public enum ErrorCode {
+  INVALID_ALLOWED_SERVICE_POINT
+}

--- a/src/main/java/org/folio/support/exception/HttpException.java
+++ b/src/main/java/org/folio/support/exception/HttpException.java
@@ -23,6 +23,7 @@ public class HttpException extends RuntimeException {
 
   @Override
   public String getMessage() {
-    return String.format("%s %s failed: [%d] %s", httpMethod, url, responseStatus, responseBody);
+    return String.format("Request failed: %s %s. Response: [%d] %s", httpMethod, url,
+      responseStatus, responseBody);
   }
 }

--- a/src/main/java/org/folio/support/exception/ValidationException.java
+++ b/src/main/java/org/folio/support/exception/ValidationException.java
@@ -1,0 +1,14 @@
+package org.folio.support.exception;
+
+import java.util.List;
+
+import org.folio.rest.jaxrs.model.Error;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public class ValidationException extends RuntimeException {
+  private final List<Error> errors;
+}

--- a/src/main/java/org/folio/support/exception/ValidationException.java
+++ b/src/main/java/org/folio/support/exception/ValidationException.java
@@ -10,5 +10,5 @@ import lombok.Getter;
 @AllArgsConstructor
 @Getter
 public class ValidationException extends RuntimeException {
-  private final List<Error> errors;
+  private transient final List<Error> errors;
 }

--- a/src/main/java/org/folio/support/exception/ValidationException.java
+++ b/src/main/java/org/folio/support/exception/ValidationException.java
@@ -10,5 +10,5 @@ import lombok.Getter;
 @AllArgsConstructor
 @Getter
 public class ValidationException extends RuntimeException {
-  private transient final List<Error> errors;
+  private final transient List<Error> errors;
 }

--- a/src/test/java/org/folio/rest/api/EventConsumerVerticleTest.java
+++ b/src/test/java/org/folio/rest/api/EventConsumerVerticleTest.java
@@ -1,5 +1,7 @@
 package org.folio.rest.api;
 
+import static com.github.tomakehurst.wiremock.client.WireMock.ok;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathMatching;
 import static io.vertx.core.json.JsonObject.mapFrom;
 import static java.lang.String.format;
 import static java.util.concurrent.TimeUnit.SECONDS;
@@ -49,6 +51,9 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import com.github.tomakehurst.wiremock.client.WireMock;
+
+import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import io.vertx.kafka.admin.KafkaAdminClient;
 import io.vertx.kafka.client.common.TopicPartition;
@@ -261,6 +266,7 @@ public class EventConsumerVerticleTest extends ApiTests {
     JsonObject servicePoint1 = buildServicePoint(servicePoint1Id, "sp-1");
     JsonObject servicePoint2 = buildServicePoint(servicePoint2Id, "sp-2");
     JsonObject servicePoint3 = buildServicePoint(servicePoint3Id, "sp-3");
+    createStubForServicePoints(List.of(servicePoint1, servicePoint2, servicePoint3));
 
     var requestTypes = List.of(RequestType.HOLD, RequestType.PAGE, RequestType.RECALL);
     var allowedServicePoints = new AllowedServicePoints()
@@ -305,9 +311,10 @@ public class EventConsumerVerticleTest extends ApiTests {
     String servicePoint1Id = randomId();
     String servicePoint2Id = randomId();
     String servicePoint3Id = randomId();
-    buildServicePoint(servicePoint1Id, "sp-1");
+    JsonObject servicePoint1 = buildServicePoint(servicePoint1Id, "sp-1");
     JsonObject servicePoint2 = buildServicePoint(servicePoint2Id, "sp-2");
-    buildServicePoint(servicePoint3Id, "sp-3");
+    JsonObject servicePoint3 = buildServicePoint(servicePoint3Id, "sp-3");
+    createStubForServicePoints(List.of(servicePoint1, servicePoint2, servicePoint3));
 
     var requestTypes = List.of(RequestType.HOLD, RequestType.PAGE, RequestType.RECALL);
     var allowedServicePoints = new AllowedServicePoints()
@@ -365,6 +372,7 @@ public class EventConsumerVerticleTest extends ApiTests {
     return new ServicePointBuilder(name)
       .withId(id)
       .withCode(code)
+      .withPickupLocation(true)
       .create();
   }
 
@@ -616,5 +624,12 @@ public class EventConsumerVerticleTest extends ApiTests {
           .map(Long::intValue)
           .orElse(0)) // if topic does not exist yet
     );
+  }
+
+  private void createStubForServicePoints(List<JsonObject> servicePoints) {
+    StorageTestSuite.getWireMockServer()
+      .stubFor(WireMock.get(urlPathMatching("/service-points.*"))
+        .willReturn(ok().withBody(new JsonObject().put("servicepoints", new JsonArray(servicePoints))
+          .encodePrettily())));
   }
 }

--- a/src/test/java/org/folio/rest/api/RequestPoliciesApiTest.java
+++ b/src/test/java/org/folio/rest/api/RequestPoliciesApiTest.java
@@ -10,6 +10,7 @@ import static org.folio.rest.support.matchers.HttpResponseStatusCodeMatchers.isC
 import static org.folio.rest.support.matchers.HttpResponseStatusCodeMatchers.isNotFound;
 import static org.folio.rest.support.matchers.HttpResponseStatusCodeMatchers.isUnprocessableEntity;
 import static org.folio.rest.support.matchers.TextDateTimeMatcher.withinSecondsAfter;
+import static org.folio.rest.support.matchers.ValidationErrorMatchers.hasCode;
 import static org.folio.rest.support.matchers.ValidationErrorMatchers.hasErrorWith;
 import static org.folio.rest.support.matchers.ValidationErrorMatchers.hasMessage;
 import static org.folio.rest.support.matchers.ValidationErrorMatchers.hasParameter;
@@ -63,6 +64,7 @@ public class RequestPoliciesApiTest extends ApiTests {
   private static final int CONNECTION_TIMEOUT = 5;
   private static final String DEFAULT_REQUEST_POLICY_NAME = "default_request_policy";
   private static final String SERVICE_POINTS_URL = "/service-points";
+  private static final String INVALID_ALLOWED_SERVICE_POINT_ERROR_CODE = "INVALID_ALLOWED_SERVICE_POINT";
   private static int REQ_POLICY_NAME_INCR = 0;  //This number is appended to the name of the default request policy to ensure uniqueness
 
   @Before
@@ -773,7 +775,8 @@ public class RequestPoliciesApiTest extends ApiTests {
 
     assertThat(response, isValidationResponseWhich(allOf(
       hasMessage(format("Service point %s does not exist", servicePointId)),
-      hasParameter("servicePointId", servicePointId)
+      hasParameter("servicePointId", servicePointId),
+      hasCode(INVALID_ALLOWED_SERVICE_POINT_ERROR_CODE)
     )));
   }
 
@@ -789,7 +792,8 @@ public class RequestPoliciesApiTest extends ApiTests {
 
     assertThat(response, isValidationResponseWhich(allOf(
       hasMessage(format("Service point %s does not exist", servicePointId)),
-      hasParameter("servicePointId", servicePointId)
+      hasParameter("servicePointId", servicePointId),
+      hasCode(INVALID_ALLOWED_SERVICE_POINT_ERROR_CODE)
     )));
   }
 
@@ -809,7 +813,8 @@ public class RequestPoliciesApiTest extends ApiTests {
 
     assertThat(response, isValidationResponseWhich(allOf(
       hasMessage(format("Service point %s is not a pickup location", servicePointId)),
-      hasParameter("servicePointId", servicePointId)
+      hasParameter("servicePointId", servicePointId),
+      hasCode(INVALID_ALLOWED_SERVICE_POINT_ERROR_CODE)
     )));
   }
 
@@ -829,7 +834,8 @@ public class RequestPoliciesApiTest extends ApiTests {
 
     assertThat(response, isValidationResponseWhich(allOf(
       hasMessage(format("Service point %s is not a pickup location", servicePointId)),
-      hasParameter("servicePointId", servicePointId)
+      hasParameter("servicePointId", servicePointId),
+      hasCode(INVALID_ALLOWED_SERVICE_POINT_ERROR_CODE)
     )));
   }
 
@@ -850,7 +856,8 @@ public class RequestPoliciesApiTest extends ApiTests {
 
     assertThat(response, isValidationResponseWhich(allOf(
       hasMessage(format("Service point %s is not a pickup location", servicePointId)),
-      hasParameter("servicePointId", servicePointId)
+      hasParameter("servicePointId", servicePointId),
+      hasCode(INVALID_ALLOWED_SERVICE_POINT_ERROR_CODE)
     )));
   }
 
@@ -871,12 +878,13 @@ public class RequestPoliciesApiTest extends ApiTests {
 
     assertThat(response, isValidationResponseWhich(allOf(
       hasMessage(format("Service point %s is not a pickup location", servicePointId)),
-      hasParameter("servicePointId", servicePointId)
+      hasParameter("servicePointId", servicePointId),
+      hasCode(INVALID_ALLOWED_SERVICE_POINT_ERROR_CODE)
     )));
   }
 
   @Test
-  public void multipleErrorsWithoutDuplicatesAreReturnedsWhenUsingInvalidServicePointIds()
+  public void multipleErrorsWithoutDuplicatesAreReturnedWhenUsingInvalidServicePointIds()
     throws MalformedURLException, ExecutionException, InterruptedException, TimeoutException {
 
     String nonExistentServicePointId = randomId();
@@ -909,13 +917,16 @@ public class RequestPoliciesApiTest extends ApiTests {
     assertThat(response.getJson(), allOf(
       hasErrorWith(allOf(
         hasMessage(format("Service point %s does not exist", nonExistentServicePointId)),
-        hasParameter("servicePointId", nonExistentServicePointId))),
+        hasParameter("servicePointId", nonExistentServicePointId),
+        hasCode(INVALID_ALLOWED_SERVICE_POINT_ERROR_CODE))),
       hasErrorWith(allOf(
         hasMessage(format("Service point %s is not a pickup location", nonPickupLocationServicePointId)),
-        hasParameter("servicePointId", nonPickupLocationServicePointId))),
+        hasParameter("servicePointId", nonPickupLocationServicePointId),
+        hasCode(INVALID_ALLOWED_SERVICE_POINT_ERROR_CODE))),
       hasErrorWith(allOf(
         hasMessage(format("Service point %s is not a pickup location", nullPickupLocationServicePointId)),
-        hasParameter("servicePointId", nullPickupLocationServicePointId)))
+        hasParameter("servicePointId", nullPickupLocationServicePointId),
+        hasCode(INVALID_ALLOWED_SERVICE_POINT_ERROR_CODE)))
     ));
   }
 

--- a/src/test/java/org/folio/rest/api/RequestPoliciesApiTest.java
+++ b/src/test/java/org/folio/rest/api/RequestPoliciesApiTest.java
@@ -774,7 +774,7 @@ public class RequestPoliciesApiTest extends ApiTests {
     JsonResponse response = createRequestPolicy(requestPolicy);
 
     assertThat(response, isValidationResponseWhich(allOf(
-      hasMessage(format("Service point %s does not exist", servicePointId)),
+      hasMessage("Service point does not exist"),
       hasParameter("servicePointId", servicePointId),
       hasCode(INVALID_ALLOWED_SERVICE_POINT_ERROR_CODE)
     )));
@@ -791,7 +791,7 @@ public class RequestPoliciesApiTest extends ApiTests {
     JsonResponse response = updateRequestPolicy(requestPolicy);
 
     assertThat(response, isValidationResponseWhich(allOf(
-      hasMessage(format("Service point %s does not exist", servicePointId)),
+      hasMessage("Service point does not exist"),
       hasParameter("servicePointId", servicePointId),
       hasCode(INVALID_ALLOWED_SERVICE_POINT_ERROR_CODE)
     )));
@@ -812,7 +812,7 @@ public class RequestPoliciesApiTest extends ApiTests {
     JsonResponse response = createRequestPolicy(requestPolicy);
 
     assertThat(response, isValidationResponseWhich(allOf(
-      hasMessage(format("Service point %s is not a pickup location", servicePointId)),
+      hasMessage("Service point is not a pickup location"),
       hasParameter("servicePointId", servicePointId),
       hasCode(INVALID_ALLOWED_SERVICE_POINT_ERROR_CODE)
     )));
@@ -833,7 +833,7 @@ public class RequestPoliciesApiTest extends ApiTests {
     JsonResponse response = updateRequestPolicy(requestPolicy);
 
     assertThat(response, isValidationResponseWhich(allOf(
-      hasMessage(format("Service point %s is not a pickup location", servicePointId)),
+      hasMessage("Service point is not a pickup location"),
       hasParameter("servicePointId", servicePointId),
       hasCode(INVALID_ALLOWED_SERVICE_POINT_ERROR_CODE)
     )));
@@ -855,7 +855,7 @@ public class RequestPoliciesApiTest extends ApiTests {
     JsonResponse response = createRequestPolicy(requestPolicy);
 
     assertThat(response, isValidationResponseWhich(allOf(
-      hasMessage(format("Service point %s is not a pickup location", servicePointId)),
+      hasMessage("Service point is not a pickup location"),
       hasParameter("servicePointId", servicePointId),
       hasCode(INVALID_ALLOWED_SERVICE_POINT_ERROR_CODE)
     )));
@@ -877,7 +877,7 @@ public class RequestPoliciesApiTest extends ApiTests {
     JsonResponse response = updateRequestPolicy(requestPolicy);
 
     assertThat(response, isValidationResponseWhich(allOf(
-      hasMessage(format("Service point %s is not a pickup location", servicePointId)),
+      hasMessage("Service point is not a pickup location"),
       hasParameter("servicePointId", servicePointId),
       hasCode(INVALID_ALLOWED_SERVICE_POINT_ERROR_CODE)
     )));
@@ -916,15 +916,15 @@ public class RequestPoliciesApiTest extends ApiTests {
 
     assertThat(response.getJson(), allOf(
       hasErrorWith(allOf(
-        hasMessage(format("Service point %s does not exist", nonExistentServicePointId)),
+        hasMessage("Service point does not exist"),
         hasParameter("servicePointId", nonExistentServicePointId),
         hasCode(INVALID_ALLOWED_SERVICE_POINT_ERROR_CODE))),
       hasErrorWith(allOf(
-        hasMessage(format("Service point %s is not a pickup location", nonPickupLocationServicePointId)),
+        hasMessage("Service point is not a pickup location"),
         hasParameter("servicePointId", nonPickupLocationServicePointId),
         hasCode(INVALID_ALLOWED_SERVICE_POINT_ERROR_CODE))),
       hasErrorWith(allOf(
-        hasMessage(format("Service point %s is not a pickup location", nullPickupLocationServicePointId)),
+        hasMessage("Service point is not a pickup location"),
         hasParameter("servicePointId", nullPickupLocationServicePointId),
         hasCode(INVALID_ALLOWED_SERVICE_POINT_ERROR_CODE)))
     ));

--- a/src/test/java/org/folio/rest/api/RequestPoliciesApiTest.java
+++ b/src/test/java/org/folio/rest/api/RequestPoliciesApiTest.java
@@ -908,8 +908,8 @@ public class RequestPoliciesApiTest extends ApiTests {
 
     assertThat(response.getJson(), allOf(
       hasErrorWith(allOf(
-          hasMessage(format("Service point %s does not exist", nonExistentServicePointId)),
-          hasParameter("servicePointId", nonExistentServicePointId))),
+        hasMessage(format("Service point %s does not exist", nonExistentServicePointId)),
+        hasParameter("servicePointId", nonExistentServicePointId))),
       hasErrorWith(allOf(
         hasMessage(format("Service point %s is not a pickup location", nonPickupLocationServicePointId)),
         hasParameter("servicePointId", nonPickupLocationServicePointId))),

--- a/src/test/java/org/folio/rest/client/OkapiClientTest.java
+++ b/src/test/java/org/folio/rest/client/OkapiClientTest.java
@@ -20,7 +20,7 @@ public class OkapiClientTest {
   @Test
   public void noOkapiUrl(TestContext context) {
     new OkapiClient(Vertx.vertx(), Map.of())
-    .get("/foo", "cql.allRecords=1", 10)
+    .get("/foo", "cql.allRecords=1", Object.class, "collectionName", 10)
     .onComplete(context.asyncAssertFailure(e -> {
       assertThat(e.getCause(), is(instanceOf(MalformedURLException.class)));
     }));

--- a/src/test/java/org/folio/rest/support/matchers/ValidationErrorMatchers.java
+++ b/src/test/java/org/folio/rest/support/matchers/ValidationErrorMatchers.java
@@ -130,4 +130,22 @@ public class ValidationErrorMatchers {
       }
     };
   }
+
+  public static TypeSafeDiagnosingMatcher<JsonObject> hasCode(String errorCode) {
+    return new TypeSafeDiagnosingMatcher<>() {
+      @Override
+      public void describeTo(Description description) {
+        description.appendText("has code ").appendValue(errorCode);
+      }
+
+      @Override
+      protected boolean matchesSafely(JsonObject error, Description description) {
+        final Matcher<String> matcher = is(errorCode);
+
+        matcher.describeMismatch(error, description);
+
+        return matcher.matches(error.getString("code"));
+      }
+    };
+  }
 }

--- a/src/test/java/org/folio/support/AsyncUtilsTest.java
+++ b/src/test/java/org/folio/support/AsyncUtilsTest.java
@@ -1,0 +1,43 @@
+package org.folio.support;
+
+import static java.util.concurrent.CompletableFuture.supplyAsync;
+import static org.folio.support.AsyncUtils.mapSequentially;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import org.junit.jupiter.api.Test;
+
+import io.vertx.core.Future;
+import lombok.SneakyThrows;
+
+class AsyncUtilsTest {
+
+  @Test
+  @SneakyThrows
+  void mapSequentiallyRunsFuturesInOrder() {
+    List<Integer> numbers = IntStream.range(0, 1000)
+      .boxed()
+      .collect(Collectors.toList());
+
+    List<Integer> mappingResults = new ArrayList<>();
+
+    Function<Integer, Future<Integer>> mapper = number ->
+      Future.fromCompletionStage(supplyAsync(() -> mappingResults.add(number))
+        .thenApply(r -> number));
+
+    Collection<Integer> invocationResults = mapSequentially(numbers, mapper)
+      .toCompletionStage()
+      .toCompletableFuture()
+      .get(5, TimeUnit.SECONDS);
+
+    assertEquals(numbers, mappingResults);
+    assertEquals(numbers, invocationResults);
+  }
+}


### PR DESCRIPTION
Do not allow saving or updating a request policy when at least one of the configured allowed pickup service points does not exist or is not explicitly marked as a pickup location.
Resolves [CIRCSTORE-429](https://issues.folio.org/browse/CIRCSTORE-429).