### PR TITLE
CIRCSTORE-651: Re-enabling tenant overwrites circulation rules

### DIFF
--- a/reference-data/circulation-rules-storage/single-rule.json
+++ b/reference-data/circulation-rules-storage/single-rule.json
@@ -1,3 +1,0 @@
-{
-  "rulesAsText": "priority: number-of-criteria, criterium (t, s, c, b, a, m, g), last-line\nfallback-policy: l d9cd0bed-1b49-4b5e-a7bd-064b8d177231 r 334e5a9e-94f9-4673-8d1d-ab552863886b n 122b3d2b-4788-4f1e-9117-56daa91cb75c o cd3f6cac-fa17-4079-9fae-2fb28e521412 i ed892c0e-52e0-4cd9-8133-c0ef07b4a709 \nm 1a54b431-2e4f-452d-9cae-9cee66c9a892: l 43198de5-f56a-4a53-a0bd-5a324418967a r 334e5a9e-94f9-4673-8d1d-ab552863886b n 122b3d2b-4788-4f1e-9117-56daa91cb75c o cd3f6cac-fa17-4079-9fae-2fb28e521412 i ed892c0e-52e0-4cd9-8133-c0ef07b4a709"
-}

--- a/src/main/java/org/folio/rest/impl/TenantRefAPI.java
+++ b/src/main/java/org/folio/rest/impl/TenantRefAPI.java
@@ -61,8 +61,6 @@ public class TenantRefAPI extends TenantAPI {
         .add("request-policy-storage/request-policies")
         .add("patron-notice-policy-storage/patron-notice-policies")
         .add("staff-slips-storage/staff-slips")
-        .withIdRaw()
-        .add("circulation-rules-storage")
         .withIdContent()
         .add("cancellation-reason-storage/cancellation-reasons");
     }

--- a/src/main/resources/templates/db_scripts/insertCirculationRulesRecord.sql
+++ b/src/main/resources/templates/db_scripts/insertCirculationRulesRecord.sql
@@ -16,6 +16,8 @@ BEGIN
   END IF;
 END $$;
 INSERT INTO ${myuniversity}_${mymodule}.${table.tableName}
-  SELECT id, jsonb_build_object('id', id, 'rulesAsText', '')
+  SELECT id, jsonb_build_object(
+    'id', id,
+    'rulesAsText', '"priority: number-of-criteria, criterium (t, s, c, b, a, m, g), last-line\nfallback-policy: l d9cd0bed-1b49-4b5e-a7bd-064b8d177231 r 334e5a9e-94f9-4673-8d1d-ab552863886b n 122b3d2b-4788-4f1e-9117-56daa91cb75c o cd3f6cac-fa17-4079-9fae-2fb28e521412 i ed892c0e-52e0-4cd9-8133-c0ef07b4a709 \nm 1a54b431-2e4f-452d-9cae-9cee66c9a892: l 43198de5-f56a-4a53-a0bd-5a324418967a r 334e5a9e-94f9-4673-8d1d-ab552863886b n 122b3d2b-4788-4f1e-9117-56daa91cb75c o cd3f6cac-fa17-4079-9fae-2fb28e521412 i ed892c0e-52e0-4cd9-8133-c0ef07b4a709"')
   FROM (SELECT md5('${myuniversity}_${mymodule}.${table.tableName}.rulesAsText')::uuid AS id) AS alias
   ON CONFLICT DO NOTHING;

--- a/src/main/resources/templates/db_scripts/schema.json
+++ b/src/main/resources/templates/db_scripts/schema.json
@@ -415,7 +415,7 @@
       "tableName": "circulation_rules",
       "withMetadata": true,
       "withAuditing": false,
-      "customSnippetPath": "insertEmptyCirculationRulesRecord.sql"
+      "customSnippetPath": "insertCirculationRulesRecord.sql"
     },
     {
       "tableName": "staff_slips",


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/CIRCSTORE-651

When disabling a tenant and then re-enabling the tenant the circulation rules get overwritten with the default circulation rules:

* https://github.com/folio-org/mod-circulation-storage/blob/v17.5.0/src/main/java/org/folio/rest/impl/TenantRefAPI.java#L65
* https://github.com/folio-org/mod-circulation-storage/blob/v17.5.0/reference-data/circulation-rules-storage/single-rule.json

This data loss should be fixed by moving the default circulation rules into the code that creates the record:

* https://github.com/folio-org/mod-circulation-storage/blob/b14.0/src/main/resources/templates/db_scripts/insertEmptyCirculationRulesRecord.sql