### PR TITLE
CIRCSTORE-509: Create CRUD API for storing circulation settings

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -112,32 +112,32 @@
           "methods": ["GET"],
           "pathPattern": "/circulation-settings-storage/circulation-settings",
           "permissionsRequired": [
-            "circulation-settings-storage.circulation-settings.collection.get"
+            "circulation-storage.circulation-settings.collection.get"
           ]
         },
         {
           "methods": ["GET"],
           "pathPattern": "/circulation-settings-storage/circulation-settings/{id}",
           "permissionsRequired": [
-            "circulation-settings-storage.circulation-settings.item.get"
+            "circulation-storage.circulation-settings.item.get"
           ]
         }, {
           "methods": ["PUT"],
           "pathPattern": "/circulation-settings-storage/circulation-settings/{id}",
           "permissionsRequired": [
-            "circulation-settings-storage.circulation-settings.item.put"
+            "circulation-storage.circulation-settings.item.put"
           ]
         }, {
           "methods": ["POST"],
           "pathPattern": "/circulation-settings-storage/circulation-settings",
           "permissionsRequired": [
-            "circulation-settings-storage.circulation-settings.item.post"
+            "circulation-storage.circulation-settings.item.post"
           ]
         }, {
           "methods": ["DELETE"],
           "pathPattern": "/circulation-settings-storage/circulation-settings/{id}",
           "permissionsRequired": [
-            "circulation-settings-storage.circulation-settings.item.delete"
+            "circulation-storage.circulation-settings.item.delete"
           ]
         }
       ]
@@ -1009,27 +1009,27 @@
       "description": "Get expired session patron ids collection from storage"
     },
     {
-      "permissionName": "circulation-settings-storage.circulation-settings.collection.get",
+      "permissionName": "circulation-storage.circulation-settings.collection.get",
       "displayName": "Circulation storage - get circulation settings collection",
       "description": "Get circulation settings collection from storage"
     },
     {
-      "permissionName": "circulation-settings-storage.circulation-settings.item.get",
+      "permissionName": "circulation-storage.circulation-settings.item.get",
       "displayName": "Circulation storage - get circulation setting by id",
       "description": "Get circulation setting by id from storage"
     },
     {
-      "permissionName": "circulation-settings-storage.circulation-settings.item.post",
+      "permissionName": "circulation-storage.circulation-settings.item.post",
       "displayName": "Circulation storage - create circulation setting",
       "description": "Create circulation setting in storage"
     },
     {
-      "permissionName": "circulation-settings-storage.circulation-settings.item.put",
+      "permissionName": "circulation-storage.circulation-settings.item.put",
       "displayName": "Circulation storage - update circulation setting by id",
       "description": "Update circulation setting by id"
     },
     {
-      "permissionName": "circulation-settings-storage.circulation-settings.item.delete",
+      "permissionName": "circulation-storage.circulation-settings.item.delete",
       "displayName": "Circulation storage - delete circulation setting by id",
       "description": "Delete circulation setting by id"
     },
@@ -1125,11 +1125,11 @@
         "checkout-lock-storage.checkout-locks.item.delete",
         "checkout-lock-storage.checkout-locks.item.get",
         "checkout-lock-storage.checkout-locks.collection.get",
-        "circulation-settings-storage.circulation-settings.collection.get",
-        "circulation-settings-storage.circulation-settings.item.get",
-        "circulation-settings-storage.circulation-settings.item.post",
-        "circulation-settings-storage.circulation-settings.item.put",
-        "circulation-settings-storage.circulation-settings.item.delete"
+        "circulation-storage.circulation-settings.collection.get",
+        "circulation-storage.circulation-settings.item.get",
+        "circulation-storage.circulation-settings.item.post",
+        "circulation-storage.circulation-settings.item.put",
+        "circulation-storage.circulation-settings.item.delete"
       ]
     },
     {

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -105,6 +105,34 @@
       ]
     },
     {
+      "id": "circulation-settings-storage",
+      "version": "1.0",
+      "handlers": [
+        {
+          "methods": ["GET"],
+          "pathPattern": "/circulation-settings-storage/circulation-settings",
+          "permissionsRequired": []
+        },
+        {
+          "methods": ["GET"],
+          "pathPattern": "/circulation-settings-storage/circulation-settings/{id}",
+          "permissionsRequired": []
+        }, {
+          "methods": ["PUT"],
+          "pathPattern": "/circulation-settings-storage/circulation-settings/{id}",
+          "permissionsRequired": []
+        }, {
+          "methods": ["POST"],
+          "pathPattern": "/circulation-settings-storage/circulation-settings",
+          "permissionsRequired": []
+        }, {
+          "methods": ["DELETE"],
+          "pathPattern": "/circulation-settings-storage/circulation-settings/{id}",
+          "permissionsRequired": []
+        }
+      ]
+    },
+    {
       "id": "loan-policy-storage",
       "version": "2.3",
       "handlers": [
@@ -1178,7 +1206,7 @@
       { "name": "JAVA_OPTIONS",
         "value": "-XX:MaxRAMPercentage=66.0"
       },
-      { "name": "DB_HOST", "value": "postgres" },
+      { "name": "DB_HOST", "value": "localhost" },
       { "name": "DB_PORT", "value": "5432" },
       { "name": "DB_USERNAME", "value": "folio_admin" },
       { "name": "DB_PASSWORD", "value": "folio_admin" },
@@ -1186,7 +1214,7 @@
       { "name": "DB_QUERYTIMEOUT", "value": "60000" },
       { "name": "DB_CHARSET", "value": "UTF-8" },
       { "name": "DB_MAXPOOLSIZE", "value": "5" },
-      { "name": "KAFKA_HOST", "value": "kafka" },
+      { "name": "KAFKA_HOST", "value": "localhost" },
       { "name": "KAFKA_PORT", "value": "9092" },
       { "name": "REPLICATION_FACTOR", "value": "1" },
       { "name": "ENV", "value": "folio" }

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -111,24 +111,34 @@
         {
           "methods": ["GET"],
           "pathPattern": "/circulation-settings-storage/circulation-settings",
-          "permissionsRequired": []
+          "permissionsRequired": [
+            "circulation-settings-storage.circulation-settings.collection.get"
+          ]
         },
         {
           "methods": ["GET"],
           "pathPattern": "/circulation-settings-storage/circulation-settings/{id}",
-          "permissionsRequired": []
+          "permissionsRequired": [
+            "circulation-settings-storage.circulation-settings.item.get"
+          ]
         }, {
           "methods": ["PUT"],
           "pathPattern": "/circulation-settings-storage/circulation-settings/{id}",
-          "permissionsRequired": []
+          "permissionsRequired": [
+            "circulation-settings-storage.circulation-settings.item.put"
+          ]
         }, {
           "methods": ["POST"],
           "pathPattern": "/circulation-settings-storage/circulation-settings",
-          "permissionsRequired": []
+          "permissionsRequired": [
+            "circulation-settings-storage.circulation-settings.item.post"
+          ]
         }, {
           "methods": ["DELETE"],
           "pathPattern": "/circulation-settings-storage/circulation-settings/{id}",
-          "permissionsRequired": []
+          "permissionsRequired": [
+            "circulation-settings-storage.circulation-settings.item.delete"
+          ]
         }
       ]
     },
