### PR TITLE
CIRCSTORE-505: Add required interface "configuration"

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -25,6 +25,10 @@
     {
       "id": "pubsub-publish",
       "version": "0.1"
+    },
+    {
+      "id": "configuration",
+      "version": "2.0"
     }
   ],
   "provides": [


### PR DESCRIPTION
mod-circulation-storage consumes interface `configuration` provided by mod-configuration, but does not declare this dependency in its `ModuleDescriptor.json`.
[CIRCSTORE-505](https://folio-org.atlassian.net/browse/CIRCSTORE-505)