### PR TITLE
Circstore 452

### DIFF
--- a/ramls/scheduled-notice.json
+++ b/ramls/scheduled-notice.json
@@ -46,6 +46,7 @@
         "Due date",
         "Overdue fine returned",
         "Overdue fine renewed",
+        "Due date - with reminder fee",
         "Aged to lost",
         "Aged to lost - fine charged",
         "Aged to lost & item returned - fine adjusted",


### PR DESCRIPTION
Upcoming logic in mod-circulation will be processing so called reminder fees. Reminder fees are notices with fees, which is a special case of overdue notices. The logic requires notices to be created with a triggering event that distinguishes them from "Due date" events. The new event is "Due date - with reminder fee",  see CIRCSTORE-452 for details. 