### PR TITLE
CIRCSTORE-605 add loan type to the request object

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -196,7 +196,7 @@
     },
     {
       "id": "request-storage",
-      "version": "6.2",
+      "version": "6.3",
       "handlers": [
         {
           "methods": ["GET"],

--- a/ramls/request.json
+++ b/ramls/request.json
@@ -151,6 +151,15 @@
         "retrievalServicePointName": {
           "description": "Item's location primary service point name",
           "type": "string"
+        },
+        "loanTypeId": {
+          "description": "Item's temporary loan type, if any, otherwise item's permanent loan type",
+          "type": "string",
+          "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$"
+        },
+        "loanTypeName": {
+          "description": "Name of item's temporary loan type, if any, otherwise name of item's permanent loan type",
+          "type": "string"
         }
       },
       "additionalProperties": false


### PR DESCRIPTION
There is a need to display the loan type on requests in the UI. This has specifically come up in relation to the new development of reading room circulation (UXPROD-5036)  

This PR is first part of the addition, allowing for the properties to be stored in request objects in circulation storage. Next part is a change to mod-circulation to set and render the values, CIRC-2441.  