### PR TITLE
CIRCSTORE-652: Undeploy verticle before stopping Kafka

### DIFF
--- a/src/test/java/org/folio/rest/api/StorageTestSuite.java
+++ b/src/test/java/org/folio/rest/api/StorageTestSuite.java
@@ -92,6 +92,7 @@ public class StorageTestSuite {
   public static final String TENANT_ID = "test_tenant";
 
   private static Vertx vertx;
+  private static String restVerticleId;
   public static final int PROXY_PORT = NetworkUtils.nextFreePort();
   public static final int OKAPI_MOCK_PORT = NetworkUtils.nextFreePort();
   private static boolean initialised = false;
@@ -194,6 +195,12 @@ public class StorageTestSuite {
       removeTenant(TENANT_ID);
     } catch (Throwable e) {
       log.warn("after:: removeTenant failed (ignored): {}", e.getMessage());
+    }
+
+    try {
+      stopVerticle();
+    } catch (Throwable e) {
+      log.warn("after:: stopVerticle failed (ignored): {}", e.getMessage());
     }
 
     try {
@@ -309,7 +316,12 @@ public class StorageTestSuite {
       .onSuccess(deploymentComplete::complete)
       .onFailure(deploymentComplete::completeExceptionally);
 
-    deploymentComplete.get(30, TimeUnit.SECONDS);
+    restVerticleId = deploymentComplete.get(30, TimeUnit.SECONDS);
+  }
+
+  private static void stopVerticle() throws InterruptedException, ExecutionException, TimeoutException {
+    vertx.undeploy(restVerticleId)
+    .toCompletionStage().toCompletableFuture().get(5, TimeUnit.SECONDS);
   }
 
   static protected void prepareTenant(String tenantId, boolean loadSample) {


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/CIRCSTORE-652

Build of master branch fails in more than 50% of the runs. Examples:

```
2026-05-12T14:04:05.0916212Z [ERROR] Errors:
2026-05-12T14:04:05.0917247Z [ERROR] StaffSlipsHoldTransitMigrationScriptTest>ApiTests.after:71 » Timeout
2026-05-12T14:04:05.0918650Z [ERROR] StaffSlipsPickRequestMigrationScriptTest>ApiTests.after:71 » Timeout
2026-05-12T14:04:05.0919378Z [INFO]
2026-05-12T14:04:05.0919821Z [ERROR] Tests run: 470, Failures: 0, Errors: 2, Skipped: 2
```

```
2026-05-12T13:55:01.3690525Z [ERROR] Errors:
2026-05-12T13:55:01.3691462Z [ERROR] StaffSlipsHoldTransitMigrationScriptTest>ApiTests.after:71 » Timeout
2026-05-12T13:55:01.3692492Z [INFO]
2026-05-12T13:55:01.3692892Z [ERROR] Tests run: 469, Failures: 0, Errors: 1, Skipped: 2
```

```
2026-05-12T13:50:41.4889556Z [ERROR] Errors:
2026-05-12T13:50:41.4891968Z [ERROR] StaffSlipsPickRequestMigrationScriptTest>ApiTests.after:71 » Timeout
2026-05-12T13:50:41.4892811Z [INFO]
2026-05-12T13:50:41.4893318Z [ERROR] Tests run: 469, Failures: 0, Errors: 1, Skipped: 2
```

This is caused by StorageTestSuite that stops Kafka without stopping the RestVerticle. This causes RestVerticle to try to reconnect to Kafka causing shutdown delays depending on the timing (race condition).

Solution: Undeploy RestVerticle before stopping Kafka.