### PR TITLE
CIRCSTORE-474: Add missing indexes to table audit_loan

### DIFF
--- a/src/main/resources/templates/db_scripts/schema.json
+++ b/src/main/resources/templates/db_scripts/schema.json
@@ -502,6 +502,24 @@
           "tOps": "ADD"
         }
       ]
+    },
+    {
+      "tableName": "audit_loan",
+      "withMetadata": false,
+      "likeIndex": [
+        {
+          "fieldName": "loan.id",
+          "tOps": "ADD",
+          "caseSensitive": false,
+          "removeAccents": true
+        },
+        {
+          "fieldName": "loan.action",
+          "tOps": "ADD",
+          "caseSensitive": false,
+          "removeAccents": true
+        }
+      ]
     }
   ],
   "scripts": [


### PR DESCRIPTION
Add missing indexes to table `audit_loan`. Search without these indexes while building patron notice contexts is causing severe DB performance degradation on environments with particularly large dataset (such as Bugfest).
Fixes [CIRCSTORE-474](https://issues.folio.org/browse/CIRCSTORE-474]