### PR TITLE
CIRCSTORE-487: Poppy: snappy-java 1.1.10.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -121,6 +121,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.xerial.snappy</groupId>
+      <artifactId>snappy-java</artifactId>
+      <version>1.1.10.5</version>
+    </dependency>
+    <dependency>
       <groupId>org.glassfish.web</groupId>
       <artifactId>javax.el</artifactId>
       <version>2.2.4</version>


### PR DESCRIPTION
The latest Poppy release mod-circulation-storage 17.1.8 comes with snappy-java 1.1.8.1.

Upgrade snappy-java from 1.1.8.1 to 1.1.10.5 fixing these vulnerabilities:

* https://nvd.nist.gov/vuln/detail/CVE-2023-43642 Allocation of Resources Without Limits or Throttling
* https://nvd.nist.gov/vuln/detail/CVE-2023-34455 Denial of Service (DoS)
* https://nvd.nist.gov/vuln/detail/CVE-2023-34453 Integer Overflow or Wraparound
* https://nvd.nist.gov/vuln/detail/CVE-2023-34454 Integer Overflow or Wraparound

Lessons learnt:

It was forgotten to back-port the RMB/Vert.x upgrade (CIRCSTORE-459) to the Poppy b17.1 release branch. Always upgrade to the officially supported technology versions before release: https://folio-org.atlassian.net/wiki/spaces/TC/pages/5056300/Poppy