### PR TITLE
CIRCSTORE-512 added test case for EnableRequestPrintDetailsSetting

### DIFF
--- a/src/test/java/org/folio/rest/api/CirculationSettingsAPITest.java
+++ b/src/test/java/org/folio/rest/api/CirculationSettingsAPITest.java
@@ -72,4 +72,24 @@ public class CirculationSettingsAPITest extends ApiTests {
       .put("value", new JsonObject().put("sample", "OK"));
   }
 
+  @Test
+  public void canCreateAndRetrieveEnableRequestPrintDetailsSetting() throws MalformedURLException,
+    ExecutionException, InterruptedException, TimeoutException {
+    String id = UUID.randomUUID().toString();
+    JsonObject enableRequestPrintDetailsSettingJson = new JsonObject();
+    enableRequestPrintDetailsSettingJson.put("id", id);
+    enableRequestPrintDetailsSettingJson.put("name", "Enable Request Print");
+    enableRequestPrintDetailsSettingJson.put("value", new JsonObject().put("Enable Request Print", true));
+
+    JsonObject circulationSettingsResponse =
+      circulationSettingsClient.create(enableRequestPrintDetailsSettingJson).getJson();
+    JsonObject circulationSettingsById = circulationSettingsClient.getById(id).getJson();
+
+    assertThat(circulationSettingsResponse.getString("id"), is(id));
+    assertThat(circulationSettingsResponse.getString("name"),
+      is(enableRequestPrintDetailsSettingJson.getString("name")));
+    assertThat(circulationSettingsById.getString("id"), is(id));
+    assertThat(circulationSettingsById.getJsonObject("value"),
+      is(enableRequestPrintDetailsSettingJson.getJsonObject("value")));
+  }
 }


### PR DESCRIPTION
Purpose: https://folio-org.atlassian.net/browse/CIRCSTORE-512
Approach: added a new test case for persisting and retrieving EnableRequestPrintDetailsSetting.