### PR TITLE
CIRCSTORE-494 Upgrade to RMB 35.2.0, Vertx 4.5.5, Spring 6.1.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
     <ramlfiles_path>${basedir}/ramls</ramlfiles_path>
     <vertx-version>4.5.5</vertx-version>
     <raml-module-builder-version>35.2.0</raml-module-builder-version>
-    <spring.version>5.3.23</spring.version>
+    <spring.version>6.1.5</spring.version>
     <argLine />
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -28,8 +28,8 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <ramlfiles_path>${basedir}/ramls</ramlfiles_path>
-    <vertx-version>4.4.6</vertx-version>
-    <raml-module-builder-version>35.1.0</raml-module-builder-version>
+    <vertx-version>4.5.5</vertx-version>
+    <raml-module-builder-version>35.2.0</raml-module-builder-version>
     <spring.version>5.3.23</spring.version>
     <argLine />
   </properties>

--- a/src/main/java/org/folio/rest/impl/AnonymizeStorageLoansAPI.java
+++ b/src/main/java/org/folio/rest/impl/AnonymizeStorageLoansAPI.java
@@ -3,13 +3,17 @@ package org.folio.rest.impl;
 import static io.vertx.core.Future.succeededFuture;
 import static org.folio.support.ModuleConstants.LOAN_HISTORY_TABLE;
 import static org.folio.support.ModuleConstants.MODULE_NAME;
+
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
-import javax.validation.constraints.NotNull;
+
 import javax.ws.rs.core.Response;
+
 import org.apache.commons.collections4.CollectionUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.folio.rest.annotations.Validate;
 import org.folio.rest.jaxrs.model.AnonymizeStorageLoansRequest;
 import org.folio.rest.jaxrs.model.AnonymizeStorageLoansResponse;
@@ -21,15 +25,15 @@ import org.folio.rest.persist.PostgresClient;
 import org.folio.rest.tools.utils.TenantTool;
 import org.folio.rest.tools.utils.ValidationHelper;
 import org.folio.support.UUIDValidation;
+
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Context;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.Promise;
-import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.LogManager;
 import io.vertx.sqlclient.Row;
 import io.vertx.sqlclient.RowSet;
+import jakarta.validation.constraints.NotNull;
 
 public class AnonymizeStorageLoansAPI implements AnonymizeStorageLoans {
   private static final Logger log = LogManager.getLogger();

--- a/src/main/java/org/folio/service/loan/LoanService.java
+++ b/src/main/java/org/folio/service/loan/LoanService.java
@@ -18,7 +18,6 @@ import java.util.Objects;
 import java.util.StringJoiner;
 import java.util.function.Function;
 
-import javax.validation.constraints.NotNull;
 import javax.ws.rs.core.Response;
 
 import org.apache.commons.lang3.StringUtils;
@@ -51,6 +50,7 @@ import io.vertx.core.AsyncResult;
 import io.vertx.core.Context;
 import io.vertx.core.Future;
 import io.vertx.core.Promise;
+import jakarta.validation.constraints.NotNull;
 
 public class LoanService {
 

--- a/src/test/java/org/folio/rest/api/TlrFeatureToggleJobAPITest.java
+++ b/src/test/java/org/folio/rest/api/TlrFeatureToggleJobAPITest.java
@@ -257,7 +257,7 @@ public class TlrFeatureToggleJobAPITest extends ApiTests {
       .get(), is(expectedPosition));
   }
 
-  private void  checkFailedTlrFeatureToggleJob(String errorMessage)
+  private void checkFailedTlrFeatureToggleJob(String errorMessage)
     throws MalformedURLException, ExecutionException, InterruptedException, TimeoutException {
 
     TlrFeatureToggleJob tlrFeatureToggleJob = createTlrFeatureToggleJob();

--- a/src/test/java/org/folio/rest/api/TlrFeatureToggleJobAPITest.java
+++ b/src/test/java/org/folio/rest/api/TlrFeatureToggleJobAPITest.java
@@ -234,7 +234,7 @@ public class TlrFeatureToggleJobAPITest extends ApiTests {
     throws MalformedURLException, ExecutionException, InterruptedException, TimeoutException {
 
     stubWithInvalidTlrSettings();
-    checkFailedTlrFeatureToggleJob("Invalid configurations response");
+    checkFailedTlrFeatureToggleJob("Unrecognized token");
   }
 
   @Test
@@ -257,7 +257,7 @@ public class TlrFeatureToggleJobAPITest extends ApiTests {
       .get(), is(expectedPosition));
   }
 
-  private void checkFailedTlrFeatureToggleJob(String errorMessage)
+  private void  checkFailedTlrFeatureToggleJob(String errorMessage)
     throws MalformedURLException, ExecutionException, InterruptedException, TimeoutException {
 
     TlrFeatureToggleJob tlrFeatureToggleJob = createTlrFeatureToggleJob();


### PR DESCRIPTION
[CIRCSTORE-494](https://folio-org.atlassian.net/browse/CIRCSTORE-494)

Upgrade to RMB 35.2.0, Vertx 4.5.5, Spring 6.1.5

According to https://github.com/folio-org/raml-module-builder/blob/master/doc/upgrading.md#version-352, changed javax.validation package to jakarta.validation.