### PR TITLE
CIRCSTORE-451: Return single error for invalid request policy

### DIFF
--- a/src/main/java/org/folio/service/policy/RequestPolicyValidationService.java
+++ b/src/main/java/org/folio/service/policy/RequestPolicyValidationService.java
@@ -71,7 +71,7 @@ public class RequestPolicyValidationService {
 
     for (String id : allowedServicePointIds) {
       Servicepoint servicePoint = servicePointsById.get(id);
-      if (servicePoint == null || servicePoint.getPickupLocation() != TRUE) {
+      if (servicePoint == null || !TRUE.equals(servicePoint.getPickupLocation())) {
         log.warn("validateServicePoints:: validation failed, invalid allowed service point: {}", id);
         return failedFuture(new ValidationException(new Error()
           .withMessage("One or more Pickup locations are no longer available")

--- a/src/main/java/org/folio/support/exception/ValidationException.java
+++ b/src/main/java/org/folio/support/exception/ValidationException.java
@@ -11,4 +11,8 @@ import lombok.Getter;
 @Getter
 public class ValidationException extends RuntimeException {
   private final transient List<Error> errors;
+
+  public ValidationException(Error error) {
+    this(List.of(error));
+  }
 }

--- a/src/test/java/org/folio/rest/api/RequestPoliciesApiTest.java
+++ b/src/test/java/org/folio/rest/api/RequestPoliciesApiTest.java
@@ -12,9 +12,7 @@ import static org.folio.rest.support.matchers.HttpResponseStatusCodeMatchers.isN
 import static org.folio.rest.support.matchers.HttpResponseStatusCodeMatchers.isUnprocessableEntity;
 import static org.folio.rest.support.matchers.TextDateTimeMatcher.withinSecondsAfter;
 import static org.folio.rest.support.matchers.ValidationErrorMatchers.hasCode;
-import static org.folio.rest.support.matchers.ValidationErrorMatchers.hasErrorWith;
 import static org.folio.rest.support.matchers.ValidationErrorMatchers.hasMessage;
-import static org.folio.rest.support.matchers.ValidationErrorMatchers.hasParameter;
 import static org.folio.rest.support.matchers.ValidationResponseMatchers.isValidationResponseWhich;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.allOf;
@@ -775,8 +773,7 @@ public class RequestPoliciesApiTest extends ApiTests {
     JsonResponse response = createRequestPolicy(requestPolicy);
 
     assertThat(response, isValidationResponseWhich(allOf(
-      hasMessage("Service point does not exist"),
-      hasParameter("servicePointId", servicePointId),
+      hasMessage("One or more Pickup locations are no longer available"),
       hasCode(INVALID_ALLOWED_SERVICE_POINT_ERROR_CODE)
     )));
   }
@@ -792,8 +789,7 @@ public class RequestPoliciesApiTest extends ApiTests {
     JsonResponse response = updateRequestPolicy(requestPolicy);
 
     assertThat(response, isValidationResponseWhich(allOf(
-      hasMessage("Service point does not exist"),
-      hasParameter("servicePointId", servicePointId),
+      hasMessage("One or more Pickup locations are no longer available"),
       hasCode(INVALID_ALLOWED_SERVICE_POINT_ERROR_CODE)
     )));
   }
@@ -813,8 +809,7 @@ public class RequestPoliciesApiTest extends ApiTests {
     JsonResponse response = createRequestPolicy(requestPolicy);
 
     assertThat(response, isValidationResponseWhich(allOf(
-      hasMessage("Service point is not a pickup location"),
-      hasParameter("servicePointId", servicePointId),
+      hasMessage("One or more Pickup locations are no longer available"),
       hasCode(INVALID_ALLOWED_SERVICE_POINT_ERROR_CODE)
     )));
   }
@@ -834,8 +829,7 @@ public class RequestPoliciesApiTest extends ApiTests {
     JsonResponse response = updateRequestPolicy(requestPolicy);
 
     assertThat(response, isValidationResponseWhich(allOf(
-      hasMessage("Service point is not a pickup location"),
-      hasParameter("servicePointId", servicePointId),
+      hasMessage("One or more Pickup locations are no longer available"),
       hasCode(INVALID_ALLOWED_SERVICE_POINT_ERROR_CODE)
     )));
   }
@@ -856,8 +850,7 @@ public class RequestPoliciesApiTest extends ApiTests {
     JsonResponse response = createRequestPolicy(requestPolicy);
 
     assertThat(response, isValidationResponseWhich(allOf(
-      hasMessage("Service point is not a pickup location"),
-      hasParameter("servicePointId", servicePointId),
+      hasMessage("One or more Pickup locations are no longer available"),
       hasCode(INVALID_ALLOWED_SERVICE_POINT_ERROR_CODE)
     )));
   }
@@ -878,14 +871,13 @@ public class RequestPoliciesApiTest extends ApiTests {
     JsonResponse response = updateRequestPolicy(requestPolicy);
 
     assertThat(response, isValidationResponseWhich(allOf(
-      hasMessage("Service point is not a pickup location"),
-      hasParameter("servicePointId", servicePointId),
+      hasMessage("One or more Pickup locations are no longer available"),
       hasCode(INVALID_ALLOWED_SERVICE_POINT_ERROR_CODE)
     )));
   }
 
   @Test
-  public void multipleErrorsWithoutDuplicatesAreReturnedWhenUsingInvalidServicePointIds()
+  public void singleErrorIsReturnedWhenUsingMultipleInvalidServicePointIds()
     throws MalformedURLException, ExecutionException, InterruptedException, TimeoutException {
 
     String nonExistentServicePointId = randomId();
@@ -913,22 +905,12 @@ public class RequestPoliciesApiTest extends ApiTests {
         .withRecall(servicePointIds)));
 
     assertThat(response, isUnprocessableEntity());
-    assertThat(response.getJson().getJsonArray("errors"), iterableWithSize(3));
+    assertThat(response.getJson().getJsonArray("errors"), iterableWithSize(1));
 
-    assertThat(response.getJson(), allOf(
-      hasErrorWith(allOf(
-        hasMessage("Service point does not exist"),
-        hasParameter("servicePointId", nonExistentServicePointId),
-        hasCode(INVALID_ALLOWED_SERVICE_POINT_ERROR_CODE))),
-      hasErrorWith(allOf(
-        hasMessage("Service point is not a pickup location"),
-        hasParameter("servicePointId", nonPickupLocationServicePointId),
-        hasCode(INVALID_ALLOWED_SERVICE_POINT_ERROR_CODE))),
-      hasErrorWith(allOf(
-        hasMessage("Service point is not a pickup location"),
-        hasParameter("servicePointId", nullPickupLocationServicePointId),
-        hasCode(INVALID_ALLOWED_SERVICE_POINT_ERROR_CODE)))
-    ));
+    assertThat(response, isValidationResponseWhich(allOf(
+      hasMessage("One or more Pickup locations are no longer available"),
+      hasCode(INVALID_ALLOWED_SERVICE_POINT_ERROR_CODE)
+    )));
   }
 
   @Test


### PR DESCRIPTION
Return only one validation error with text "One or more Pickup locations are no longer available" when trying to create or update a request policy with invalid allowed service points.
Resolves [CIRCSTORE-451](https://issues.folio.org/browse/CIRCSTORE-451).