### PR TITLE
[CIRCSTORE-521] Publish request batch event when requests are reordered

### DIFF
--- a/ramls/request-queue-reordering.json
+++ b/ramls/request-queue-reordering.json
@@ -7,14 +7,14 @@
     "instanceId": {
       "description": "Instance ID of reordered requests",
       "type": "string",
-      "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$"
+      "$ref": "raml-util/schemas/uuid.schema"
     },
     "requestIds": {
       "description": "Array of requests ids",
       "type": "array",
       "items": {
         "type": "string",
-        "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$"
+        "$ref": "raml-util/schemas/uuid.schema"
       }
     }
   },

--- a/ramls/request-queue-reordering.json
+++ b/ramls/request-queue-reordering.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "Requests batch update",
+  "description": "List of ids reordered requests",
+  "type": "object",
+  "properties": {
+    "instanceId": {
+      "description": "Instance ID of reordered requests",
+      "type": "string",
+      "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$"
+    },
+    "requestIds": {
+      "description": "Array of requests ids",
+      "type": "array",
+      "items": {
+        "type": "string",
+        "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$"
+      }
+    }
+  },
+  "additionalProperties": false
+}

--- a/ramls/request-storage-batch.raml
+++ b/ramls/request-storage-batch.raml
@@ -11,6 +11,7 @@ documentation:
 types:
   requests-batch: !include requests-batch.json
   errors: !include raml-util/schemas/errors.schema
+  request-queue-reordering: !include request-queue-reordering.json
 
 traits:
   validate: !include raml-util/traits/validation.raml

--- a/src/main/java/org/folio/rest/impl/RequestsBatchAPI.java
+++ b/src/main/java/org/folio/rest/impl/RequestsBatchAPI.java
@@ -43,15 +43,11 @@ public class RequestsBatchAPI implements RequestStorageBatch {
       return;
     }
 
-    BatchResourceService batchUpdateService = new BatchResourceService(
-      PgUtil.postgresClient(context, okapiHeaders)
-    );
+    RequestBatchResourceService requestBatchUpdateService = new RequestBatchResourceService(
+      context, okapiHeaders);
 
-    RequestBatchResourceService requestBatchUpdateService =
-      new RequestBatchResourceService(tenantId(okapiHeaders), batchUpdateService);
 
