### PR TITLE
CIRCSTORE-445: Create constraints only if they don't exist

### DIFF
--- a/src/main/resources/templates/db_scripts/insertEmptyCirculationRulesRecord.sql
+++ b/src/main/resources/templates/db_scripts/insertEmptyCirculationRulesRecord.sql
@@ -1,7 +1,19 @@
 -- ensure that there will be one row only
-ALTER TABLE ${myuniversity}_${mymodule}.${table.tableName}
-  ADD COLUMN IF NOT EXISTS
-    lock boolean DEFAULT true UNIQUE CHECK(lock=true);
+DO $$
+BEGIN
+  -- create constraints only if they do not exist, otherwise they are piling up
+  IF NOT EXISTS (
+    SELECT constraint_name
+    FROM information_schema.constraint_column_usage
+    WHERE table_schema = '${myuniversity}_${mymodule}'
+    AND table_name = '${table.tableName}'
+    AND column_name = 'lock'
+    AND constraint_name LIKE '${table.tableName}_lock_%'
+  ) THEN
+    ALTER TABLE ${myuniversity}_${mymodule}.${table.tableName}
+    ADD COLUMN lock boolean DEFAULT true UNIQUE CHECK(lock=true);
+  END IF;
+END $$;
 INSERT INTO ${myuniversity}_${mymodule}.${table.tableName}
   SELECT id, jsonb_build_object('id', id, 'rulesAsText', '')
   FROM (SELECT md5('${myuniversity}_${mymodule}.${table.tableName}.rulesAsText')::uuid AS id) AS alias

--- a/src/main/resources/templates/db_scripts/insertEmptyCirculationRulesRecord.sql
+++ b/src/main/resources/templates/db_scripts/insertEmptyCirculationRulesRecord.sql
@@ -11,7 +11,8 @@ BEGIN
     AND constraint_name LIKE '${table.tableName}_lock_%'
   ) THEN
     ALTER TABLE ${myuniversity}_${mymodule}.${table.tableName}
-    ADD COLUMN lock boolean DEFAULT true UNIQUE CHECK(lock=true);
+    -- this will create constraints even when column already exists
+    ADD COLUMN IF NOT EXISTS lock boolean DEFAULT true UNIQUE CHECK(lock=true);
   END IF;
 END $$;
 INSERT INTO ${myuniversity}_${mymodule}.${table.tableName}


### PR DESCRIPTION
Create unique constraints for column `lock` in table `circulation_rules` only if they do not exist, otherwise every time the script is executed, a new pair of constraints is created and added to existing ones.
Resolves [CIRCSTORE-445](https://issues.folio.org/browse/CIRCSTORE-445).