@@ -999,6 +1009,31 @@
       "description": "Get expired session patron ids collection from storage"
     },
     {
+      "permissionName": "circulation-settings-storage.circulation-settings.collection.get",
+      "displayName": "Circulation storage - get circulation settings collection",
+      "description": "Get circulation settings collection from storage"
+    },
+    {
+      "permissionName": "circulation-settings-storage.circulation-settings.item.get",
+      "displayName": "Circulation storage - get circulation setting by id",
+      "description": "Get circulation setting by id from storage"
+    },
+    {
+      "permissionName": "circulation-settings-storage.circulation-settings.item.post",
+      "displayName": "Circulation storage - create circulation setting",
+      "description": "Create circulation setting in storage"
+    },
+    {
+      "permissionName": "circulation-settings-storage.circulation-settings.item.put",
+      "displayName": "Circulation storage - update circulation setting by id",
+      "description": "Update circulation setting by id"
+    },
+    {
+      "permissionName": "circulation-settings-storage.circulation-settings.item.delete",
+      "displayName": "Circulation storage - delete circulation setting by id",
+      "description": "Delete circulation setting by id"
+    },
+    {
       "permissionName": "circulation-storage.all",
       "displayName": "Circulation storage module - all permissions",
       "description": "Entire set of permissions needed to use the circulation storage module",
@@ -1089,7 +1124,12 @@
         "checkout-lock-storage.checkout-locks.item.post",
         "checkout-lock-storage.checkout-locks.item.delete",
         "checkout-lock-storage.checkout-locks.item.get",
-        "checkout-lock-storage.checkout-locks.collection.get"
+        "checkout-lock-storage.checkout-locks.collection.get",
+        "circulation-settings-storage.circulation-settings.collection.get",
+        "circulation-settings-storage.circulation-settings.item.get",
+        "circulation-settings-storage.circulation-settings.item.post",
+        "circulation-settings-storage.circulation-settings.item.put",
+        "circulation-settings-storage.circulation-settings.item.delete"
       ]
     },
     {

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -1206,7 +1206,7 @@
       { "name": "JAVA_OPTIONS",
         "value": "-XX:MaxRAMPercentage=66.0"
       },
-      { "name": "DB_HOST", "value": "localhost" },
+      { "name": "DB_HOST", "value": "postgres" },
       { "name": "DB_PORT", "value": "5432" },
       { "name": "DB_USERNAME", "value": "folio_admin" },
       { "name": "DB_PASSWORD", "value": "folio_admin" },
@@ -1214,7 +1214,7 @@
       { "name": "DB_QUERYTIMEOUT", "value": "60000" },
       { "name": "DB_CHARSET", "value": "UTF-8" },
       { "name": "DB_MAXPOOLSIZE", "value": "5" },
-      { "name": "KAFKA_HOST", "value": "localhost" },
+      { "name": "KAFKA_HOST", "value": "kafka" },
       { "name": "KAFKA_PORT", "value": "9092" },
       { "name": "REPLICATION_FACTOR", "value": "1" },
       { "name": "ENV", "value": "folio" }

--- a/ramls/circulation-setting.json
+++ b/ramls/circulation-setting.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "Circulation Setting Schema",
+  "description": "Circulation setting",
+  "type": "object",
+  "properties": {
+    "id": {
+      "description": "ID of the circulation setting",
+      "type": "string"
+    },
+    "name": {
+      "description": "Circulation setting name",
+      "type": "string"
+    },
+    "value": {
+      "description": "Circulation setting",
+      "type": "object",
+      "additionalProperties": true
+    },
+    "metadata": {
+      "description": "Metadata about creation and changes, provided by the server (client should not provide)",
+      "type": "object",
+      "$ref": "raml-util/schemas/metadata.schema"
+    }
+  },
+  "additionalProperties": false,
+  "required": [
+    "id",
+    "name",
+    "value"
+  ]
+}

