### PR TITLE
CIRCSTORE-422 fix NPE for requests with no position

### DIFF
--- a/src/main/java/org/folio/service/RequestExpirationService.java
+++ b/src/main/java/org/folio/service/RequestExpirationService.java
@@ -179,7 +179,8 @@ public class RequestExpirationService {
   private Future<Void> updateRequestsPositions(Conn conn,
     List<Request> requests) {
 
-    requests.sort(Comparator.comparingInt(Request::getPosition));
+    requests.sort(Comparator.comparing(Request::getPosition, Comparator.nullsLast(
+      Integer::compareTo)));
     AtomicInteger pos = new AtomicInteger(1);
     Future<Void> future = succeededFuture();
 


### PR DESCRIPTION
## Purpose
Fix the NPE exception related to missing position for a request in the queue

Resolves: [CIRCSTORE-488](https://folio-org.atlassian.net/browse/CIRCSTORE-488)