### PR TITLE
[CIRCSTORE-533] Upgrade "holdings-storage" API

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,7 @@
-* ## 17.2.0 2024-03-20
+## 17.3.0
+* [CIRCSTORE-533](https://folio-org.atlassian.net/browse/CIRCSTORE-533) Upgrade "holdings-storage" to 8.0
+
+## 17.2.0 2024-03-20
 * Upgrade RMB to 35.2.0, Vert.x to 4.5.5, Spring to 6.1.5 (CIRCSTORE-494)
 * Add `displaySummary` field to `ActualCostRecord` schema (CIRCSTORE-493)
 * Fix NPE for requests with no position (CIRCSTORE-422) 

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -8,7 +8,7 @@
     },
     {
       "id": "holdings-storage",
-      "version": "1.3 2.0 3.0 4.0 5.0 6.0 7.0"
+      "version": "1.3 2.0 3.0 4.0 5.0 6.0 7.0 8.0"
     },
     {
       "id": "pubsub-event-types",


### PR DESCRIPTION
[CIRCSTORE-533](https://folio-org.atlassian.net/browse/CIRCSTORE-533)
Upgrade the API version in the ModuleDescriptor-template.json:

-`holdings-storage 8.0`