-    requestBatchUpdateService.executeRequestBatchUpdate(entity.getRequests(),
-      updateResult -> {
+    requestBatchUpdateService.executeRequestBatchUpdate(entity.getRequests(), updateResult -> {
         // Successfully updated
         if (updateResult.succeeded()) {
           LOG.debug("Batch update executed successfully");

--- a/src/main/java/org/folio/rest/impl/RequestsBatchAPI.java
+++ b/src/main/java/org/folio/rest/impl/RequestsBatchAPI.java
@@ -41,11 +41,8 @@ public class RequestsBatchAPI implements RequestStorageBatch {
     }
 
     log.info("postRequestStorageBatchRequests:: requests: {}", entity.getRequests());
-    RequestBatchResourceService requestBatchUpdateService = new RequestBatchResourceService(
-      context, okapiHeaders);
-
-
-    requestBatchUpdateService.executeRequestBatchUpdate(entity.getRequests(), updateResult -> {
+    new RequestBatchResourceService(context, okapiHeaders)
+      .executeRequestBatchUpdate(entity.getRequests(), updateResult -> {
         // Successfully updated
         if (updateResult.succeeded()) {
           log.debug("Batch update executed successfully");

--- a/src/main/java/org/folio/rest/impl/RequestsBatchAPI.java
+++ b/src/main/java/org/folio/rest/impl/RequestsBatchAPI.java
@@ -6,7 +6,6 @@ import static org.folio.rest.impl.util.RequestsApiUtil.samePositionInQueueError;
 import static org.folio.rest.jaxrs.resource.RequestStorageBatch.PostRequestStorageBatchRequestsResponse.respond201;
 import static org.folio.rest.jaxrs.resource.RequestStorageBatch.PostRequestStorageBatchRequestsResponse.respond422WithApplicationJson;
 import static org.folio.rest.jaxrs.resource.RequestStorageBatch.PostRequestStorageBatchRequestsResponse.respond500WithTextPlain;
-import static org.folio.rest.tools.utils.TenantTool.tenantId;
 
 import java.util.Map;
 
@@ -14,9 +13,7 @@ import javax.ws.rs.core.Response;
 import org.folio.rest.annotations.Validate;
 import org.folio.rest.jaxrs.model.RequestsBatch;
 import org.folio.rest.jaxrs.resource.RequestStorageBatch;
-import org.folio.rest.persist.PgUtil;
 import org.folio.rest.tools.utils.MetadataUtil;
-import org.folio.service.BatchResourceService;
 import org.folio.service.request.RequestBatchResourceService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -26,7 +23,7 @@ import io.vertx.core.Context;
 import io.vertx.core.Handler;
 
 public class RequestsBatchAPI implements RequestStorageBatch {
-  private static final Logger LOG = LoggerFactory.getLogger(RequestsBatchAPI.class);
+  private static final Logger log = LoggerFactory.getLogger(RequestsBatchAPI.class);
 
   @Validate
   @Override
@@ -38,11 +35,12 @@ public class RequestsBatchAPI implements RequestStorageBatch {
       MetadataUtil.populateMetadata(entity.getRequests(), okapiHeaders);
     } catch (Throwable e) {
       String msg = "Cannot populate metadata of request list elements: " + e.getMessage();
-      LOG.error(msg, e);
+      log.error(msg, e);
       asyncResultHandler.handle(succeededFuture(respond500WithTextPlain(msg)));
       return;
     }
 
+    log.info("postRequestStorageBatchRequests:: requests: {}", entity.getRequests());
     RequestBatchResourceService requestBatchUpdateService = new RequestBatchResourceService(
       context, okapiHeaders);
 
@@ -50,20 +48,20 @@ public class RequestsBatchAPI implements RequestStorageBatch {
     requestBatchUpdateService.executeRequestBatchUpdate(entity.getRequests(), updateResult -> {
         // Successfully updated
         if (updateResult.succeeded()) {
-          LOG.debug("Batch update executed successfully");
+          log.debug("Batch update executed successfully");
           asyncResultHandler.handle(succeededFuture(respond201()));
           return;
         }
 
         // Update failed due to can not have more then one request in the same position
         if (hasSamePositionConstraintViolated(updateResult.cause())) {
-          LOG.warn("Same position constraint violated", updateResult.cause());
+          log.warn("Same position constraint violated", updateResult.cause());
           asyncResultHandler.handle(succeededFuture(
             respond422WithApplicationJson(samePositionInQueueError(null, null))
           ));
         } else {
           // Other failure occurred
-          LOG.warn("Unhandled error occurred during update", updateResult.cause());
+          log.warn("Unhandled error occurred during update", updateResult.cause());
           asyncResultHandler.handle(succeededFuture(
             respond500WithTextPlain(updateResult.cause().getMessage())
           ));

--- a/src/main/java/org/folio/service/BatchResourceService.java
+++ b/src/main/java/org/folio/service/BatchResourceService.java
@@ -65,8 +65,9 @@ public class BatchResourceService {
         if (updateResult.failed()) {
           log.warn("Batch update rejected", updateResult.cause());
 
+          // Rollback transaction and keep original cause.
           postgresClient.rollbackTx(connectionResult, rollback -> {
-            onFinishHandler.handle(Future.failedFuture(updateResult.cause()));
+            onFinishHandler.handle(failedFuture(updateResult.cause()));
             promise.fail(updateResult.cause());
           });
         } else {

--- a/src/main/java/org/folio/service/event/EntityChangedEventPublisherFactory.java
+++ b/src/main/java/org/folio/service/event/EntityChangedEventPublisherFactory.java
@@ -5,6 +5,7 @@ import static org.folio.support.kafka.topic.CirculationStorageKafkaTopic.CHECK_I
 import static org.folio.support.kafka.topic.CirculationStorageKafkaTopic.CIRCULATION_SETTINGS;
 import static org.folio.support.kafka.topic.CirculationStorageKafkaTopic.LOAN;
 import static org.folio.support.kafka.topic.CirculationStorageKafkaTopic.REQUEST;
+import static org.folio.support.kafka.topic.CirculationStorageKafkaTopic.REQUEST_QUEUE_REORDERING;
 import static org.folio.support.kafka.topic.CirculationStorageKafkaTopic.RULES;
 
 import java.util.Map;
@@ -19,6 +20,7 @@ import org.folio.rest.jaxrs.model.CirculationRules;
 import org.folio.rest.jaxrs.model.CirculationSetting;
 import org.folio.rest.jaxrs.model.Loan;
 import org.folio.rest.jaxrs.model.Request;
+import org.folio.rest.jaxrs.model.RequestQueueReordering;
 
 import io.vertx.core.Context;
 import lombok.extern.log4j.Log4j2;
@@ -51,6 +53,15 @@ public class EntityChangedEventPublisherFactory {
             REQUEST.fullTopicName(tenantId(okapiHeaders)),
             FailureHandler.noOperation()),
         new RequestRepository(vertxContext, okapiHeaders));
+  }
+
+  public static EntityChangedEventPublisher<String, RequestQueueReordering>
+  requestBatchEventPublisher(Context vertxContext, Map<String, String> okapiHeaders) {
+
+    return new EntityChangedEventPublisher<>(okapiHeaders, RequestQueueReordering::getInstanceId,
+      NULL_ID, new EntityChangedEventFactory<>(), new DomainEventPublisher<>(vertxContext,
+      REQUEST_QUEUE_REORDERING.fullTopicName(tenantId(okapiHeaders)),
+      FailureHandler.noOperation()), null);
   }
 
   public static EntityChangedEventPublisher<String, CheckIn> checkInEventPublisher(

--- a/src/main/java/org/folio/service/request/RequestBatchResourceService.java
+++ b/src/main/java/org/folio/service/request/RequestBatchResourceService.java
@@ -2,21 +2,28 @@ package org.folio.service.request;
 
 import static java.util.stream.IntStream.rangeClosed;
 import static org.folio.rest.persist.PostgresClient.convertToPsqlStandard;
+import static org.folio.rest.tools.utils.TenantTool.tenantId;
+import static org.folio.service.event.EntityChangedEventPublisherFactory.requestBatchEventPublisher;
 import static org.folio.support.ModuleConstants.REQUEST_TABLE;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import org.folio.rest.jaxrs.model.Request;
+import org.folio.rest.jaxrs.model.RequestQueueReordering;
+import org.folio.rest.persist.PgUtil;
 import org.folio.rest.persist.SQLConnection;
 import org.folio.service.BatchResourceService;
+import org.folio.service.event.EntityChangedEventPublisher;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import io.vertx.core.AsyncResult;
+import io.vertx.core.Context;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.sqlclient.Row;
@@ -29,12 +36,13 @@ public class RequestBatchResourceService {
 
   private final BatchResourceService batchResourceService;
   private final String tenantName;
+  private final EntityChangedEventPublisher<String, RequestQueueReordering> eventPublisher;
 
-  public RequestBatchResourceService(String tenantName,
-                                     BatchResourceService batchResourceService) {
-
-    this.batchResourceService = batchResourceService;
-    this.tenantName = tenantName;
+  public RequestBatchResourceService(Context context, Map<String, String> okapiHeaders) {
+    this.batchResourceService = new BatchResourceService(PgUtil.postgresClient(context,
+      okapiHeaders));
+    this.tenantName = tenantId(okapiHeaders);
+    this.eventPublisher = requestBatchEventPublisher(context, okapiHeaders);
   }
 
   /**
@@ -59,8 +67,8 @@ public class RequestBatchResourceService {
    * @param requests        - List of requests to execute in batch.
    * @param onFinishHandler - Callback function.
    */
-  public void executeRequestBatchUpdate(
-    List<Request> requests, Handler<AsyncResult<Void>> onFinishHandler) {
+  public void executeRequestBatchUpdate(List<Request> requests,
+    Handler<AsyncResult<Void>> onFinishHandler) {
 
     LOG.debug("Removing positions for all request to go through positions constraint");
     List<Function<SQLConnection, Future<RowSet<Row>>>> allDatabaseOperations =
@@ -80,7 +88,20 @@ public class RequestBatchResourceService {
     LOG.info("Executing batch update, total records to update [{}] (including remove positions)",
       allDatabaseOperations.size());
 
-    batchResourceService.executeBatchUpdate(allDatabaseOperations, onFinishHandler);
+    RequestQueueReordering payload = mapRequestsToPayload(requests);
+    LOG.info("executeRequestBatchUpdate:: payload: {}", payload);
+
+    batchResourceService.executeBatchUpdate(allDatabaseOperations, onFinishHandler)
+      .compose(v -> eventPublisher.publishCreated(payload.getInstanceId(), payload));
+  }
+
+  private RequestQueueReordering mapRequestsToPayload(List<Request> requests) {
+
+    return new RequestQueueReordering()
+      .withRequestIds(requests.stream()
+        .map(Request::getId)
+        .toList())
+      .withInstanceId(requests.get(0).getInstanceId());
   }
 
   private Function<SQLConnection, Future<RowSet<Row>>> removePositionsForRequestsBatch(

--- a/src/main/java/org/folio/service/request/RequestBatchResourceService.java
+++ b/src/main/java/org/folio/service/request/RequestBatchResourceService.java
@@ -89,7 +89,8 @@ public class RequestBatchResourceService {
       allDatabaseOperations.size());
 
     RequestQueueReordering payload = mapRequestsToPayload(requests);
-    LOG.info("executeRequestBatchUpdate:: payload: {}", payload);
+    LOG.info("executeRequestBatchUpdate:: instanceId: {}, requests: {}",
+      payload.getInstanceId(), payload.getRequestIds());
 
     batchResourceService.executeBatchUpdate(allDatabaseOperations, onFinishHandler)
       .compose(v -> eventPublisher.publishCreated(payload.getInstanceId(), payload));

--- a/src/main/java/org/folio/support/kafka/topic/CirculationStorageKafkaTopic.java
+++ b/src/main/java/org/folio/support/kafka/topic/CirculationStorageKafkaTopic.java
@@ -4,6 +4,7 @@ import org.folio.kafka.services.KafkaTopic;
 
 public enum CirculationStorageKafkaTopic implements KafkaTopic {
   REQUEST("request", 10),
+  REQUEST_QUEUE_REORDERING("request-queue-reordering", 10),
   CIRCULATION_SETTINGS("circulation-settings", 10),
   LOAN("loan", 10),
   CHECK_IN("check-in", 10),

--- a/src/test/java/org/folio/rest/api/RequestBatchAPITest.java
+++ b/src/test/java/org/folio/rest/api/RequestBatchAPITest.java
@@ -3,7 +3,7 @@ package org.folio.rest.api;
 import static org.folio.rest.api.RequestsApiTest.requestStorageUrl;
 import static org.folio.rest.api.StorageTestSuite.TENANT_ID;
 import static org.folio.rest.api.StorageTestSuite.storageUrl;
-import static org.folio.rest.support.matchers.DomainEventAssertions.assertCreateRequestQueueReorderingEvent;
+import static org.folio.rest.support.matchers.DomainEventAssertions.assertRequestQueueReorderingEvent;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.hasItems;
@@ -248,7 +248,7 @@ public class RequestBatchAPITest extends ApiTests {
     assertThat(r[0].getString("id"), is(secondRequest.getString("id")));
     assertThat(r[1].getString("id"), is(firstRequest.getString("id")));
 
-    assertCreateRequestQueueReorderingEvent(instanceId.toString(), List.of(
+    assertRequestQueueReorderingEvent(instanceId.toString(), List.of(
       firstRequest.getString("id"), secondRequest.getString("id")));
   }
 

--- a/src/test/java/org/folio/rest/api/RequestBatchAPITest.java
+++ b/src/test/java/org/folio/rest/api/RequestBatchAPITest.java
@@ -1,13 +1,16 @@
 package org.folio.rest.api;
 
+import static org.awaitility.Awaitility.await;
 import static org.folio.rest.api.RequestsApiTest.requestStorageUrl;
 import static org.folio.rest.api.StorageTestSuite.TENANT_ID;
 import static org.folio.rest.api.StorageTestSuite.storageUrl;
+import static org.folio.rest.support.kafka.FakeKafkaConsumer.getRequestQueueReorderingEvents;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.hasItems;
-import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
 
 import java.net.URL;
 import java.util.Arrays;
@@ -16,6 +19,7 @@ import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
+
 import org.folio.rest.impl.RequestsBatchAPI;
 import org.folio.rest.jaxrs.model.Request;
 import org.folio.rest.support.ApiTests;
@@ -52,8 +56,8 @@ public class RequestBatchAPITest extends ApiTests {
   public void canUpdateRequestPositionsInBatch() throws Exception {
     UUID itemId = UUID.randomUUID();
 
-    JsonObject firstRequest = createRequestForItemAtPosition(itemId, 1);
-    JsonObject secondRequest = createRequestForItemAtPosition(itemId, 2);
+    JsonObject firstRequest = createRequestAtPosition(itemId, null, 1);
+    JsonObject secondRequest = createRequestAtPosition(itemId, null, 2);
 
     ReorderRequest firstReorderRequest = new ReorderRequest(firstRequest, 2);
     ReorderRequest secondReorderRequest = new ReorderRequest(secondRequest, 1);
@@ -81,8 +85,8 @@ public class RequestBatchAPITest extends ApiTests {
   public void canCloseRequestsInBatch() throws Exception {
     UUID itemId = UUID.randomUUID();
 
-    JsonObject firstRequest = createRequestForItemAtPosition(itemId, 1);
-    JsonObject secondRequest = createRequestForItemAtPosition(itemId, 2);
+    JsonObject firstRequest = createRequestAtPosition(itemId, null, 1);
+    JsonObject secondRequest = createRequestAtPosition(itemId, null, 2);
 
     firstRequest.put("status", Request.Status.CLOSED_FILLED.value());
     firstRequest.remove("position");
@@ -111,8 +115,8 @@ public class RequestBatchAPITest extends ApiTests {
   public void canUpdateRequestFulfillmentPreferenceInBatch() throws Exception {
     UUID itemId = UUID.randomUUID();
 
-    JsonObject firstRequest = createRequestForItemAtPosition(itemId, 1);
-    JsonObject secondRequest = createRequestForItemAtPosition(itemId, 2);
+    JsonObject firstRequest = createRequestAtPosition(itemId, null, 1);
+    JsonObject secondRequest = createRequestAtPosition(itemId, null, 2);
 
     firstRequest.put("fulfillmentPreference", "Delivery");
     secondRequest.put("fulfillmentPreference", "Delivery");
@@ -153,8 +157,8 @@ public class RequestBatchAPITest extends ApiTests {
   public void willAbortBatchUpdateForRequestsAtTheSamePositionInAnItemsQueue() throws Exception {
     UUID itemId = UUID.randomUUID();
 
-    JsonObject firstRequest = createRequestForItemAtPosition(itemId, 1);
-    JsonObject secondRequest = createRequestForItemAtPosition(itemId, 2);
+    JsonObject firstRequest = createRequestAtPosition(itemId, null, 1);
+    JsonObject secondRequest = createRequestAtPosition(itemId, null, 2);
 
     JsonResponse reorderResponse = attemptReorderRequests(ResponseHandler::json,
       new ReorderRequest(firstRequest, 1),
@@ -170,8 +174,8 @@ public class RequestBatchAPITest extends ApiTests {
   public void willAbortBatchUpdateWhenOnlyOnePositionIsModified() throws Exception {
     UUID itemId = UUID.randomUUID();
 
-    JsonObject firstRequest = createRequestForItemAtPosition(itemId, 1);
-    JsonObject secondRequest = createRequestForItemAtPosition(itemId, 2);
+    JsonObject firstRequest = createRequestAtPosition(itemId, null, 1);
+    JsonObject secondRequest = createRequestAtPosition(itemId, null, 2);
 
     JsonResponse reorderResponse = attemptReorderRequests(ResponseHandler::json,
       new ReorderRequest(firstRequest, 2)
@@ -186,8 +190,8 @@ public class RequestBatchAPITest extends ApiTests {
   public void willAbortBatchUpdateOnNullPointerExceptionDueToNoIdInRequest() throws Exception {
     UUID itemId = UUID.randomUUID();
 
-    JsonObject firstRequest = createRequestForItemAtPosition(itemId, 1);
-    JsonObject secondRequest = createRequestForItemAtPosition(itemId, 2);
+    JsonObject firstRequest = createRequestAtPosition(itemId, null, 1);
+    JsonObject secondRequest = createRequestAtPosition(itemId, null, 2);
 
     JsonObject firstRequestCopy = firstRequest.copy();
     firstRequestCopy.remove("id");
@@ -205,7 +209,7 @@ public class RequestBatchAPITest extends ApiTests {
   public void cannotInjectSqlThroughRequestId() throws Exception {
     UUID itemId = UUID.randomUUID();
 
-    JsonObject firstRequest = createRequestForItemAtPosition(itemId, 1);
+    JsonObject firstRequest = createRequestAtPosition(itemId, null, 1);
 
     JsonObject firstRequestCopy = firstRequest.copy();
     firstRequestCopy.put("id", "1'; DELETE FROM request where id::text is not '1");
@@ -219,6 +223,37 @@ public class RequestBatchAPITest extends ApiTests {
     assertRequestsNotUpdated(itemId, firstRequest);
   }
 
+  @Test
+  public void canUpdateRequestPositionsInBatchForTheInstance() throws Exception {
+    UUID instanceId = UUID.randomUUID();
+
+    JsonObject firstRequest = createRequestAtPosition(null, instanceId, 1);
+    JsonObject secondRequest = createRequestAtPosition(null, instanceId, 2);
+
+    ReorderRequest firstReorderRequest = new ReorderRequest(firstRequest, 2);
+    ReorderRequest secondReorderRequest = new ReorderRequest(secondRequest, 1);
+
+    reorderRequests(
+      firstReorderRequest,
+      secondReorderRequest
+    );
+
+    JsonObject requestsForInstanceReply = getAllRequestsForInstance(instanceId);
+    assertThat(requestsForInstanceReply.getInteger("totalRecords"), is(2));
+    JsonArray requestsFromDb = requestsForInstanceReply.getJsonArray("requests");
+    assertThat(requestsFromDb.size(), is(2));
+    JsonObject [] r = new JsonObject [] { requestsFromDb.getJsonObject(0), requestsFromDb.getJsonObject(1) };
+    if (r[0].getInteger("position") == 2) {
+      r = new JsonObject [] { r[1], r[0] };
+    }
+    assertThat(r[0].getInteger("position"), is(1));
+    assertThat(r[1].getInteger("position"), is(2));
+    assertThat(r[0].getString("id"), is(secondRequest.getString("id")));
+    assertThat(r[1].getString("id"), is(firstRequest.getString("id")));
+
+    assertCreateRequestQueueReorderingEvent();
+  }
+
   private JsonObject getAllRequestsForItem(UUID itemId) throws Exception {
     CompletableFuture<JsonResponse> getRequestsCompleted = new CompletableFuture<>();
 
@@ -228,10 +263,30 @@ public class RequestBatchAPITest extends ApiTests {
     return getRequestsCompleted.get(5, TimeUnit.SECONDS).getJson();
   }
 
-  private JsonObject createRequestForItemAtPosition(UUID itemId, int position) throws Exception {
-    JsonObject request = createEntity(
-      new RequestRequestBuilder()
+  private JsonObject getAllRequestsForInstance(UUID instanceId) throws Exception {
+    CompletableFuture<JsonResponse> getRequestsCompleted = new CompletableFuture<>();
+
+    client.get(requestStorageUrl() + String.format("?query=instanceId==%s", instanceId),
+      TENANT_ID, ResponseHandler.json(getRequestsCompleted));
+
+    return getRequestsCompleted.get(5, TimeUnit.SECONDS).getJson();
+  }
+
+  private JsonObject createRequestAtPosition(UUID itemId, UUID instanceId, int position)
+    throws Exception {
+
+    RequestRequestBuilder requestBuilder = null;
+    if (instanceId != null) {
+      requestBuilder = new RequestRequestBuilder()
+        .withInstanceId(instanceId)
+        .withRequestLevel("Title");
+    } else {
+      requestBuilder = new RequestRequestBuilder()
         .withItemId(itemId)
+        .withRequestLevel("Item");
+    }
+    JsonObject request = createEntity(
+      requestBuilder
         .withPosition(position)
         .recall()
         .toHoldShelf()
@@ -240,7 +295,11 @@ public class RequestBatchAPITest extends ApiTests {
       requestStorageUrl()
     ).getJson();
 
-    assertThat(request.getString("itemId"), is(itemId.toString()));
+    if (itemId != null) {
+      assertThat(request.getString("itemId"), is(itemId.toString()));
+    } else {
+      assertThat(request.getString("instanceId"), is(instanceId.toString()));
+    }
     assertThat(request.getInteger("position"), is(position));
 
     return request;
@@ -325,6 +384,10 @@ public class RequestBatchAPITest extends ApiTests {
     assertThat(errors.size(), is(1));
     assertThat(errors.getJsonObject(0).getString("message"),
       errorMessageMatcher);
+  }
+
+  public static void assertCreateRequestQueueReorderingEvent() {
+    await().until(() -> getRequestQueueReorderingEvents().size(), greaterThan(0));
   }
 
   /**

--- a/src/test/java/org/folio/rest/api/RequestBatchAPITest.java
+++ b/src/test/java/org/folio/rest/api/RequestBatchAPITest.java
@@ -3,6 +3,7 @@ package org.folio.rest.api;
 import static org.folio.rest.api.RequestsApiTest.requestStorageUrl;
 import static org.folio.rest.api.StorageTestSuite.TENANT_ID;
 import static org.folio.rest.api.StorageTestSuite.storageUrl;
+import static org.folio.rest.support.kafka.FakeKafkaConsumer.removeAllEvents;
 import static org.folio.rest.support.matchers.DomainEventAssertions.assertRequestQueueReorderingEvent;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
@@ -44,6 +45,7 @@ public class RequestBatchAPITest extends ApiTests {
   @Before
   public void beforeEach() throws Exception {
     StorageTestSuite.deleteAll(requestStorageUrl());
+    removeAllEvents();
   }
 
   @After

--- a/src/test/java/org/folio/rest/api/RequestBatchAPITest.java
+++ b/src/test/java/org/folio/rest/api/RequestBatchAPITest.java
@@ -241,14 +241,14 @@ public class RequestBatchAPITest extends ApiTests {
     assertThat(requestsForInstanceReply.getInteger("totalRecords"), is(2));
     JsonArray requestsFromDb = requestsForInstanceReply.getJsonArray("requests");
     assertThat(requestsFromDb.size(), is(2));
-    JsonObject [] r = new JsonObject [] { requestsFromDb.getJsonObject(0), requestsFromDb.getJsonObject(1) };
-    if (r[0].getInteger("position") == 2) {
-      r = new JsonObject [] { r[1], r[0] };
-    }
-    assertThat(r[0].getInteger("position"), is(1));
-    assertThat(r[1].getInteger("position"), is(2));
-    assertThat(r[0].getString("id"), is(secondRequest.getString("id")));
-    assertThat(r[1].getString("id"), is(firstRequest.getString("id")));
+    List<JsonObject> requestsSorted = requestsFromDb.stream()
+      .map(JsonObject.class::cast)
+      .sorted(Comparator.comparingInt(obj -> obj.getInteger("position")))
+      .toList();
+    assertThat(requestsSorted.get(0).getInteger("position"), is(1));
+    assertThat(requestsSorted.get(1).getInteger("position"), is(2));
+    assertThat(requestsSorted.get(0).getString("id"), is(secondRequest.getString("id")));
+    assertThat(requestsSorted.get(1).getString("id"), is(firstRequest.getString("id")));
 
     assertRequestQueueReorderingEvent(instanceId.toString(), List.of(
       firstRequest.getString("id"), secondRequest.getString("id")));

--- a/src/test/java/org/folio/rest/support/kafka/FakeKafkaConsumer.java
+++ b/src/test/java/org/folio/rest/support/kafka/FakeKafkaConsumer.java
@@ -137,6 +137,10 @@ public final class FakeKafkaConsumer {
     return getFirstEvent(getCheckInEvents(checkInId));
   }
 
+  public static KafkaConsumerRecord<String, JsonObject> getFirstRequestQueueReorderingEvent() {
+    return getFirstEvent(getRequestQueueReorderingEvents());
+  }
+
   private static KafkaConsumerRecord<String, JsonObject> getFirstEvent(
       Collection<KafkaConsumerRecord<String, JsonObject>> events) {
 

--- a/src/test/java/org/folio/rest/support/kafka/FakeKafkaConsumer.java
+++ b/src/test/java/org/folio/rest/support/kafka/FakeKafkaConsumer.java
@@ -27,6 +27,7 @@ public final class FakeKafkaConsumer {
   private static final String REQUEST_TOPIC_NAME = "folio.test_tenant.circulation.request";
   private static final String CHECKIN_TOPIC_NAME = "folio.test_tenant.circulation.check-in";
   private static final String CIRCULATION_RULES_TOPIC_NAME = "folio.test_tenant.circulation.rules";
+  private static final String REQUEST_QUEUE_REORDERING_TOPIC_NAME = "folio.test_tenant.circulation.request-queue-reordering";
 
   private static final Map<String, List<KafkaConsumerRecord<String, JsonObject>>> loanEvents =
       new ConcurrentHashMap<>();
@@ -36,19 +37,21 @@ public final class FakeKafkaConsumer {
       new ConcurrentHashMap<>();
   private static final Map<String, List<KafkaConsumerRecord<String, JsonObject>>> circulationRulesEvents =
     new ConcurrentHashMap<>();
-
+  private static final Map<String, List<KafkaConsumerRecord<String, JsonObject>>> requestQueueReorderingEvents =
+    new ConcurrentHashMap<>();
   private static final Map<String, Map<String, List<KafkaConsumerRecord<String, JsonObject>>>> topicToEvents = Map.of(
     LOAN_TOPIC_NAME, loanEvents,
     REQUEST_TOPIC_NAME, requestEvents,
     CHECKIN_TOPIC_NAME, checkInEvents,
-    CIRCULATION_RULES_TOPIC_NAME, circulationRulesEvents
+    CIRCULATION_RULES_TOPIC_NAME, circulationRulesEvents,
+    REQUEST_QUEUE_REORDERING_TOPIC_NAME, requestQueueReorderingEvents
   );
 
   public FakeKafkaConsumer consume(Vertx vertx) {
     final KafkaConsumer<String, JsonObject> consumer = create(vertx, consumerProperties());
 
     consumer.subscribe(Set.of(LOAN_TOPIC_NAME, REQUEST_TOPIC_NAME, CHECKIN_TOPIC_NAME,
-      CIRCULATION_RULES_TOPIC_NAME));
+      CIRCULATION_RULES_TOPIC_NAME, REQUEST_QUEUE_REORDERING_TOPIC_NAME));
 
     consumer.handler(message -> {
       var recordEvents = topicToEvents.get(message.topic());
@@ -69,6 +72,7 @@ public final class FakeKafkaConsumer {
     requestEvents.clear();
     checkInEvents.clear();
     circulationRulesEvents.clear();
+    requestQueueReorderingEvents.clear();
   }
 
   public static int getAllPublishedLoanCount() {
@@ -89,6 +93,13 @@ public final class FakeKafkaConsumer {
 
   public static Collection<KafkaConsumerRecord<String, JsonObject>> getCirculationRulesEvents() {
     return circulationRulesEvents.values()
+      .stream()
+      .findFirst()
+      .orElseGet(Collections::emptyList);
+  }
+
+  public static Collection<KafkaConsumerRecord<String, JsonObject>> getRequestQueueReorderingEvents() {
+    return requestQueueReorderingEvents.values()
       .stream()
       .findFirst()
       .orElseGet(Collections::emptyList);

--- a/src/test/java/org/folio/rest/support/matchers/DomainEventAssertions.java
+++ b/src/test/java/org/folio/rest/support/matchers/DomainEventAssertions.java
@@ -111,7 +111,7 @@ public final class DomainEventAssertions {
     assertCreateEvent(getLastRequestEvent(requestId), request);
   }
 
-  public static void assertCreateRequestQueueReorderingEvent(String instanceId,
+  public static void assertRequestQueueReorderingEvent(String instanceId,
     List<String> requestIds) {
 
     await().until(() -> getRequestQueueReorderingEvents().size(), greaterThan(0));

--- a/src/test/java/org/folio/rest/support/matchers/DomainEventAssertions.java
+++ b/src/test/java/org/folio/rest/support/matchers/DomainEventAssertions.java
@@ -11,12 +11,14 @@ import static org.folio.rest.api.StorageTestSuite.storageUrl;
 import static org.folio.rest.support.kafka.FakeKafkaConsumer.getCheckInEvents;
 import static org.folio.rest.support.kafka.FakeKafkaConsumer.getCirculationRulesEvents;
 import static org.folio.rest.support.kafka.FakeKafkaConsumer.getFirstLoanEvent;
+import static org.folio.rest.support.kafka.FakeKafkaConsumer.getFirstRequestQueueReorderingEvent;
 import static org.folio.rest.support.kafka.FakeKafkaConsumer.getLastCheckInEvent;
 import static org.folio.rest.support.kafka.FakeKafkaConsumer.getLastCirculationRulesEvent;
 import static org.folio.rest.support.kafka.FakeKafkaConsumer.getLastLoanEvent;
 import static org.folio.rest.support.kafka.FakeKafkaConsumer.getLastRequestEvent;
 import static org.folio.rest.support.kafka.FakeKafkaConsumer.getLoanEvents;
 import static org.folio.rest.support.kafka.FakeKafkaConsumer.getRequestEvents;
+import static org.folio.rest.support.kafka.FakeKafkaConsumer.getRequestQueueReorderingEvents;
 import static org.folio.rest.support.matchers.UUIDMatchers.hasUUIDFormat;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
@@ -34,6 +36,7 @@ import org.awaitility.core.ConditionFactory;
 import org.folio.service.event.DomainEventType;
 
 import io.vertx.core.MultiMap;
+import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import io.vertx.kafka.client.consumer.KafkaConsumerRecord;
 import io.vertx.kafka.client.producer.KafkaHeader;
@@ -106,6 +109,18 @@ public final class DomainEventAssertions {
     await().until(() -> getRequestEvents(requestId).size(), greaterThan(0));
 
     assertCreateEvent(getLastRequestEvent(requestId), request);
+  }
+
+  public static void assertCreateRequestQueueReorderingEvent(String instanceId,
+    List<String> requestIds) {
+
+    await().until(() -> getRequestQueueReorderingEvents().size(), greaterThan(0));
+
+    JsonObject payload = new JsonObject()
+      .put("instanceId", instanceId)
+      .put("requestIds", new JsonArray(requestIds));
+
+    assertCreateEvent(getFirstRequestQueueReorderingEvent(), payload);
   }
 
   public static void assertNoRequestEvent(String requestId) {

--- a/src/test/java/org/folio/service/kafka/topic/KafkaAdminClientServiceTest.java
+++ b/src/test/java/org/folio/service/kafka/topic/KafkaAdminClientServiceTest.java
@@ -43,7 +43,8 @@ public class KafkaAdminClientServiceTest {
       "folio.foo-tenant.circulation.loan",
       "folio.foo-tenant.circulation.check-in",
       "folio.foo-tenant.circulation.rules",
-      "folio.foo-tenant.circulation.circulation-settings"
+      "folio.foo-tenant.circulation.circulation-settings",
+      "folio.foo-tenant.circulation.request-queue-reordering"
   );
 
   private KafkaAdminClient mockClient;


### PR DESCRIPTION
##Purpose
When the UI reorders requests, it calls the /circulation/requests/queue/instance/{instanceId}/reorder endpoint 

This endpoint calls /request-storage-batch/requests from mod-circulation-storage, and after successful reordering, mod-circulation-storage should publish a Kafka request-batch-update event. The event's payload must include the instanceId and the IDs of the reordered requests

Resolves: [CIRCSTORE-521](https://folio-org.atlassian.net/browse/CIRCSTORE-521)