--- a/ramls/circulation-setting.json
+++ b/ramls/circulation-setting.json
@@ -6,7 +6,8 @@
   "properties": {
     "id": {
       "description": "ID of the circulation setting",
-      "type": "string"
+      "type": "string",
+      "$ref": "raml-util/schemas/uuid.schema"
     },
     "name": {
       "description": "Circulation setting name",

--- a/ramls/circulation-settings-storage.raml
+++ b/ramls/circulation-settings-storage.raml
@@ -75,8 +75,11 @@ resourceTypes:
             body:
               application/json:
                 type: circulation-setting
-          501:
-            description: "Not implemented yet"
+          500:
+            description: "Internal server error"
+            body:
+              text/plain:
+                example: "Internal server error"
       put:
         is: [ validate ]
         body:
@@ -85,13 +88,19 @@ resourceTypes:
         responses:
           204:
             description: "Circulation settings have been saved."
-          501:
-            description: "Not implemented yet"
+          500:
+            description: "Internal server error"
+            body:
+              text/plain:
+                example: "Internal server error"
       delete:
         is: [ validate ]
         responses:
           204:
             description: "Circulation settings deleted"
-          501:
-            description: "Not implemented yet"
+          500:
+            description: "Internal server error"
+            body:
+              text/plain:
+                example: "Internal server error"
 

--- a/ramls/circulation-settings-storage.raml
+++ b/ramls/circulation-settings-storage.raml
@@ -1,0 +1,97 @@
+#%RAML 1.0
+title: Circulation Settings Storage
+version: v1.0
+protocols: [ HTTP, HTTPS ]
+baseUri: http://localhost:9130
+
+documentation:
+  - title: Circulation Settings Storage API
+    content: <b>Storage for circulation settings</b>
+
+traits:
+  language: !include raml-util/traits/language.raml
+  pageable: !include raml-util/traits/pageable.raml
+  searchable: !include raml-util/traits/searchable.raml
+  validate: !include raml-util/traits/validation.raml
+
+types:
+  circulation-setting: !include circulation-setting.json
+  circulation-settings: !include circulation-settings.json
+  errors: !include raml-util/schemas/errors.schema
+  parameters: !include raml-util/schemas/parameters.schema
+
+resourceTypes:
+  collection: !include raml-util/rtypes/collection.raml
+  collection-item: !include raml-util/rtypes/item-collection.raml
+
+/circulation-settings-storage:
+  /circulation-settings:
+    type:
+      collection:
+        exampleCollection: !include examples/circulation-settings.json
+        exampleItem:       !include examples/circulation-setting.json
+        schemaCollection: circulation-settings
+        schemaItem: circulation-setting
+    post:
+      is: [validate]
+      description: Create a new circulation setting
+      body:
+        application/json:
+          type: circulation-setting
+      responses:
+        201:
+          description: "Circulation setting has been created"
+          body:
+            application/json:
+              type: circulation-setting
+        500:
+          description: "Internal server error"
+          body:
+            text/plain:
+              example: "Internal server error"
+    get:
+      is: [validate, pageable, searchable: { description: "with valid searchable fields", example: "id=497f6eca-6276-4993-bfeb-98cbbbba8f79" }]
+      description: Get all circulation settings
+      responses:
+        200:
+          description: "Circulation settings successfully retreived"
+          body:
+            application/json:
+              type: circulation-settings
+        500:
+          description: "Internal server error"
+          body:
+            text/plain:
+              example: "Internal server error"
+    /{circulationSettingsId}:
+      type:
+        collection-item:
+          exampleItem: !include examples/circulation-setting.json
+          schema: circulation-setting
+      get:
+        responses:
+          200:
+            description: "Circulation setting successfully retreived"
+            body:
+              application/json:
+                type: circulation-setting
+          501:
+            description: "Not implemented yet"
+      put:
+        is: [ validate ]
+        body:
+          application/json:
+            type: circulation-setting
+        responses:
+          204:
+            description: "Circulation settings have been saved."
+          501:
+            description: "Not implemented yet"
+      delete:
+        is: [ validate ]
+        responses:
+          204:
+            description: "Circulation settings deleted"
+          501:
+            description: "Not implemented yet"
+

--- a/ramls/circulation-settings.json
+++ b/ramls/circulation-settings.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "description": "Collection of Circulation settings",
+  "type": "object",
+  "properties": {
+    "circulationSettings": {
+      "description": "List of circulation settings",
+      "id": "circulationSettings",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "$ref": "circulation-setting.json"
+      }
+    },
+    "totalRecords": {
+      "type": "integer"
+    }
+  },
+  "required": [
+    "circulationSettings",
+    "totalRecords"
+  ]
+}

--- a/ramls/examples/circulation-setting.json
+++ b/ramls/examples/circulation-setting.json
@@ -1,0 +1,7 @@
+{
+  "id": "497f6eca-6276-4993-bfeb-53cbbbba6f09",
+  "name": "Sample settings",
+  "value": {
+    "org.folio.circulation.settings": "true"
+  }
+}

--- a/ramls/examples/circulation-settings.json
+++ b/ramls/examples/circulation-settings.json
@@ -8,5 +8,5 @@
       }
     }
   ],
-  "totalRecords": 0
+  "totalRecords": 1
 }

--- a/ramls/examples/circulation-settings.json
+++ b/ramls/examples/circulation-settings.json
@@ -1,0 +1,12 @@
+{
+  "circulationSettings": [
+    {
+      "id": "497f6eca-6276-4993-bfeb-53cbbbba6f09",
+      "name": "Sample settings",
+      "value": {
+        "org.folio.circulation.settings": "true"
+      }
+    }
+  ],
+  "totalRecords": 0
+}

--- a/src/main/java/org/folio/persist/CirculationSettingsRepository.java
+++ b/src/main/java/org/folio/persist/CirculationSettingsRepository.java
@@ -1,0 +1,16 @@
+package org.folio.persist;
+
+import static org.folio.rest.persist.PgUtil.postgresClient;
+import static org.folio.support.ModuleConstants.CIRCULATION_SETTINGS_TABLE;
+
+import java.util.Map;
+import org.folio.rest.jaxrs.model.CirculationSetting;
+import io.vertx.core.Context;
+
+public class CirculationSettingsRepository extends AbstractRepository<CirculationSetting> {
+
+  public CirculationSettingsRepository(Context context, Map<String, String> okapiHeaders) {
+    super(postgresClient(context, okapiHeaders), CIRCULATION_SETTINGS_TABLE, CirculationSetting.class);
+  }
+
+}

--- a/src/main/java/org/folio/persist/CirculationSettingsRepository.java
+++ b/src/main/java/org/folio/persist/CirculationSettingsRepository.java
@@ -14,6 +14,7 @@ public class CirculationSettingsRepository
 
   public CirculationSettingsRepository(Context context, Map<String,
     String> okapiHeaders) {
+
     super(postgresClient(context, okapiHeaders), CIRCULATION_SETTINGS_TABLE,
       CirculationSetting.class);
   }

--- a/src/main/java/org/folio/persist/CirculationSettingsRepository.java
+++ b/src/main/java/org/folio/persist/CirculationSettingsRepository.java
@@ -4,7 +4,9 @@ import static org.folio.rest.persist.PgUtil.postgresClient;
 import static org.folio.support.ModuleConstants.CIRCULATION_SETTINGS_TABLE;
 
 import java.util.Map;
+
 import org.folio.rest.jaxrs.model.CirculationSetting;
