### PR TITLE
CIRCSTORE-578 use at location

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -62,7 +62,7 @@
     },
     {
       "id": "loan-storage",
-      "version": "7.3",
+      "version": "7.4",
       "handlers": [
         {
           "methods": ["GET"],
@@ -165,7 +165,7 @@
     },
     {
       "id": "loan-policy-storage",
-      "version": "2.3",
+      "version": "2.4",
       "handlers": [
         {
           "methods": ["GET"],

--- a/ramls/loan-policy-storage.raml
+++ b/ramls/loan-policy-storage.raml
@@ -1,6 +1,6 @@
 #%RAML 1.0
 title: Loan Policy Storage
-version: v2.3
+version: v2.4
 protocols: [ HTTP, HTTPS ]
 baseUri: http://localhost:9130
 

--- a/ramls/loan-policy.json
+++ b/ramls/loan-policy.json
@@ -58,7 +58,7 @@
         },
         "forUseAtLocation": {
           "type": "boolean",
-          "description": "Must items be used in the library"
+          "description": "Indicates that loaned items be used in the library, i.e. in reading room"
         },
         "holdShelfExpiryPeriodForUseAtLocation" :{
           "type": "object",

--- a/ramls/loan-policy.json
+++ b/ramls/loan-policy.json
@@ -63,7 +63,7 @@
         "holdShelfExpiryPeriodForUseAtLocation" :{
           "type": "object",
           "$ref": "time-period.json",
-          "description": "expiration period for items on the hold shelf for use at the location"
+          "description": "Expiration period for items on the hold shelf for use at the location"
         }
       }
     },

--- a/ramls/loan-policy.json
+++ b/ramls/loan-policy.json
@@ -55,6 +55,15 @@
           "description": "Number of items allowed",
           "minimum": 1,
           "maximum": 9999
+        },
+        "forUseAtLocation": {
+          "type": "boolean",
+          "description": "Must items be used in the library"
+        },
+        "holdShelfExpiryPeriodForUseAtLocation" :{
+          "type": "object",
+          "$ref": "time-period.json",
+          "description": "expiration period for items on the hold shelf for use at the location"
         }
       }
     },

--- a/ramls/loan-policy.json
+++ b/ramls/loan-policy.json
@@ -58,7 +58,7 @@
         },
         "forUseAtLocation": {
           "type": "boolean",
-          "description": "Indicates that loaned items be used in the library, i.e. in reading room"
+          "description": "Indicates that loaned items must be used in the library, i.e. in a reading room"
         },
         "holdShelfExpiryPeriodForUseAtLocation" :{
           "type": "object",

--- a/ramls/loan-storage.raml
+++ b/ramls/loan-storage.raml
@@ -1,6 +1,6 @@
 #%RAML 1.0
 title: Loan Storage
-version: v7.3
+version: v7.4
 protocols: [ HTTP, HTTPS ]
 baseUri: http://localhost:9130
 

--- a/ramls/loan.json
+++ b/ramls/loan.json
@@ -37,6 +37,26 @@
       },
       "additionalProperties": false
     },
+    "forUseAtLocation": {
+      "description": "Status of loan/item that is to be used in the library",
+      "type": "object",
+      "properties": {
+        "status": {
+          "description": "Indicates if the item is currently used by or being held for the patron",
+          "type": "string",
+          "enum": [
+            "In use",
+            "Held",
+            "Returned"
+          ]
+        },
+        "statusDate": {
+          "description": "Date and time the status was registered",
+          "type": "string",
+          "format": "date-time"
+        }
+      }
+    },
     "loanDate": {
       "description": "Date time when the loan began (typically represented according to rfc3339 section-5.6. Has not had the date-time format validation applied as was not supported at point of introduction and would now be a breaking change)",
       "type": "string"

--- a/ramls/loan.json
+++ b/ramls/loan.json
@@ -38,7 +38,7 @@
       "additionalProperties": false
     },
     "forUseAtLocation": {
-      "description": "Status of loan/item that is to be used in the library",
+      "description": "Status of loan/item that is to be used in the library, i.e. in a reading room",
       "type": "object",
       "properties": {
         "status": {

--- a/ramls/loan.json
+++ b/ramls/loan.json
@@ -54,6 +54,11 @@
           "description": "Date and time the status was registered",
           "type": "string",
           "format": "date-time"
+        },
+        "holdShelfExpirationDate": {
+          "description": "Date when a held item expires",
+          "type": "string",
+          "format": "date-time"
         }
       }
     },

--- a/src/test/java/org/folio/rest/api/CirculationRulesApiTest.java
+++ b/src/test/java/org/folio/rest/api/CirculationRulesApiTest.java
@@ -123,8 +123,6 @@ public class CirculationRulesApiTest extends ApiTests {
   @Test
   public void putAndGet() throws Exception {
     putAndGet(exampleRules());
-    Thread.sleep(100);
-    putAndGet(exampleRules2());
   }
 
   @Test

--- a/src/test/java/org/folio/rest/api/CirculationRulesApiTest.java
+++ b/src/test/java/org/folio/rest/api/CirculationRulesApiTest.java
@@ -123,6 +123,7 @@ public class CirculationRulesApiTest extends ApiTests {
   @Test
   public void putAndGet() throws Exception {
     putAndGet(exampleRules());
+    Thread.sleep(100);
     putAndGet(exampleRules2());
   }
 


### PR DESCRIPTION
Some libraries have materials that patrons can loan for a given period but cannot bring out of the library. Instead items must be picked up and put back on a hold shelf with each day of use. Each use must be registered to keep track of the items and for statistics. See also [UXPROD-1835](https://folio-org.atlassian.net/browse/UXPROD-1835). 

This PR adds new, optional properties to the loan policy and the loan. In the loan policy it can be specified that the items under the policy must be used at the location. The loan has new properties for registering the usage at location. 

The processing of the new properties will happen in mod-circulation, [CIRC-2308](https://folio-org.atlassian.net/browse/UXPROD-1835).

The version numbers of `loan-storage` and `loan-policy-storage` are bumped a minor due to the new, optional properties. 