### PR TITLE
CIRCSTORE-429: Remove staff slips from service point schema

### DIFF
--- a/ramls/service-point.json
+++ b/ramls/service-point.json
@@ -49,28 +49,6 @@
       ],
       "default" : "Keep_the_current_due_date"
     },
-    "staffSlips": {
-      "type": "array",
-      "description": "List of staff slips for this service point",
-      "items": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "string",
-            "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$",
-            "description": "The ID of the staff slip"
-          },
-          "printByDefault": {
-            "type": "boolean",
-            "description": "Whether or not to print the staff slip by default"
-          }
-        },
-        "required": [
-          "id",
-          "printByDefault"
-        ]
-      }
-    },
     "metadata": {
       "type": "object",
       "$ref": "raml-util/schemas/metadata.schema",


### PR DESCRIPTION
This is a follow-up PR for [CIRCSTORE-429](https://issues.folio.org/browse/CIRCSTORE-429). Once #419 was merged, it became impossible to create or update a request policy when an explicitly allowed pickup service point contains staff slips configuration. This issue was caused by a conflict between JSON-schemas of a full-fledged staff slip and its reduced representation within service point schema. Removing `staffSlips` property from service point schema pushes staff slips into `additionalProperties` field of a generated service point class, which resolves the issue.