### PR TITLE
CIRCSTORE-665: Remove unused org.glassfish.web:javax.el

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -125,11 +125,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.glassfish.web</groupId>
-      <artifactId>javax.el</artifactId>
-      <version>2.2.4</version>
-    </dependency>
-    <dependency>
       <groupId>org.projectlombok</groupId>
       <artifactId>lombok</artifactId>
       <version>1.18.36</version>


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/CIRCSTORE-665

https://github.com/folio-org/mod-circulation-storage/commit/977fd9c58ff16fe13b2c08137d1bca9e172ecb0a has added org.glassfish.web:javax.el but has never used it.

Remove this unused dependency.