### PR TITLE
CIRCSTORE-452

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -403,7 +403,7 @@
     },
     {
       "id": "scheduled-notice-storage",
-      "version": "0.5",
+      "version": "0.6",
       "handlers": [
         {
           "methods": ["GET"],

--- a/ramls/scheduled-notice-storage.raml
+++ b/ramls/scheduled-notice-storage.raml
@@ -1,6 +1,6 @@
 #%RAML 1.0
 title: Scheduled Notice Storage
-version: v0.5
+version: v0.6
 protocols: [ HTTP, HTTPS ]
 baseUri: http://localhost:9130
 

--- a/ramls/scheduled-notice.json
+++ b/ramls/scheduled-notice.json
@@ -46,6 +46,7 @@
         "Due date",
         "Overdue fine returned",
         "Overdue fine renewed",
+        "Due date - with reminder fee",
         "Aged to lost",
         "Aged to lost - fine charged",
         "Aged to lost & item returned - fine adjusted",


### PR DESCRIPTION
Upcoming processing of reminder fees in mod-circulation will require an new triggering event type for scheduled notices - "Due date - with reminder fee". Reminder fees are a special case of overdue notices, and require an event type that distinguish them from due date notices. 

API version of scheduled-notice-storage is upped a minor for this change. 