+
 import io.vertx.core.Context;
 
 public class CirculationSettingsRepository

--- a/src/main/java/org/folio/persist/CirculationSettingsRepository.java
+++ b/src/main/java/org/folio/persist/CirculationSettingsRepository.java
@@ -7,10 +7,13 @@ import java.util.Map;
 import org.folio.rest.jaxrs.model.CirculationSetting;
 import io.vertx.core.Context;
 
-public class CirculationSettingsRepository extends AbstractRepository<CirculationSetting> {
+public class CirculationSettingsRepository
+  extends AbstractRepository<CirculationSetting> {
 
-  public CirculationSettingsRepository(Context context, Map<String, String> okapiHeaders) {
-    super(postgresClient(context, okapiHeaders), CIRCULATION_SETTINGS_TABLE, CirculationSetting.class);
+  public CirculationSettingsRepository(Context context, Map<String,
+    String> okapiHeaders) {
+    super(postgresClient(context, okapiHeaders), CIRCULATION_SETTINGS_TABLE,
+      CirculationSetting.class);
   }
 
 }

--- a/src/main/java/org/folio/rest/impl/CirculationSettingsAPI.java
+++ b/src/main/java/org/folio/rest/impl/CirculationSettingsAPI.java
@@ -38,6 +38,7 @@ public class CirculationSettingsAPI implements CirculationSettingsStorage {
   public void getCirculationSettingsStorageCirculationSettingsByCirculationSettingsId(
     String circulationSettingsId, String lang, Map<String, String> okapiHeaders,
     Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
+
       new CirculationSettingsService(vertxContext, okapiHeaders)
         .findById(circulationSettingsId)
         .onComplete(asyncResultHandler);
@@ -48,6 +49,7 @@ public class CirculationSettingsAPI implements CirculationSettingsStorage {
     String circulationSettingsId, String lang, CirculationSetting entity,
     Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler,
     Context vertxContext) {
+
       new CirculationSettingsService(vertxContext, okapiHeaders)
         .update(circulationSettingsId, entity)
         .onComplete(asyncResultHandler);
@@ -57,6 +59,7 @@ public class CirculationSettingsAPI implements CirculationSettingsStorage {
   public void deleteCirculationSettingsStorageCirculationSettingsByCirculationSettingsId(
     String circulationSettingsId, String lang, Map<String, String> okapiHeaders,
     Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
+
       new CirculationSettingsService(vertxContext, okapiHeaders).delete(circulationSettingsId)
         .onComplete(asyncResultHandler);
   }

--- a/src/main/java/org/folio/rest/impl/CirculationSettingsAPI.java
+++ b/src/main/java/org/folio/rest/impl/CirculationSettingsAPI.java
@@ -60,7 +60,8 @@ public class CirculationSettingsAPI implements CirculationSettingsStorage {
     String circulationSettingsId, String lang, Map<String, String> okapiHeaders,
     Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
 
-      new CirculationSettingsService(vertxContext, okapiHeaders).delete(circulationSettingsId)
+      new CirculationSettingsService(vertxContext, okapiHeaders)
+        .delete(circulationSettingsId)
         .onComplete(asyncResultHandler);
   }
 }

--- a/src/main/java/org/folio/rest/impl/CirculationSettingsAPI.java
+++ b/src/main/java/org/folio/rest/impl/CirculationSettingsAPI.java
@@ -15,31 +15,48 @@ import io.vertx.core.Handler;
 public class CirculationSettingsAPI implements CirculationSettingsStorage {
 
   @Override
-  public void postCirculationSettingsStorageCirculationSettings(String lang, CirculationSetting circulationSettings, Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
-    new CirculationSettingsService(vertxContext, okapiHeaders).create(circulationSettings)
+  public void postCirculationSettingsStorageCirculationSettings(String lang,
+    CirculationSetting circulationSettings, Map<String, String> okapiHeaders,
+    Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
+
+    new CirculationSettingsService(vertxContext, okapiHeaders)
+      .create(circulationSettings)
       .onComplete(asyncResultHandler);
   }
 
   @Override
-  public void getCirculationSettingsStorageCirculationSettings(int offset, int limit, String query, String lang, Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
-    new CirculationSettingsService(vertxContext, okapiHeaders).getAll(offset, limit, query)
+  public void getCirculationSettingsStorageCirculationSettings(int offset,
+    int limit, String query, String lang, Map<String, String> okapiHeaders,
+    Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
+
+    new CirculationSettingsService(vertxContext, okapiHeaders)
+      .getAll(offset, limit, query)
       .onComplete(asyncResultHandler);
   }
 
   @Override
-  public void getCirculationSettingsStorageCirculationSettingsByCirculationSettingsId(String circulationSettingsId, String lang, Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
-      new CirculationSettingsService(vertxContext, okapiHeaders).findById(circulationSettingsId)
+  public void getCirculationSettingsStorageCirculationSettingsByCirculationSettingsId(
+    String circulationSettingsId, String lang, Map<String, String> okapiHeaders,
+    Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
+      new CirculationSettingsService(vertxContext, okapiHeaders)
+        .findById(circulationSettingsId)
         .onComplete(asyncResultHandler);
   }
 
   @Override
-  public void putCirculationSettingsStorageCirculationSettingsByCirculationSettingsId(String circulationSettingsId, String lang, CirculationSetting entity, Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
-      new CirculationSettingsService(vertxContext, okapiHeaders).update(circulationSettingsId, entity)
+  public void putCirculationSettingsStorageCirculationSettingsByCirculationSettingsId(
+    String circulationSettingsId, String lang, CirculationSetting entity,
+    Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler,
+    Context vertxContext) {
+      new CirculationSettingsService(vertxContext, okapiHeaders)
+        .update(circulationSettingsId, entity)
         .onComplete(asyncResultHandler);
   }
 
   @Override
-  public void deleteCirculationSettingsStorageCirculationSettingsByCirculationSettingsId(String circulationSettingsId, String lang, Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
+  public void deleteCirculationSettingsStorageCirculationSettingsByCirculationSettingsId(
+    String circulationSettingsId, String lang, Map<String, String> okapiHeaders,
+    Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
       new CirculationSettingsService(vertxContext, okapiHeaders).delete(circulationSettingsId)
         .onComplete(asyncResultHandler);
   }

--- a/src/main/java/org/folio/rest/impl/CirculationSettingsAPI.java
+++ b/src/main/java/org/folio/rest/impl/CirculationSettingsAPI.java
@@ -1,0 +1,46 @@
+package org.folio.rest.impl;
+
+import java.util.Map;
+
+import javax.ws.rs.core.Response;
+
+import org.folio.rest.jaxrs.model.CirculationSetting;
+import org.folio.rest.jaxrs.resource.CirculationSettingsStorage;
+import org.folio.service.CirculationSettingsService;
+
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Context;
+import io.vertx.core.Handler;
+
+public class CirculationSettingsAPI implements CirculationSettingsStorage {
+
+  @Override
+  public void postCirculationSettingsStorageCirculationSettings(String lang, CirculationSetting circulationSettings, Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
+    new CirculationSettingsService(vertxContext, okapiHeaders).create(circulationSettings)
+      .onComplete(asyncResultHandler);
+  }
+
+  @Override
+  public void getCirculationSettingsStorageCirculationSettings(int offset, int limit, String query, String lang, Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
+    new CirculationSettingsService(vertxContext, okapiHeaders).getAll(offset, limit, query)
+      .onComplete(asyncResultHandler);
+  }
+
+  @Override
+  public void getCirculationSettingsStorageCirculationSettingsByCirculationSettingsId(String circulationSettingsId, String lang, Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
+      new CirculationSettingsService(vertxContext, okapiHeaders).findById(circulationSettingsId)
+        .onComplete(asyncResultHandler);
+  }
+
+  @Override
+  public void putCirculationSettingsStorageCirculationSettingsByCirculationSettingsId(String circulationSettingsId, String lang, CirculationSetting entity, Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
+      new CirculationSettingsService(vertxContext, okapiHeaders).update(circulationSettingsId, entity)
+        .onComplete(asyncResultHandler);
+  }
+
+  @Override
+  public void deleteCirculationSettingsStorageCirculationSettingsByCirculationSettingsId(String circulationSettingsId, String lang, Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
+      new CirculationSettingsService(vertxContext, okapiHeaders).delete(circulationSettingsId)
+        .onComplete(asyncResultHandler);
+  }
+}

--- a/src/main/java/org/folio/rest/impl/TenantRefAPI.java
+++ b/src/main/java/org/folio/rest/impl/TenantRefAPI.java
@@ -58,7 +58,9 @@ public class TenantRefAPI extends TenantAPI {
           .add("cancellation-reason-storage/cancellation-reasons")
           .withKey(SAMPLE_KEY).withLead(SAMPLE_LEAD)
           .add("loans", "loan-storage/loans")
-          .add("requests", "request-storage/requests");
+          .add("requests", "request-storage/requests")
+          .add("circulation-settings-storage/circulation-settings");
+
 
         tl.perform(attributes, headers, vertx, res -> {
           if (res.failed()) {

--- a/src/main/java/org/folio/service/CirculationSettingsService.java
+++ b/src/main/java/org/folio/service/CirculationSettingsService.java
@@ -1,0 +1,81 @@
+package org.folio.service;
+
+import static org.folio.service.event.EntityChangedEventPublisherFactory.circulationSettingsEventPublisher;
+import static org.folio.service.event.EntityChangedEventPublisherFactory.requestEventPublisher;
+import static org.folio.support.ModuleConstants.CIRCULATION_SETTINGS_TABLE;
+
+import java.util.Map;
+
+import javax.ws.rs.core.Response;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.folio.persist.CirculationSettingsRepository;
+import org.folio.rest.jaxrs.model.CancellationReason;
+import org.folio.rest.jaxrs.model.CancellationReasons;
+import org.folio.rest.jaxrs.model.CirculationSetting;
+import org.folio.rest.jaxrs.model.CirculationSettings;
+import org.folio.rest.jaxrs.resource.CancellationReasonStorage;
+import org.folio.rest.jaxrs.resource.CirculationSettingsStorage;
+import org.folio.rest.persist.PgUtil;
+import org.folio.service.event.EntityChangedEventPublisher;
+
+import io.vertx.core.Context;
+import io.vertx.core.Future;
+import io.vertx.core.Promise;
+
+public class CirculationSettingsService {
+
+  private static final Logger log = LogManager.getLogger(CirculationSettingsService.class);
+  private final Context vertxContext;
+  private final Map<String, String> okapiHeaders;
+  private final CirculationSettingsRepository repository;
+  private final EntityChangedEventPublisher<String, CirculationSetting> eventPublisher;
+
+  public CirculationSettingsService(Context vertxContext, Map<String, String> okapiHeaders) {
+    this.vertxContext = vertxContext;
+    this.okapiHeaders = okapiHeaders;
+    this.repository = new CirculationSettingsRepository(vertxContext, okapiHeaders);
+    this.eventPublisher = circulationSettingsEventPublisher(vertxContext, okapiHeaders);
+  }
+
+  public Future<Response> getAll(int offset, int limit, String query) {
+    return PgUtil.get(CIRCULATION_SETTINGS_TABLE, CirculationSetting.class,
+      CirculationSettings.class,
+      query, offset, limit, okapiHeaders, vertxContext,
+      CirculationSettingsStorage.GetCirculationSettingsStorageCirculationSettingsResponse.class);
+  }
+
+  public Future<Response> create(CirculationSetting circulationSetting) {
+    Promise<Response> createResult = Promise.promise();
+    PgUtil.post(CIRCULATION_SETTINGS_TABLE, circulationSetting, okapiHeaders, vertxContext,
+      CirculationSettingsStorage.PostCirculationSettingsStorageCirculationSettingsResponse.class, createResult);
+    return createResult.future()
+      .compose(eventPublisher.publishCreated());
+  }
+
+  public Future<Response> findById(String circulationSettingsId) {
+    return PgUtil.getById(CIRCULATION_SETTINGS_TABLE, CirculationSetting.class,
+      circulationSettingsId, okapiHeaders, vertxContext,
+      CirculationSettingsStorage.GetCirculationSettingsStorageCirculationSettingsByCirculationSettingsIdResponse.class);
+  }
+
+  public Future<Response> update(String circulationSettingsId, CirculationSetting circulationSetting) {
+    Promise<Response> updateResult = Promise.promise();
+    PgUtil.put(CIRCULATION_SETTINGS_TABLE, circulationSetting, circulationSettingsId, okapiHeaders, vertxContext,
+      CirculationSettingsStorage.PutCirculationSettingsStorageCirculationSettingsByCirculationSettingsIdResponse.class, updateResult);
+    return updateResult.future()
+      .compose(eventPublisher.publishUpdated(circulationSetting));
+  }
+
+  public Future<Response> delete(String circulationSettingsId) {
+    return repository.getById(circulationSettingsId).compose ( circulationSetting -> {
+      Promise<Response> deleteResult = Promise.promise();
+      PgUtil.deleteById(CIRCULATION_SETTINGS_TABLE, circulationSettingsId, okapiHeaders, vertxContext,
+        CirculationSettingsStorage.DeleteCirculationSettingsStorageCirculationSettingsByCirculationSettingsIdResponse.class, deleteResult);
+      return deleteResult.future()
+        .compose(eventPublisher.publishRemoved(circulationSetting));
+      }
+    );
+  }
+}

--- a/src/main/java/org/folio/service/CirculationSettingsService.java
+++ b/src/main/java/org/folio/service/CirculationSettingsService.java
@@ -1,7 +1,6 @@
 package org.folio.service;
 
 import static org.folio.service.event.EntityChangedEventPublisherFactory.circulationSettingsEventPublisher;
-import static org.folio.service.event.EntityChangedEventPublisherFactory.requestEventPublisher;
 import static org.folio.support.ModuleConstants.CIRCULATION_SETTINGS_TABLE;
 
 import java.util.Map;
@@ -11,11 +10,8 @@ import javax.ws.rs.core.Response;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.folio.persist.CirculationSettingsRepository;
-import org.folio.rest.jaxrs.model.CancellationReason;
-import org.folio.rest.jaxrs.model.CancellationReasons;
 import org.folio.rest.jaxrs.model.CirculationSetting;
 import org.folio.rest.jaxrs.model.CirculationSettings;
-import org.folio.rest.jaxrs.resource.CancellationReasonStorage;
 import org.folio.rest.jaxrs.resource.CirculationSettingsStorage;
 import org.folio.rest.persist.PgUtil;
 import org.folio.service.event.EntityChangedEventPublisher;

--- a/src/main/java/org/folio/service/CirculationSettingsService.java
+++ b/src/main/java/org/folio/service/CirculationSettingsService.java
@@ -10,13 +10,16 @@ import javax.ws.rs.core.Response;
 import org.folio.persist.CirculationSettingsRepository;
 import org.folio.rest.jaxrs.model.CirculationSetting;
 import org.folio.rest.jaxrs.model.CirculationSettings;
-import org.folio.rest.jaxrs.resource.CirculationSettingsStorage;
+import org.folio.rest.jaxrs.resource.CirculationSettingsStorage.DeleteCirculationSettingsStorageCirculationSettingsByCirculationSettingsIdResponse;
+import org.folio.rest.jaxrs.resource.CirculationSettingsStorage.GetCirculationSettingsStorageCirculationSettingsByCirculationSettingsIdResponse;
+import org.folio.rest.jaxrs.resource.CirculationSettingsStorage.GetCirculationSettingsStorageCirculationSettingsResponse;
+import org.folio.rest.jaxrs.resource.CirculationSettingsStorage.PostCirculationSettingsStorageCirculationSettingsResponse;
+import org.folio.rest.jaxrs.resource.CirculationSettingsStorage.PutCirculationSettingsStorageCirculationSettingsByCirculationSettingsIdResponse;
 import org.folio.rest.persist.PgUtil;
 import org.folio.service.event.EntityChangedEventPublisher;
 
 import io.vertx.core.Context;
 import io.vertx.core.Future;
-import io.vertx.core.Promise;
 
 public class CirculationSettingsService {
 
@@ -36,39 +39,32 @@ public class CirculationSettingsService {
     return PgUtil.get(CIRCULATION_SETTINGS_TABLE, CirculationSetting.class,
       CirculationSettings.class,
       query, offset, limit, okapiHeaders, vertxContext,
-      CirculationSettingsStorage.GetCirculationSettingsStorageCirculationSettingsResponse.class);
+      GetCirculationSettingsStorageCirculationSettingsResponse.class);
   }
 
   public Future<Response> create(CirculationSetting circulationSetting) {
-    Promise<Response> createResult = Promise.promise();
-    PgUtil.post(CIRCULATION_SETTINGS_TABLE, circulationSetting, okapiHeaders, vertxContext,
-      CirculationSettingsStorage.PostCirculationSettingsStorageCirculationSettingsResponse.class, createResult);
-    return createResult.future()
+    return PgUtil.post(CIRCULATION_SETTINGS_TABLE, circulationSetting, okapiHeaders, vertxContext,
+      PostCirculationSettingsStorageCirculationSettingsResponse.class)
       .compose(eventPublisher.publishCreated());
   }
 
   public Future<Response> findById(String circulationSettingsId) {
     return PgUtil.getById(CIRCULATION_SETTINGS_TABLE, CirculationSetting.class,
       circulationSettingsId, okapiHeaders, vertxContext,
-      CirculationSettingsStorage.GetCirculationSettingsStorageCirculationSettingsByCirculationSettingsIdResponse.class);
+      GetCirculationSettingsStorageCirculationSettingsByCirculationSettingsIdResponse.class);
   }
 
   public Future<Response> update(String circulationSettingsId, CirculationSetting circulationSetting) {
-    Promise<Response> updateResult = Promise.promise();
-    PgUtil.put(CIRCULATION_SETTINGS_TABLE, circulationSetting, circulationSettingsId, okapiHeaders, vertxContext,
-      CirculationSettingsStorage.PutCirculationSettingsStorageCirculationSettingsByCirculationSettingsIdResponse.class, updateResult);
-    return updateResult.future()
+    return PgUtil.put(CIRCULATION_SETTINGS_TABLE, circulationSetting, circulationSettingsId, okapiHeaders, vertxContext,
+        PutCirculationSettingsStorageCirculationSettingsByCirculationSettingsIdResponse.class)
       .compose(eventPublisher.publishUpdated(circulationSetting));
   }
 
   public Future<Response> delete(String circulationSettingsId) {
-    return repository.getById(circulationSettingsId).compose ( circulationSetting -> {
-      Promise<Response> deleteResult = Promise.promise();
-      PgUtil.deleteById(CIRCULATION_SETTINGS_TABLE, circulationSettingsId, okapiHeaders, vertxContext,
-        CirculationSettingsStorage.DeleteCirculationSettingsStorageCirculationSettingsByCirculationSettingsIdResponse.class, deleteResult);
-      return deleteResult.future()
-        .compose(eventPublisher.publishRemoved(circulationSetting));
-      }
+    return repository.getById(circulationSettingsId).compose (
+      circulationSetting -> PgUtil.deleteById(CIRCULATION_SETTINGS_TABLE, circulationSettingsId, okapiHeaders, vertxContext,
+        DeleteCirculationSettingsStorageCirculationSettingsByCirculationSettingsIdResponse.class)
+      .compose(eventPublisher.publishRemoved(circulationSetting))
     );
   }
 }

--- a/src/main/java/org/folio/service/CirculationSettingsService.java
+++ b/src/main/java/org/folio/service/CirculationSettingsService.java
@@ -7,8 +7,6 @@ import java.util.Map;
 
 import javax.ws.rs.core.Response;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.folio.persist.CirculationSettingsRepository;
 import org.folio.rest.jaxrs.model.CirculationSetting;
 import org.folio.rest.jaxrs.model.CirculationSettings;
@@ -22,7 +20,6 @@ import io.vertx.core.Promise;
 
 public class CirculationSettingsService {
 
-  private static final Logger log = LogManager.getLogger(CirculationSettingsService.class);
   private final Context vertxContext;
   private final Map<String, String> okapiHeaders;
   private final CirculationSettingsRepository repository;

--- a/src/main/java/org/folio/service/event/EntityChangedEventPublisherFactory.java
+++ b/src/main/java/org/folio/service/event/EntityChangedEventPublisherFactory.java
@@ -10,10 +10,12 @@ import java.util.Map;
 
 import org.folio.persist.CheckInRepository;
 import org.folio.persist.CirculationRulesRepository;
+import org.folio.persist.CirculationSettingsRepository;
 import org.folio.persist.LoanRepository;
 import org.folio.persist.RequestRepository;
 import org.folio.rest.jaxrs.model.CheckIn;
 import org.folio.rest.jaxrs.model.CirculationRules;
+import org.folio.rest.jaxrs.model.CirculationSetting;
 import org.folio.rest.jaxrs.model.Loan;
 import org.folio.rest.jaxrs.model.Request;
 
@@ -72,6 +74,17 @@ public class EntityChangedEventPublisherFactory {
         RULES.fullTopicName(tenantId(okapiHeaders)),
         FailureHandler.noOperation()),
       new CirculationRulesRepository(vertxContext, okapiHeaders));
+  }
+
+  public static EntityChangedEventPublisher<String, CirculationSetting> circulationSettingsEventPublisher(
+    Context vertxContext, Map<String, String> okapiHeaders) {
+
+    return new EntityChangedEventPublisher<>(okapiHeaders, CirculationSetting::getId, NULL_ID,
+      new EntityChangedEventFactory<>(),
+      new DomainEventPublisher<>(vertxContext,
+        REQUEST.fullTopicName(tenantId(okapiHeaders)),
+        FailureHandler.noOperation()),
+      new CirculationSettingsRepository(vertxContext, okapiHeaders));
   }
 
 }

--- a/src/main/java/org/folio/service/event/EntityChangedEventPublisherFactory.java
+++ b/src/main/java/org/folio/service/event/EntityChangedEventPublisherFactory.java
@@ -2,6 +2,7 @@ package org.folio.service.event;
 
 import static org.folio.rest.tools.utils.TenantTool.tenantId;
 import static org.folio.support.kafka.topic.CirculationStorageKafkaTopic.CHECK_IN;
+import static org.folio.support.kafka.topic.CirculationStorageKafkaTopic.CIRCULATION_SETTINGS;
 import static org.folio.support.kafka.topic.CirculationStorageKafkaTopic.LOAN;
 import static org.folio.support.kafka.topic.CirculationStorageKafkaTopic.REQUEST;
 import static org.folio.support.kafka.topic.CirculationStorageKafkaTopic.RULES;
@@ -82,7 +83,7 @@ public class EntityChangedEventPublisherFactory {
     return new EntityChangedEventPublisher<>(okapiHeaders, CirculationSetting::getId, NULL_ID,
       new EntityChangedEventFactory<>(),
       new DomainEventPublisher<>(vertxContext,
-        REQUEST.fullTopicName(tenantId(okapiHeaders)),
+        CIRCULATION_SETTINGS.fullTopicName(tenantId(okapiHeaders)),
         FailureHandler.noOperation()),
       new CirculationSettingsRepository(vertxContext, okapiHeaders));
   }

--- a/src/main/java/org/folio/support/ModuleConstants.java
+++ b/src/main/java/org/folio/support/ModuleConstants.java
@@ -15,6 +15,8 @@ public class ModuleConstants {
   public static final String LOAN_TABLE = "loan";
   public static final String OPEN_LOAN_STATUS = "Open";
   public static final String REQUEST_TABLE = "request";
+  public static final String CIRCULATION_SETTINGS_TABLE =
+    "circulation_settings";
   public static final Class<Request> REQUEST_CLASS = Request.class;
   public static final String CHECKIN_TABLE = "check_in";
   public static final Class<CheckIn> CHECKIN_CLASS = CheckIn.class;

--- a/src/main/java/org/folio/support/kafka/topic/CirculationStorageKafkaTopic.java
+++ b/src/main/java/org/folio/support/kafka/topic/CirculationStorageKafkaTopic.java
@@ -4,7 +4,7 @@ import org.folio.kafka.services.KafkaTopic;
 
 public enum CirculationStorageKafkaTopic implements KafkaTopic {
   REQUEST("request", 10),
-  CIRCULATION_SETTINGS("circulation_settings", 10),
+  CIRCULATION_SETTINGS("circulation-settings", 10),
   LOAN("loan", 10),
   CHECK_IN("check-in", 10),
   RULES("rules", 10);

--- a/src/main/java/org/folio/support/kafka/topic/CirculationStorageKafkaTopic.java
+++ b/src/main/java/org/folio/support/kafka/topic/CirculationStorageKafkaTopic.java
@@ -4,6 +4,7 @@ import org.folio.kafka.services.KafkaTopic;
 
 public enum CirculationStorageKafkaTopic implements KafkaTopic {
   REQUEST("request", 10),
+  CIRCULATION_SETTINGS("circulation_settings", 10),
   LOAN("loan", 10),
   CHECK_IN("check-in", 10),
   RULES("rules", 10);

--- a/src/main/resources/postgres-conf.json
+++ b/src/main/resources/postgres-conf.json
@@ -1,0 +1,7 @@
+{
+  "host" : "localhost",
+  "port" : 5432,
+  "database" : "okapi_modules",
+  "username" : "folio_admin",
+  "password" : "folio_admin"
+}

--- a/src/main/resources/postgres-conf.json
+++ b/src/main/resources/postgres-conf.json
@@ -1,7 +1,0 @@
-{
-  "host" : "localhost",
-  "port" : 5432,
-  "database" : "okapi_modules",
-  "username" : "folio_admin",
-  "password" : "folio_admin"
-}

--- a/src/main/resources/templates/db_scripts/schema.json
+++ b/src/main/resources/templates/db_scripts/schema.json
@@ -152,6 +152,18 @@
       ]
     },
     {
+      "tableName": "circulation_settings",
+      "withMetadata": true,
+      "withAuditing": false,
+      "uniqueIndex": [
+        {
+          "fieldName": "id",
+          "tOps": "ADD",
+          "caseSensitive": false
+        }
+      ]
+    },
+    {
       "tableName": "request",
       "withMetadata": true,
       "withAuditing": false,

--- a/src/main/resources/templates/db_scripts/schema.json
+++ b/src/main/resources/templates/db_scripts/schema.json
@@ -154,14 +154,7 @@
     {
       "tableName": "circulation_settings",
       "withMetadata": true,
-      "withAuditing": false,
-      "uniqueIndex": [
-        {
-          "fieldName": "id",
-          "tOps": "ADD",
-          "caseSensitive": false
-        }
-      ]
+      "withAuditing": false
     },
     {
       "tableName": "request",

--- a/src/test/java/org/folio/rest/api/CirculationSettingsAPITest.java
+++ b/src/test/java/org/folio/rest/api/CirculationSettingsAPITest.java
@@ -1,0 +1,47 @@
+package org.folio.rest.api;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.junit.MatcherAssert.assertThat;
+
+import java.net.MalformedURLException;
+import java.util.UUID;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeoutException;
+
+import org.folio.rest.support.ApiTests;
+import org.folio.rest.support.http.AssertingRecordClient;
+import org.folio.rest.support.http.InterfaceUrls;
+import org.folio.rest.support.spring.TestContextConfiguration;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.test.context.ContextConfiguration;
+
+import io.vertx.core.json.JsonObject;
+import junitparams.JUnitParamsRunner;
+
+@RunWith(JUnitParamsRunner.class)
+@ContextConfiguration(classes = TestContextConfiguration.class)
+public class CirculationSettingsAPITest extends ApiTests {
+
+  private final AssertingRecordClient circulationSettingsClient =
+    new AssertingRecordClient(
+    client, StorageTestSuite.TENANT_ID, InterfaceUrls::circulationSettingsUrl,
+      "circulation-settings");
+
+  @Test
+  void canCreateCirculationSettings() throws MalformedURLException,
+    ExecutionException, InterruptedException, TimeoutException {
+    String id = UUID.randomUUID().toString();
+    JsonObject circulationSettingsJson = new JsonObject()
+      .put("id", id)
+      .put("name", "Sample settings")
+      .put("value",
+        new JsonObject().put("org.folio.circulation.settings", "true"));
+
+    JsonObject circulationSettingsResponse =
+      circulationSettingsClient.create(circulationSettingsJson).getJson();
+
+    assertThat(circulationSettingsResponse.getString("id"), is(id));
+  }
+
+}

--- a/src/test/java/org/folio/rest/support/http/InterfaceUrls.java
+++ b/src/test/java/org/folio/rest/support/http/InterfaceUrls.java
@@ -48,4 +48,8 @@ public class InterfaceUrls {
     return storageUrl("/check-out-lock-storage" + subPath);
   }
 
+  public static URL circulationSettingsUrl(String subPath) throws MalformedURLException {
+    return storageUrl("/circulation-settings-storage/circulation-settings" + subPath);
+  }
+
 }

--- a/src/test/java/org/folio/service/kafka/topic/KafkaAdminClientServiceTest.java
+++ b/src/test/java/org/folio/service/kafka/topic/KafkaAdminClientServiceTest.java
@@ -43,7 +43,7 @@ public class KafkaAdminClientServiceTest {
       "folio.foo-tenant.circulation.loan",
       "folio.foo-tenant.circulation.check-in",
       "folio.foo-tenant.circulation.rules",
-      "folio.foo-tenant.circulation.circulation_settings"
+      "folio.foo-tenant.circulation.circulation-settings"
   );
 
   private KafkaAdminClient mockClient;

--- a/src/test/java/org/folio/service/kafka/topic/KafkaAdminClientServiceTest.java
+++ b/src/test/java/org/folio/service/kafka/topic/KafkaAdminClientServiceTest.java
@@ -42,7 +42,8 @@ public class KafkaAdminClientServiceTest {
       "folio.foo-tenant.circulation.request",
       "folio.foo-tenant.circulation.loan",
       "folio.foo-tenant.circulation.check-in",
-      "folio.foo-tenant.circulation.rules"
+      "folio.foo-tenant.circulation.rules",
+      "folio.foo-tenant.circulation.circulation_settings"
   );
 
   private KafkaAdminClient mockClient;


### PR DESCRIPTION
Covers: [CIRCSTORE-509](https://folio-org.atlassian.net/browse/CIRCSTORE-509)

**Purpose**
Create a new API (GET, POST, PUT, DELETE) for storing circulation settings . It will be used for syncing ECS TLR setting (MODTLR-44) through consortia publications.