### PR TITLE
CIRCSTORE-612 Handle empty CQL set (==()) in queries

### DIFF
--- a/src/main/java/org/folio/service/request/RequestService.java
+++ b/src/main/java/org/folio/service/request/RequestService.java
@@ -63,8 +63,17 @@ public class RequestService {
   }
 
   public Future<Response> findByQuery(String query, int offset, int limit) {
+    if (containsEmptyCqlSet(query)) {
+      log.info("findByQuery:: query contains empty CQL set, returning empty result: {}", query);
+      return succeededFuture(RequestStorage.GetRequestStorageRequestsResponse
+        .respond200WithApplicationJson(new Requests().withRequests(List.of()).withTotalRecords(0)));
+    }
     return PgUtil.get(REQUEST_TABLE, REQUEST_CLASS, Requests.class, query, offset, limit, okapiHeaders, vertxContext,
         RequestStorage.GetRequestStorageRequestsResponse.class);
+  }
+
+  private static boolean containsEmptyCqlSet(String query) {
+    return query != null && query.contains("==()");
   }
 
   public Future<Response> findById(String requestId) {

--- a/src/test/java/org/folio/rest/api/RequestsApiTest.java
+++ b/src/test/java/org/folio/rest/api/RequestsApiTest.java
@@ -2174,4 +2174,23 @@ class RequestsApiTest extends ApiTests {
     return StorageTestSuite.storageUrl(
       CANCEL_REASON_URL + subPath);
   }
+
+  @Test
+  void shouldReturnEmptyResultWhenQueryContainsEmptyCqlSet()
+    throws MalformedURLException, InterruptedException, ExecutionException, TimeoutException {
+
+    CompletableFuture<JsonResponse> getCompleted = new CompletableFuture<>();
+
+    client.get(requestStorageUrl() + "?query=itemId==()&limit=10000",
+      TENANT_ID, ResponseHandler.json(getCompleted));
+
+    JsonResponse response = getCompleted.get(5, TimeUnit.SECONDS);
+
+    assertThat(String.format("Expected 200 OK but got: %s", response.getBody()),
+      response.getStatusCode(), is(HttpURLConnection.HTTP_OK));
+
+    JsonObject body = response.getJson();
+    assertThat(body.getJsonArray("requests").size(), is(0));
+    assertThat(body.getInteger("totalRecords"), is(0));
+  }
 }


### PR DESCRIPTION
Resolves: [CIRCSTORE-612](https://folio-org.atlassian.net/browse/CIRCSTORE-612)