### PR TITLE
CIRCSTORE-499 Upgrade folio-kafka-wrapper, org.aspectj versions

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,3 @@
-* ## 17.3.1 2024-04-16
-* Upgrade folio-kafka-wrapper to 3.1.1, org.aspectj to 1.9.22  (CIRCSTORE-499)
-
 * ## 17.2.0 2024-03-20
 * Upgrade RMB to 35.2.0, Vert.x to 4.5.5, Spring to 6.1.5 (CIRCSTORE-494)
 * Add `displaySummary` field to `ActualCostRecord` schema (CIRCSTORE-493)

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+* ## 17.3.1 2024-04-16
+* Upgrade folio-kafka-wrapper to 3.1.1, org.aspectj to 1.9.22  (CIRCSTORE-499)
+
 * ## 17.2.0 2024-03-20
 * Upgrade RMB to 35.2.0, Vert.x to 4.5.5, Spring to 6.1.5 (CIRCSTORE-494)
 * Add `displaySummary` field to `ActualCostRecord` schema (CIRCSTORE-493)

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <artifactId>mod-circulation-storage</artifactId>
   <groupId>org.folio</groupId>
-  <version>17.3.1-SNAPSHOT</version>
+  <version>17.3.0-SNAPSHOT</version>
   <licenses>
     <license>
       <name>Apache License 2.0</name>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <artifactId>mod-circulation-storage</artifactId>
   <groupId>org.folio</groupId>
-  <version>17.3.0-SNAPSHOT</version>
+  <version>17.3.1-SNAPSHOT</version>
   <licenses>
     <license>
       <name>Apache License 2.0</name>
@@ -80,7 +80,7 @@
     <dependency>
       <groupId>org.folio</groupId>
       <artifactId>folio-kafka-wrapper</artifactId>
-      <version>3.0.2</version>
+      <version>3.1.1</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>
@@ -316,12 +316,12 @@
           <dependency>
             <groupId>org.aspectj</groupId>
             <artifactId>aspectjrt</artifactId>
-            <version>1.9.19</version>
+            <version>1.9.22</version>
           </dependency>
           <dependency>
             <groupId>org.aspectj</groupId>
             <artifactId>aspectjtools</artifactId>
-            <version>1.9.19</version>
+            <version>1.9.22</version>
           </dependency>
         </dependencies>
       </plugin>


### PR DESCRIPTION
Covers: [CIRCSTORE-499](https://folio-org.atlassian.net/browse/CIRCSTORE-499)

## Purpose
Upgrade folio-kafka-wrapper to 3.1.1, org.aspectj to 1.9.22 to fix error with  Kafka Topic, when Tenant Collection Is Enabled, Module May Delete Topic For All Tenants