### PR TITLE
CIRCSTORE-592: testcontainers 1.21.0, apache/kafka-native 3.8.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
       <dependency>
         <groupId>org.testcontainers</groupId>
         <artifactId>testcontainers-bom</artifactId>
-        <version>1.19.1</version>
+        <version>1.21.0</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/src/test/java/org/folio/rest/api/StorageTestSuite.java
+++ b/src/test/java/org/folio/rest/api/StorageTestSuite.java
@@ -39,7 +39,7 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.testcontainers.containers.KafkaContainer;
+import org.testcontainers.kafka.KafkaContainer;
 import org.testcontainers.utility.DockerImageName;
 
 import com.github.tomakehurst.wiremock.WireMockServer;
@@ -99,7 +99,7 @@ public class StorageTestSuite {
   private static final WireMockServer wireMockServer = new WireMockServer(PROXY_PORT);
 
   private static final KafkaContainer kafkaContainer
-    = new KafkaContainer(DockerImageName.parse("confluentinc/cp-kafka:7.2.0"));
+    = new KafkaContainer(DockerImageName.parse("apache/kafka-native:3.8.0"));
 
   /**
    * Return a URL for the path and the parameters.


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/CIRCSTORE-592

Upgrade testcontainers from 1.19.1 to 1.21.0. This is needed for the other upgrade:

Upgrade deprecated

`containers.KafkaContainer confluentinc/cp-kafka:7.2.0`

to

`kafka.KafkaContainer apache/kafka-native:3.8.0`

See https://folio-org.atlassian.net/wiki/spaces/TC/pages/730891059/Trillium#Trillium-Infrastructure