### PR TITLE
[CIRCSTORE-647] Add Request Anonymization Endpoint

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -27,6 +27,7 @@
 * Implement DELETE `/loan-storage/loans` by CQL query (CIRCSTORE-591)
 * Set queue level based on TLR feature status (CIRCSTORE-589)
 * Add `isRawHtml` to staff-slip schema and bump `staff-slips-storage` to 1.1 (CIRCSTORE-585)
+* Allow anonymization of a list of requests (CIRCSTORE-647)
 
 ## 17.4.0 2025-03-12
 * Upgrade to Java v21 (CIRCSTORE-576)

--- a/src/main/java/org/folio/rest/impl/AnonymizeStorageRequestsAPI.java
+++ b/src/main/java/org/folio/rest/impl/AnonymizeStorageRequestsAPI.java
@@ -82,7 +82,7 @@ public class AnonymizeStorageRequestsAPI implements AnonymizeStorageRequests {
     final String combinedAnonymizationSql = createAnonymizationSQL(validIds,
         tenantId);
 
-    executeSql(postgresClient, combinedAnonymizationSql).map(
+    postgresClient.execute(combinedAnonymizationSql).map(
         updateResult -> PostAnonymizeStorageRequestsResponse.respond200WithApplicationJson(
             response.withAnonymizedRequests(validIds)))
         .map(Response.class::cast)
@@ -99,14 +99,6 @@ public class AnonymizeStorageRequestsAPI implements AnonymizeStorageRequests {
         new NotAnonymizedRequest().withReason(reason).withRequestIds(ids));
   }
 
-  private Future<RowSet<Row>> executeSql(PostgresClient postgresClient, String sql) {
-    final Promise<RowSet<Row>> promise = Promise.promise();
-
-    postgresClient.execute(sql, promise::handle);
-
-    return promise.future();
-  }
-
   private String createAnonymizationSQL(@NotNull Collection<String> requestIdList,
       String tenantId) {
 
@@ -114,17 +106,15 @@ public class AnonymizeStorageRequestsAPI implements AnonymizeStorageRequests {
         .map(s -> "\'" + s + "\'")
         .collect(Collectors.joining(",", "(", ")"));
 
-    return String.format(
-        new StringBuilder().append("UPDATE %s_%s.request ")
-            .append(" SET jsonb = jsonb - ARRAY['requesterId', 'proxyUserId', 'requester', 'proxy']")
-            .append(" WHERE request.id in ")
-            .append(requestIds)
-            .append(" AND request.jsonb->>'status' LIKE 'Closed - %%'")
-            .append(" AND (request.jsonb->>'requesterId' is NOT null")
-            .append(" OR request.jsonb->>'proxyUserId' is NOT null")
-            .append(" OR request.jsonb->>'requester' is NOT null")
-            .append(" OR request.jsonb->>'proxy' is NOT null)")
-            .toString(),
-        tenantId, MODULE_NAME);
+    return """
+        UPDATE %s_%s.request
+        SET jsonb = jsonb - ARRAY['requesterId', 'proxyUserId', 'requester', 'proxy']
+        WHERE request.id in %s
+          AND request.jsonb->>'status' LIKE 'Closed - %%'
+          AND (request.jsonb->>'requesterId' is NOT null
+            OR request.jsonb->>'proxyUserId' is NOT null
+            OR request.jsonb->>'requester' is NOT null
+            OR request.jsonb->>'proxy' is NOT null)
+        """.formatted(tenantId, MODULE_NAME, requestIds);
   }
 }

--- a/src/main/java/org/folio/rest/impl/AnonymizeStorageRequestsAPI.java
+++ b/src/main/java/org/folio/rest/impl/AnonymizeStorageRequestsAPI.java
@@ -1,0 +1,116 @@
+package org.folio.rest.impl;
+
+import static io.vertx.core.Future.succeededFuture;
+import static org.folio.support.ModuleConstants.MODULE_NAME;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import javax.ws.rs.core.Response;
+
+import org.apache.commons.collections4.CollectionUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.folio.rest.annotations.Validate;
+import org.folio.rest.jaxrs.model.AnonymizeStorageRequestsRequest;
+import org.folio.rest.jaxrs.model.AnonymizeStorageRequestsResponse;
+import org.folio.rest.jaxrs.model.Errors;
+import org.folio.rest.jaxrs.model.NotAnonymizedRequest;
+import org.folio.rest.jaxrs.resource.AnonymizeStorageRequests;
+import org.folio.rest.persist.PgUtil;
+import org.folio.rest.persist.PostgresClient;
+import org.folio.rest.tools.utils.TenantTool;
+import org.folio.rest.tools.utils.ValidationHelper;
+import org.folio.support.UUIDValidation;
+
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Context;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.core.Promise;
+import io.vertx.sqlclient.Row;
+import io.vertx.sqlclient.RowSet;
+import jakarta.validation.constraints.NotNull;
+
+public class AnonymizeStorageRequestsAPI implements AnonymizeStorageRequests {
+  private static final Logger log = LogManager.getLogger();
+
+  @Validate
+  @Override
+  public void postAnonymizeStorageRequests(AnonymizeStorageRequestsRequest request,
+      Map<String, String> okapiHeaders,
+      Handler<AsyncResult<Response>> responseHandler, Context vertxContext) {
+
+    AnonymizeStorageRequestsResponse response = new AnonymizeStorageRequestsResponse();
+    List<String> requestIds = request.getRequestIds();
+
+    Map<Boolean, List<String>> requestIdsMap = requestIds.stream()
+        .collect(Collectors.groupingBy(UUIDValidation::isValidUUID));
+
+    List<String> validIds = requestIdsMap.get(true);
+    List<String> invalidIds = requestIdsMap.get(false);
+
+    if (CollectionUtils.isNotEmpty(invalidIds)) {
+      log.warn("Invalid request UUIDs provided: {}", invalidIds);
+      addToNotAnonymizedRequests(response, "invalidRequestIds", invalidIds);
+    }
+
+    if (CollectionUtils.isEmpty(validIds)) {
+      final Errors errors = ValidationHelper.createValidationErrorMessage(
+          "requestIds", requestIds.toString(), "Please provide valid requestIds");
+      responseHandler.handle(succeededFuture(
+          PostAnonymizeStorageRequestsResponse.respond422WithApplicationJson(errors)));
+      return;
+    }
+
+    log.info("Anonymizing requests: {}", validIds.size());
+
+    final String tenantId = TenantTool.tenantId(okapiHeaders);
+    final PostgresClient postgresClient = PgUtil.postgresClient(vertxContext,
+        okapiHeaders);
+
+    final String combinedAnonymizationSql = createAnonymizationSQL(validIds,
+        tenantId);
+
+    executeSql(postgresClient, combinedAnonymizationSql).map(
+        updateResult -> PostAnonymizeStorageRequestsResponse.respond200WithApplicationJson(
+            response.withAnonymizedRequests(validIds)))
+        .map(Response.class::cast)
+        .otherwise(
+            e -> PostAnonymizeStorageRequestsResponse.respond500WithTextPlain(e.getMessage()))
+        .onComplete(responseHandler);
+
+  }
+
+  private void addToNotAnonymizedRequests(AnonymizeStorageRequestsResponse response,
+      String reason, List<String> ids) {
+    List<NotAnonymizedRequest> notAnonimizedLoans = response.getNotAnonymizedRequests();
+    notAnonimizedLoans.add(
+        new NotAnonymizedRequest().withReason(reason).withRequestIds(ids));
+  }
+
+  private Future<RowSet<Row>> executeSql(PostgresClient postgresClient, String sql) {
+    final Promise<RowSet<Row>> promise = Promise.promise();
+
+    postgresClient.execute(sql, promise::handle);
+
+    return promise.future();
+  }
+
+  private String createAnonymizationSQL(@NotNull Collection<String> requestIdList,
+      String tenantId) {
+
+    String loanIds = requestIdList.stream()
+        .map(s -> "\'" + s + "\'")
+        .collect(Collectors.joining(",", "(", ")"));
+
+    final String AnonymizeStorageRequestsSql = String.format(
+        "TODO: Write the SQL",
+        tenantId, MODULE_NAME);
+
+    // Loan action history needs to go first, as needs to be for specific loans
+    return AnonymizeStorageRequestsSql;
+  }
+}

--- a/src/main/java/org/folio/rest/impl/AnonymizeStorageRequestsAPI.java
+++ b/src/main/java/org/folio/rest/impl/AnonymizeStorageRequestsAPI.java
@@ -106,7 +106,7 @@ public class AnonymizeStorageRequestsAPI implements AnonymizeStorageRequests {
         .map(s -> "\'" + s + "\'")
         .collect(Collectors.joining(",", "(", ")"));
 
-    final String AnonymizeStorageRequestsSql = String.format(
+    return String.format(
         new StringBuilder().append("UPDATE %s_%s.request ")
             .append(" SET jsonb = jsonb - ARRAY['requesterId', 'proxyUserId', 'requester', 'proxy']")
             .append(" WHERE request.id in ")
@@ -118,7 +118,5 @@ public class AnonymizeStorageRequestsAPI implements AnonymizeStorageRequests {
             .append(" OR request.jsonb->>'proxy' is NOT null)")
             .toString(),
         tenantId, MODULE_NAME);
-
-    return AnonymizeStorageRequestsSql;
   }
 }

--- a/src/main/java/org/folio/rest/impl/AnonymizeStorageRequestsAPI.java
+++ b/src/main/java/org/folio/rest/impl/AnonymizeStorageRequestsAPI.java
@@ -86,8 +86,8 @@ public class AnonymizeStorageRequestsAPI implements AnonymizeStorageRequests {
 
   private void addToNotAnonymizedRequests(AnonymizeStorageRequestsResponse response,
       String reason, List<String> ids) {
-    List<NotAnonymizedRequest> notAnonimizedLoans = response.getNotAnonymizedRequests();
-    notAnonimizedLoans.add(
+    List<NotAnonymizedRequest> notAnonymizedRequests = response.getNotAnonymizedRequests();
+    notAnonymizedRequests.add(
         new NotAnonymizedRequest().withReason(reason).withRequestIds(ids));
   }
 
@@ -102,15 +102,23 @@ public class AnonymizeStorageRequestsAPI implements AnonymizeStorageRequests {
   private String createAnonymizationSQL(@NotNull Collection<String> requestIdList,
       String tenantId) {
 
-    String loanIds = requestIdList.stream()
+    String requestIds = requestIdList.stream()
         .map(s -> "\'" + s + "\'")
         .collect(Collectors.joining(",", "(", ")"));
 
     final String AnonymizeStorageRequestsSql = String.format(
-        "TODO: Write the SQL",
+        new StringBuilder().append("UPDATE %s_%s.request ")
+            .append(" SET jsonb = jsonb - ARRAY['requesterId', 'proxyUserId', 'requester', 'proxy']")
+            .append(" WHERE request.id in ")
+            .append(requestIds)
+            .append(" AND request.jsonb->>'status' LIKE 'Closed - %%'")
+            .append(" AND (request.jsonb->>'requesterId' is NOT null")
+            .append(" OR request.jsonb->>'proxyUserId' is NOT null")
+            .append(" OR request.jsonb->>'requester' is NOT null")
+            .append(" OR request.jsonb->>'proxy' is NOT null)")
+            .toString(),
         tenantId, MODULE_NAME);
 
-    // Loan action history needs to go first, as needs to be for specific loans
     return AnonymizeStorageRequestsSql;
   }
 }

--- a/src/main/java/org/folio/rest/impl/AnonymizeStorageRequestsAPI.java
+++ b/src/main/java/org/folio/rest/impl/AnonymizeStorageRequestsAPI.java
@@ -46,6 +46,14 @@ public class AnonymizeStorageRequestsAPI implements AnonymizeStorageRequests {
     AnonymizeStorageRequestsResponse response = new AnonymizeStorageRequestsResponse();
     List<String> requestIds = request.getRequestIds();
 
+    if (requestIds == null || CollectionUtils.isEmpty(requestIds)) {
+      final Errors errors = ValidationHelper.createValidationErrorMessage(
+          "requestIds", "null", "Please provide valid requestIds");
+      responseHandler.handle(succeededFuture(
+          PostAnonymizeStorageRequestsResponse.respond422WithApplicationJson(errors)));
+      return;
+    }
+
     Map<Boolean, List<String>> requestIdsMap = requestIds.stream()
         .collect(Collectors.groupingBy(UUIDValidation::isValidUUID));
 

--- a/src/main/java/org/folio/rest/impl/AnonymizeStorageRequestsAPI.java
+++ b/src/main/java/org/folio/rest/impl/AnonymizeStorageRequestsAPI.java
@@ -53,7 +53,7 @@ public class AnonymizeStorageRequestsAPI implements AnonymizeStorageRequests {
     List<String> invalidIds = requestIdsMap.get(false);
 
     if (CollectionUtils.isNotEmpty(invalidIds)) {
-      log.warn("Invalid request UUIDs provided: {}", invalidIds);
+      log.warn("postAnonymizeStorageRequests:: Invalid request UUIDs provided: {}", invalidIds);
       addToNotAnonymizedRequests(response, "invalidRequestIds", invalidIds);
     }
 
@@ -65,7 +65,7 @@ public class AnonymizeStorageRequestsAPI implements AnonymizeStorageRequests {
       return;
     }
 
-    log.info("Anonymizing requests: {}", validIds.size());
+    log.info("postAnonymizeStorageRequests:: Anonymizing requests: {}", validIds.size());
 
     final String tenantId = TenantTool.tenantId(okapiHeaders);
     final PostgresClient postgresClient = PgUtil.postgresClient(vertxContext,

--- a/src/test/java/org/folio/rest/api/AnonymizeRequestsApiTest.java
+++ b/src/test/java/org/folio/rest/api/AnonymizeRequestsApiTest.java
@@ -4,6 +4,7 @@ import static org.folio.rest.api.StorageTestSuite.TENANT_ID;
 import static org.folio.rest.support.ResponseHandler.json;
 import static org.folio.rest.support.http.InterfaceUrls.anonymizeRequestsURL;
 import static org.folio.rest.support.matchers.RequestMatchers.isAnonymized;
+import static org.folio.rest.support.matchers.RequestMatchers.isNotAnonymized;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.core.Is.is;
@@ -47,6 +48,7 @@ class AnonymizeRequestsApiTest extends ApiTests {
         .withId(UUID.fromString(firstRequestId))
         .withItemId(UUID.randomUUID())
         .withRequesterId(UUID.randomUUID())
+        .withRequester("Jones", "Stuart", "Anthony", "6837502674015")
         .create()).getJson();
 
     JsonObject request2 = requestsClient.create(new RequestRequestBuilder()
@@ -55,6 +57,9 @@ class AnonymizeRequestsApiTest extends ApiTests {
         .withId(UUID.fromString(secondRequestId))
         .withItemId(UUID.randomUUID())
         .withRequesterId(UUID.randomUUID())
+        .withRequester("Jones", "Stuart", "Anthony", "6837502674015")
+        .withProxyId(UUID.randomUUID())
+        .withProxy("Stuart", "Rebecca", "6059539205")
         .create()).getJson();
 
     requestsClient.replace(firstRequestId, RequestRequestBuilder.from(request1).closed());
@@ -75,6 +80,46 @@ class AnonymizeRequestsApiTest extends ApiTests {
     assertThat(response.getAnonymizedRequests(), containsInAnyOrder(firstRequestId, secondRequestId));
     assertThat(requestsClient.getById(firstRequestId).getJson(), isAnonymized());
     assertThat(requestsClient.getById(secondRequestId).getJson(), isAnonymized());
+  }
+
+  @Test
+  void canAnonymizeAlreadyAnonymizedRequests() throws InterruptedException, ExecutionException,
+      TimeoutException, MalformedURLException {
+
+    var response = anonymizeRequests(firstRequestId, secondRequestId);
+
+    assertThat(response.getAnonymizedRequests(), containsInAnyOrder(firstRequestId, secondRequestId));
+    assertThat(requestsClient.getById(firstRequestId).getJson(), isAnonymized());
+    assertThat(requestsClient.getById(secondRequestId).getJson(), isAnonymized());
+
+    response = anonymizeRequests(firstRequestId, secondRequestId);
+
+    assertThat(response.getAnonymizedRequests(), containsInAnyOrder(firstRequestId, secondRequestId));
+    assertThat(requestsClient.getById(firstRequestId).getJson(), isAnonymized());
+    assertThat(requestsClient.getById(secondRequestId).getJson(), isAnonymized());
+  }
+
+  @Test
+  void onlyAnonymizesOpenRequests() throws InterruptedException, ExecutionException,
+      TimeoutException, MalformedURLException {
+
+    final var openRequestId = UUID.randomUUID().toString();
+
+    requestsClient.create(new RequestRequestBuilder()
+        .hold()
+        .toHoldShelf()
+        .withId(UUID.fromString(openRequestId))
+        .withItemId(UUID.randomUUID())
+        .withRequesterId(UUID.randomUUID())
+        .withRequester("Jones", "Stuart", "Anthony", "6837502674015")
+        .create()).getJson();
+
+    // This implementation is carried over from anonymizing loans
+    // The id is returned as anonymized but actually won't be unless criteria is met
+    final var response = anonymizeRequests(firstRequestId, secondRequestId, openRequestId);
+
+    assertThat(response.getAnonymizedRequests(), containsInAnyOrder(firstRequestId, secondRequestId, openRequestId));
+    assertThat(requestsClient.getById(openRequestId).getJson(), isNotAnonymized());
   }
 
   @Test

--- a/src/test/java/org/folio/rest/api/AnonymizeRequestsApiTest.java
+++ b/src/test/java/org/folio/rest/api/AnonymizeRequestsApiTest.java
@@ -114,10 +114,10 @@ class AnonymizeRequestsApiTest extends ApiTests {
         .withRequester("Jones", "Stuart", "Anthony", "6837502674015")
         .create()).getJson();
 
-    // This implementation is carried over from anonymizing loans
-    // The id is returned as anonymized but actually won't be unless criteria is met
     final var response = anonymizeRequests(firstRequestId, secondRequestId, openRequestId);
 
+    // This implementation is carried over from anonymizing loans
+    // The id is returned as anonymized but actually won't be unless criteria is met
     assertThat(response.getAnonymizedRequests(), containsInAnyOrder(firstRequestId, secondRequestId, openRequestId));
     assertThat(requestsClient.getById(openRequestId).getJson(), isNotAnonymized());
   }

--- a/src/test/java/org/folio/rest/api/AnonymizeRequestsApiTest.java
+++ b/src/test/java/org/folio/rest/api/AnonymizeRequestsApiTest.java
@@ -1,0 +1,120 @@
+package org.folio.rest.api;
+
+import static org.folio.rest.api.StorageTestSuite.TENANT_ID;
+import static org.folio.rest.support.ResponseHandler.json;
+import static org.folio.rest.support.http.InterfaceUrls.anonymizeRequestsURL;
+import static org.folio.rest.support.matchers.RequestMatchers.isAnonymized;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.core.Is.is;
+
+import java.net.MalformedURLException;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeoutException;
+
+import org.folio.rest.jaxrs.model.AnonymizeStorageRequestsResponse;
+import org.folio.rest.support.ApiTests;
+import org.folio.rest.support.JsonResponse;
+import org.folio.rest.support.builders.RequestRequestBuilder;
+import org.folio.rest.support.http.AssertingRecordClient;
+import org.folio.rest.support.http.InterfaceUrls;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+
+class AnonymizeRequestsApiTest extends ApiTests {
+  private final AssertingRecordClient requestsClient = new AssertingRecordClient(
+      client, TENANT_ID, InterfaceUrls::requestStorageUrl, "requests");
+
+  private final String firstRequestId = UUID.randomUUID().toString();
+  private final String secondRequestId = UUID.randomUUID().toString();
+
+  @BeforeEach
+  void beforeEach() throws MalformedURLException, InterruptedException,
+      ExecutionException, TimeoutException {
+
+    StorageTestSuite.deleteAll(InterfaceUrls.requestStorageUrl());
+
+    JsonObject request1 = requestsClient.create(new RequestRequestBuilder()
+        .hold()
+        .toHoldShelf()
+        .withId(UUID.fromString(firstRequestId))
+        .withItemId(UUID.randomUUID())
+        .withRequesterId(UUID.randomUUID())
+        .create()).getJson();
+
+    JsonObject request2 = requestsClient.create(new RequestRequestBuilder()
+        .hold()
+        .toHoldShelf()
+        .withId(UUID.fromString(secondRequestId))
+        .withItemId(UUID.randomUUID())
+        .withRequesterId(UUID.randomUUID())
+        .create()).getJson();
+
+    requestsClient.replace(firstRequestId, RequestRequestBuilder.from(request1).closed());
+    requestsClient.replace(secondRequestId, RequestRequestBuilder.from(request2).closed());
+  }
+
+  @AfterEach
+  void checkIdsAfterEach() {
+    StorageTestSuite.checkForMismatchedIDs("request");
+  }
+
+  @Test
+  void canAnonymizeRequests() throws InterruptedException, ExecutionException,
+      TimeoutException, MalformedURLException {
+
+    final var response = anonymizeRequests(firstRequestId, secondRequestId);
+
+    assertThat(response.getAnonymizedRequests(), containsInAnyOrder(firstRequestId, secondRequestId));
+    assertThat(requestsClient.getById(firstRequestId).getJson(), isAnonymized());
+    assertThat(requestsClient.getById(secondRequestId).getJson(), isAnonymized());
+  }
+
+  @Test
+  void canNotAnonymizeEmptyList() throws MalformedURLException {
+    JsonResponse response = attemptAnonymizeRequests();
+
+    assertThat(response.getStatusCode(), is(422));
+  }
+
+  @Test
+  void canAnonymizeInvalidAndValidUuids() throws MalformedURLException {
+    final String firstNotValidId = "not valid";
+    final String secondNotValidId = "null";
+
+    final var response = anonymizeRequests(firstRequestId, secondRequestId,
+        firstNotValidId, secondNotValidId);
+
+    assertThat(response.getAnonymizedRequests(), containsInAnyOrder(firstRequestId, secondRequestId));
+    assertThat(response.getNotAnonymizedRequests().size(), is(1));
+    assertThat(response.getNotAnonymizedRequests().get(0).getReason(), is("invalidRequestIds"));
+    assertThat(response.getNotAnonymizedRequests().get(0).getRequestIds(),
+        containsInAnyOrder(firstNotValidId, secondNotValidId));
+  }
+
+  private AnonymizeStorageRequestsResponse anonymizeRequests(String... requestIds) throws MalformedURLException {
+    final JsonResponse response = attemptAnonymizeRequests(requestIds);
+
+    assertThat(response.getStatusCode(), is(200));
+
+    return response.getJson().mapTo(AnonymizeStorageRequestsResponse.class);
+  }
+
+  private JsonResponse attemptAnonymizeRequests(String... requestIds) throws MalformedURLException {
+    final var requestBody = new JsonObject()
+        .put("requestIds", new JsonArray(List.of(requestIds)));
+
+    final var completed = new CompletableFuture<JsonResponse>();
+
+    client.post(anonymizeRequestsURL(), requestBody, TENANT_ID, json(completed));
+
+    return get(completed);
+  }
+}

--- a/src/test/java/org/folio/rest/support/builders/RequestRequestBuilder.java
+++ b/src/test/java/org/folio/rest/support/builders/RequestRequestBuilder.java
@@ -108,10 +108,33 @@ public class RequestRequestBuilder extends JsonBuilder implements Builder {
     final UUID requesterId = example.containsKey("requesterId")
         ? UUID.fromString(example.getString("requesterId"))
         : null;
+    PatronSummary requesterSummary = null;
+
+    if (example.containsKey("requester")) {
+      JsonObject requester = example.getJsonObject("requester");
+
+      requesterSummary = new PatronSummary(
+          requester.getString("lastName"),
+          requester.getString("firstName"),
+          requester.getString("middleName"),
+          requester.getString("barcode"));
+    }
 
     final UUID proxyId = example.containsKey("proxyUserId")
         ? UUID.fromString(example.getString("proxyUserId"))
         : null;
+
+    PatronSummary proxySummary = null;
+
+    if (example.containsKey("proxy")) {
+      JsonObject proxy = example.getJsonObject("proxy");
+
+      proxySummary = new PatronSummary(
+          proxy.getString("lastName"),
+          proxy.getString("firstName"),
+          proxy.getString("middleName"),
+          proxy.getString("barcode"));
+    }
 
     final UUID deliveryAddressTypeId = example.containsKey("deliveryAddressTypeId")
         ? UUID.fromString(example.getString("deliveryAddressTypeId"))
@@ -159,8 +182,8 @@ public class RequestRequestBuilder extends JsonBuilder implements Builder {
         requestExpirationDate,
         holdShelfExpirationDate,
         null,
-        null,
-        null,
+        requesterSummary,
+        proxySummary,
         example.getString("status"),
         cancellationReasonId,
         cancelledByUserId,
@@ -478,7 +501,7 @@ public class RequestRequestBuilder extends JsonBuilder implements Builder {
     return withPosition(null);
   }
 
-  private class PatronSummary {
+  private static class PatronSummary {
     final String lastName;
     final String firstName;
     final String middleName;

--- a/src/test/java/org/folio/rest/support/builders/RequestRequestBuilder.java
+++ b/src/test/java/org/folio/rest/support/builders/RequestRequestBuilder.java
@@ -14,7 +14,7 @@ import java.util.stream.Collectors;
 
 @AllArgsConstructor
 @With
-public class RequestRequestBuilder extends JsonBuilder {
+public class RequestRequestBuilder extends JsonBuilder implements Builder {
   public static final String OPEN_NOT_YET_FILLED = "Open - Not yet filled";
   public static final String OPEN_AWAITING_PICKUP = "Open - Awaiting pickup";
   public static final String OPEN_IN_TRANSIT = "Open - In transit";
@@ -82,6 +82,98 @@ public class RequestRequestBuilder extends JsonBuilder {
       null,
       null,
       null);
+  }
+
+  public static RequestRequestBuilder from(JsonObject example) {
+    final UUID id = example.containsKey("id")
+        ? UUID.fromString(example.getString("id"))
+        : null;
+
+    final UUID holdingsRecordId = example.containsKey("holdingsRecordId")
+        ? UUID.fromString(example.getString("holdingsRecordId"))
+        : null;
+
+    final DateTime requestDate = example.containsKey("requestDate")
+        ? DateTime.parse(example.getString("requestDate"))
+        : null;
+
+    final UUID itemId = example.containsKey("itemId")
+        ? UUID.fromString(example.getString("itemId"))
+        : null;
+
+    final UUID instanceId = example.containsKey("instanceId")
+        ? UUID.fromString(example.getString("instanceId"))
+        : null;
+
+    final UUID requesterId = example.containsKey("requesterId")
+        ? UUID.fromString(example.getString("requesterId"))
+        : null;
+
+    final UUID proxyId = example.containsKey("proxyUserId")
+        ? UUID.fromString(example.getString("proxyUserId"))
+        : null;
+
+    final UUID deliveryAddressTypeId = example.containsKey("deliveryAddressTypeId")
+        ? UUID.fromString(example.getString("deliveryAddressTypeId"))
+        : null;
+
+    final DateTime requestExpirationDate = example.containsKey("requestExpirationDate")
+        ? DateTime.parse(example.getString("requestExpirationDate"))
+        : null;
+
+    final DateTime holdShelfExpirationDate = example.containsKey("holdShelfExpirationDate")
+        ? DateTime.parse(example.getString("holdShelfExpirationDate"))
+        : null;
+
+    final UUID cancellationReasonId = example.containsKey("cancellationReasonId")
+        ? UUID.fromString(example.getString("cancellationReasonId"))
+        : null;
+
+    final UUID cancelledByUserId = example.containsKey("cancelledByUserId")
+        ? UUID.fromString(example.getString("cancelledByUserId"))
+        : null;
+
+    final DateTime cancelledDate = example.containsKey("cancelledDate")
+        ? DateTime.parse(example.getString("cancelledDate"))
+        : null;
+
+    final UUID pickupServicePointId = example.containsKey("pickupServicePointId")
+        ? UUID.fromString(example.getString("pickupServicePointId"))
+        : null;
+
+    SearchIndex searchIndex = example.containsKey("searchIndex")
+        ? example.getJsonObject("searchIndex").mapTo(SearchIndex.class)
+        : null;
+
+    return new RequestRequestBuilder(
+        id,
+        example.getString("requestType"),
+        example.getString("requestLevel"),
+        requestDate,
+        itemId,
+        instanceId,
+        requesterId,
+        proxyId,
+        example.getString("fulfillmentPreference"),
+        deliveryAddressTypeId,
+        requestExpirationDate,
+        holdShelfExpirationDate,
+        null,
+        null,
+        null,
+        example.getString("status"),
+        cancellationReasonId,
+        cancelledByUserId,
+        example.getString("cancellationAdditionalInformation"),
+        cancelledDate,
+        example.getInteger("position"),
+        pickupServicePointId,
+        null,
+        example.getString("patronComments"),
+        holdingsRecordId,
+        searchIndex,
+        example.getString("itemLocationCode"),
+        example.getString("ecsRequestPhase"));
   }
 
   public JsonObject create() {
@@ -187,6 +279,14 @@ public class RequestRequestBuilder extends JsonBuilder {
 
   public RequestRequestBuilder page() {
     return withRequestType("Page");
+  }
+
+  public RequestRequestBuilder closed(String reason) {
+    return withStatus(reason);
+  }
+
+  public RequestRequestBuilder closed() {
+    return closed(CLOSED_FILLED);
   }
 
   public RequestRequestBuilder withNoId() {

--- a/src/test/java/org/folio/rest/support/http/InterfaceUrls.java
+++ b/src/test/java/org/folio/rest/support/http/InterfaceUrls.java
@@ -18,6 +18,16 @@ public class InterfaceUrls {
     return storageUrl("/loan-storage/loans" + subPath);
   }
 
+  public static URL requestStorageUrl() throws MalformedURLException {
+    return requestStorageUrl("");
+  }
+
+  public static URL requestStorageUrl(String subPath)
+    throws MalformedURLException {
+
+    return storageUrl("/request-storage/requests" + subPath);
+  }
+
   public static URL actualCostRecord(String subPath) throws MalformedURLException {
     return storageUrl("/actual-cost-record-storage/actual-cost-records" + subPath);
   }
@@ -34,6 +44,10 @@ public class InterfaceUrls {
 
   public static URL anonymizeLoansURL() throws MalformedURLException {
     return storageUrl("/anonymize-storage-loans");
+  }
+
+  public static URL anonymizeRequestsURL() throws MalformedURLException {
+    return storageUrl("/anonymize-storage-requests");
   }
 
   public static URL checkInsStorageUrl(String subPath) throws MalformedURLException {

--- a/src/test/java/org/folio/rest/support/matchers/RequestMatchers.java
+++ b/src/test/java/org/folio/rest/support/matchers/RequestMatchers.java
@@ -1,0 +1,63 @@
+package org.folio.rest.support.matchers;
+
+import static org.hamcrest.CoreMatchers.startsWith;
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.TypeSafeDiagnosingMatcher;
+import io.vertx.core.json.JsonObject;
+
+public class RequestMatchers {
+  public static TypeSafeDiagnosingMatcher<JsonObject> isOpen() {
+    return hasStatus("Open");
+  }
+
+  public static TypeSafeDiagnosingMatcher<JsonObject> isClosed() {
+    return hasStatus("Closed");
+  }
+
+  public static TypeSafeDiagnosingMatcher<JsonObject> isAnonymized() {
+    return doesNotHaveRequesterId();
+  }
+
+  static TypeSafeDiagnosingMatcher<JsonObject> hasStatus(String status) {
+    return new TypeSafeDiagnosingMatcher<JsonObject>() {
+      @Override
+      public void describeTo(Description description) {
+        description.appendText("Request should have a status of ")
+            .appendText(status);
+      }
+
+      @Override
+      protected boolean matchesSafely(JsonObject representation,
+          Description description) {
+        if (!representation.containsKey("status")) {
+          description.appendText("has no status property");
+          return false;
+        }
+
+        final Matcher<String> statusMatcher = startsWith(status);
+
+        final String statusName = representation.getString("status");
+
+        statusMatcher.describeMismatch(statusName, description);
+
+        return statusMatcher.matches(statusName);
+      }
+    };
+  }
+
+  static TypeSafeDiagnosingMatcher<JsonObject> doesNotHaveRequesterId() {
+    return new TypeSafeDiagnosingMatcher<JsonObject>() {
+      @Override
+      public void describeTo(Description description) {
+        description.appendText("Anonymized Request should not have a requesterId");
+      }
+
+      @Override
+      protected boolean matchesSafely(JsonObject representation,
+          Description description) {
+        return !representation.containsKey("requesterId");
+      }
+    };
+  }
+}

--- a/src/test/java/org/folio/rest/support/matchers/RequestMatchers.java
+++ b/src/test/java/org/folio/rest/support/matchers/RequestMatchers.java
@@ -3,6 +3,9 @@ package org.folio.rest.support.matchers;
 import static org.hamcrest.CoreMatchers.startsWith;
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.anyOf;
 import org.hamcrest.TypeSafeDiagnosingMatcher;
 import io.vertx.core.json.JsonObject;
 
@@ -15,8 +18,20 @@ public class RequestMatchers {
     return hasStatus("Closed");
   }
 
-  public static TypeSafeDiagnosingMatcher<JsonObject> isAnonymized() {
-    return doesNotHaveRequesterId();
+  public static Matcher<JsonObject> isAnonymized() {
+    return allOf(
+        not(hasRequesterId()),
+        not(hasRequesterSummary()),
+        not(hasProxyUserId()),
+        not(hasProxySummary()));
+  }
+
+  public static Matcher<JsonObject> isNotAnonymized() {
+    return anyOf(
+        hasRequesterId(),
+        hasRequesterSummary(),
+        hasProxyUserId(),
+        hasProxySummary());
   }
 
   static TypeSafeDiagnosingMatcher<JsonObject> hasStatus(String status) {
@@ -46,18 +61,64 @@ public class RequestMatchers {
     };
   }
 
-  static TypeSafeDiagnosingMatcher<JsonObject> doesNotHaveRequesterId() {
+  static TypeSafeDiagnosingMatcher<JsonObject> hasRequesterId() {
     return new TypeSafeDiagnosingMatcher<JsonObject>() {
       @Override
       public void describeTo(Description description) {
-        description.appendText("Anonymized Request should not have a requesterId");
+        description.appendText("have a requesterId");
       }
 
       @Override
       protected boolean matchesSafely(JsonObject representation,
           Description description) {
-        return !representation.containsKey("requesterId");
+        return representation.containsKey("requesterId");
       }
     };
   }
+
+  static TypeSafeDiagnosingMatcher<JsonObject> hasRequesterSummary() {
+    return new TypeSafeDiagnosingMatcher<JsonObject>() {
+      @Override
+      public void describeTo(Description description) {
+        description.appendText("have requester summary");
+      }
+
+      @Override
+      protected boolean matchesSafely(JsonObject representation,
+          Description description) {
+        return representation.containsKey("requester");
+      }
+    };
+  }
+
+  static TypeSafeDiagnosingMatcher<JsonObject> hasProxyUserId() {
+    return new TypeSafeDiagnosingMatcher<JsonObject>() {
+      @Override
+      public void describeTo(Description description) {
+        description.appendText("have a proxyUserId");
+      }
+
+      @Override
+      protected boolean matchesSafely(JsonObject representation,
+          Description description) {
+        return representation.containsKey("proxyUserId");
+      }
+    };
+  }
+
+  static TypeSafeDiagnosingMatcher<JsonObject> hasProxySummary() {
+    return new TypeSafeDiagnosingMatcher<JsonObject>() {
+      @Override
+      public void describeTo(Description description) {
+        description.appendText("have proxy summary");
+      }
+
+      @Override
+      protected boolean matchesSafely(JsonObject representation,
+          Description description) {
+        return representation.containsKey("proxy");
+      }
+    };
+  }
+
 }


### PR DESCRIPTION
I took the code from the Anonymizing Loans codepaths and used it to implement Anonymization for requests. Reusing the loan implementation carries over at least one weirdness where we don't actually check if an id can be anonymized, we just don't anonymize it and tell the user we did. There's probably more that I'm not aware of.

I'm picking up this work because the initial developers have other commitments now. This PR is _I think_ implementing this ticket: https://folio-org.atlassian.net/browse/CIRCSTORE-647 .