### PR TITLE
UXPROD-5562: spike - storage support for self-draining loan anonymization

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -100,6 +100,32 @@
       ]
     },
     {
+      "id": "anonymization-due-date-storage",
+      "version": "0.1",
+      "handlers": [
+        {
+          "methods": ["POST"],
+          "pathPattern": "/anonymization-due-date-storage/stamp",
+          "permissionsRequired": ["anonymization-due-date-storage.stamp.post"]
+        },
+        {
+          "methods": ["POST"],
+          "pathPattern": "/anonymization-due-date-storage/clear",
+          "permissionsRequired": ["anonymization-due-date-storage.clear.post"]
+        },
+        {
+          "methods": ["GET"],
+          "pathPattern": "/anonymization-due-date-storage/due",
+          "permissionsRequired": ["anonymization-due-date-storage.due.get"]
+        },
+        {
+          "methods": ["GET"],
+          "pathPattern": "/anonymization-due-date-storage/unevaluated",
+          "permissionsRequired": ["anonymization-due-date-storage.unevaluated.get"]
+        }
+      ]
+    },
+    {
       "id": "circulation-rules-storage",
       "version": "1.0",
       "handlers": [
@@ -772,6 +798,26 @@
       "description": "anonymize a list of loans"
     },
     {
+      "permissionName": "anonymization-due-date-storage.stamp.post",
+      "displayName": "circulation - stamp anonymization due dates",
+      "description": "set the anonymization due-date on closed loans (scheduled job only)"
+    },
+    {
+      "permissionName": "anonymization-due-date-storage.clear.post",
+      "displayName": "circulation - clear anonymization due dates",
+      "description": "clear anonymization due-dates so loans are re-evaluated"
+    },
+    {
+      "permissionName": "anonymization-due-date-storage.due.get",
+      "displayName": "circulation - find loans due for anonymization",
+      "description": "closed loans whose derived due-date has arrived (scheduled anonymization drain)"
+    },
+    {
+      "permissionName": "anonymization-due-date-storage.unevaluated.get",
+      "displayName": "circulation - find unevaluated closed loans",
+      "description": "closed loans with no derived due-date row yet (scheduled anonymization evaluation sweep)"
+    },
+    {
       "permissionName": "circulation-storage.circulation-rules.get",
       "displayName": "Circulation storage - get circulation rules",
       "description": "Get circulation rules from storage"
@@ -1145,6 +1191,10 @@
         "scheduled-notice-storage.scheduled-notices.item.delete",
         "scheduled-notice-storage.scheduled-notices.collection.delete",
         "anonymize-storage-loans.post",
+        "anonymization-due-date-storage.stamp.post",
+        "anonymization-due-date-storage.clear.post",
+        "anonymization-due-date-storage.due.get",
+        "anonymization-due-date-storage.unevaluated.get",
         "patron-action-session-storage.patron-action-sessions.collection.get",
         "patron-action-session-storage.patron-action-sessions.item.get",
         "patron-action-session-storage.patron-action-sessions.item.post",

--- a/ramls/anonymization-due-date-clear-request.json
+++ b/ramls/anonymization-due-date-clear-request.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "description": "Remove due-date rows so the affected loans are re-evaluated by the next sweep. Exactly one of loanIds, all must be provided",
+  "type": "object",
+  "properties": {
+    "loanIds": {
+      "description": "Clear the stamp on these loans (fee/fine closure)",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "all": {
+      "description": "Clear every stamp in the tenant, in batches (loan_history policy change). Potentially long-running on large tenants",
+      "type": "boolean"
+    }
+  },
+  "additionalProperties": false
+}

--- a/ramls/anonymization-due-date-response.json
+++ b/ramls/anonymization-due-date-response.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "description": "Result of a stamp or clear operation",
+  "type": "object",
+  "properties": {
+    "updated": {
+      "description": "Number of loan records actually updated",
+      "type": "integer"
+    }
+  },
+  "required": ["updated"],
+  "additionalProperties": false
+}

--- a/ramls/anonymization-due-date-stamp-request.json
+++ b/ramls/anonymization-due-date-stamp-request.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "description": "Upsert the due-date for closed loans into the loan_anonymization_due table. Written only by the scheduled anonymization job",
+  "type": "object",
+  "properties": {
+    "entries": {
+      "description": "Loans to stamp",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "loanId": {
+            "description": "Loan id (UUID)",
+            "type": "string"
+          },
+          "dueAt": {
+            "description": "ISO-8601 instant at which the loan becomes eligible. Omit the property to record the 'retain under current policy' (never) state",
+            "type": "string"
+          }
+        },
+        "required": [
+          "loanId"
+        ],
+        "additionalProperties": false
+      }
+    }
+  },
+  "required": [
+    "entries"
+  ],
+  "additionalProperties": false
+}

--- a/ramls/anonymization-due-date-storage.raml
+++ b/ramls/anonymization-due-date-storage.raml
@@ -1,0 +1,106 @@
+#%RAML 1.0
+title: Anonymization due date storage
+version: v0.1
+protocols: [ HTTP, HTTPS ]
+baseUri: http://localhost:9130
+
+documentation:
+  - title: Anonymization due date storage API
+    content: <b>Internal maintenance and finders for the derived anonymization
+      due-date in the loan_anonymization_due table. Stamp is called only by the
+      scheduled anonymization job; clear is called by invalidation hooks. The
+      due and unevaluated finders drive the drain and evaluation passes.</b>
+
+types:
+  errors: !include raml-util/schemas/errors.schema
+  loans: !include loans.json
+  anonymization-due-date-stamp-request: !include anonymization-due-date-stamp-request.json
+  anonymization-due-date-clear-request: !include anonymization-due-date-clear-request.json
+  anonymization-due-date-response: !include anonymization-due-date-response.json
+
+traits:
+  validate: !include raml-util/traits/validation.raml
+
+/anonymization-due-date-storage:
+  /stamp:
+    post:
+      is: [validate]
+      body:
+        application/json:
+          type: anonymization-due-date-stamp-request
+      responses:
+        200:
+          description: "Loans stamped"
+          body:
+            application/json:
+              type: anonymization-due-date-response
+        422:
+          description: "Validation error (malformed loan id or due date)"
+          body:
+            application/json:
+              type: errors
+        500:
+          description: "Internal server error"
+          body:
+            text/plain:
+              example: "Internal server error, contact administrator"
+  /clear:
+    post:
+      is: [validate]
+      body:
+        application/json:
+          type: anonymization-due-date-clear-request
+      responses:
+        200:
+          description: "Stamps cleared"
+          body:
+            application/json:
+              type: anonymization-due-date-response
+        422:
+          description: "Validation error (exactly one of loanIds, all required)"
+          body:
+            application/json:
+              type: errors
+        500:
+          description: "Internal server error"
+          body:
+            text/plain:
+              example: "Internal server error, contact administrator"
+  /due:
+    get:
+      description: "Closed loans with a userId whose due_at has arrived, oldest first (drain pass)"
+      queryParameters:
+        limit:
+          description: "Maximum number of loans to return"
+          type: integer
+          required: false
+          default: 50000
+      responses:
+        200:
+          body:
+            application/json:
+              type: loans
+        500:
+          description: "Internal server error"
+          body:
+            text/plain:
+              example: "Internal server error, contact administrator"
+  /unevaluated:
+    get:
+      description: "Closed loans with a userId that have no due-date row yet (evaluation pass)"
+      queryParameters:
+        limit:
+          description: "Maximum number of loans to return"
+          type: integer
+          required: false
+          default: 50000
+      responses:
+        200:
+          body:
+            application/json:
+              type: loans
+        500:
+          description: "Internal server error"
+          body:
+            text/plain:
+              example: "Internal server error, contact administrator"

--- a/src/main/java/org/folio/rest/impl/AnonymizationDueDateAPI.java
+++ b/src/main/java/org/folio/rest/impl/AnonymizationDueDateAPI.java
@@ -1,0 +1,148 @@
+package org.folio.rest.impl;
+
+import static io.vertx.core.Future.succeededFuture;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import javax.ws.rs.core.Response;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.folio.rest.annotations.Validate;
+import org.folio.rest.jaxrs.model.AnonymizationDueDateClearRequest;
+import org.folio.rest.jaxrs.model.AnonymizationDueDateResponse;
+import org.folio.rest.jaxrs.model.AnonymizationDueDateStampRequest;
+import org.folio.rest.jaxrs.model.Loans;
+import org.folio.rest.jaxrs.resource.AnonymizationDueDateStorage;
+import org.folio.rest.tools.utils.ValidationHelper;
+import org.folio.service.anonymization.AnonymizationDueDateService;
+import org.folio.service.anonymization.AnonymizationDueDateService.StampEntry;
+
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Context;
+import io.vertx.core.Handler;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+
+/**
+ * Endpoints for the {@code loan_anonymization_due} table. See
+ * {@link AnonymizationDueDateService} for semantics.
+ */
+public class AnonymizationDueDateAPI implements AnonymizationDueDateStorage {
+  private static final Logger log = LogManager.getLogger();
+
+  @Validate
+  @Override
+  public void postAnonymizationDueDateStorageStamp(
+    AnonymizationDueDateStampRequest request, Map<String, String> okapiHeaders,
+    Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
+
+    final List<StampEntry> entries = request.getEntries().stream()
+      .map(e -> new StampEntry(e.getLoanId(), e.getDueAt()))
+      .collect(Collectors.toList());
+
+    log.info("postAnonymizationDueDateStorageStamp:: stamping {} loans", entries.size());
+
+    new AnonymizationDueDateService(vertxContext, okapiHeaders)
+      .stamp(entries)
+      .onSuccess(updated -> asyncResultHandler.handle(succeededFuture(
+        PostAnonymizationDueDateStorageStampResponse.respond200WithApplicationJson(
+          new AnonymizationDueDateResponse().withUpdated(updated)))))
+      .onFailure(t -> asyncResultHandler.handle(succeededFuture(mapStampFailure(t))));
+  }
+
+  private Response mapStampFailure(Throwable t) {
+    if (t instanceof IllegalArgumentException) {
+      return PostAnonymizationDueDateStorageStampResponse.respond422WithApplicationJson(
+        ValidationHelper.createValidationErrorMessage("entries", "", t.getMessage()));
+    }
+    log.error("mapStampFailure:: stamp failed", t);
+    return PostAnonymizationDueDateStorageStampResponse.respond500WithTextPlain(t.getMessage());
+  }
+
+  @Validate
+  @Override
+  public void postAnonymizationDueDateStorageClear(
+    AnonymizationDueDateClearRequest request, Map<String, String> okapiHeaders,
+    Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
+
+    final boolean byLoans = request.getLoanIds() != null && !request.getLoanIds().isEmpty();
+    final boolean all = Boolean.TRUE.equals(request.getAll());
+
+    if ((byLoans ? 1 : 0) + (all ? 1 : 0) != 1) {
+      asyncResultHandler.handle(succeededFuture(
+        PostAnonymizationDueDateStorageClearResponse.respond422WithApplicationJson(
+          ValidationHelper.createValidationErrorMessage("loanIds|all", "",
+            "Exactly one of loanIds, all must be provided"))));
+      return;
+    }
+
+    final AnonymizationDueDateService service =
+      new AnonymizationDueDateService(vertxContext, okapiHeaders);
+
+    final io.vertx.core.Future<Integer> result = byLoans
+      ? service.clearByLoanIds(request.getLoanIds())
+      : service.clearAll();
+
+    result
+      .onSuccess(cleared -> {
+        log.info("postAnonymizationDueDateStorageClear:: cleared {} rows", cleared);
+        asyncResultHandler.handle(succeededFuture(
+          PostAnonymizationDueDateStorageClearResponse.respond200WithApplicationJson(
+            new AnonymizationDueDateResponse().withUpdated(cleared))));
+      })
+      .onFailure(t -> asyncResultHandler.handle(succeededFuture(mapClearFailure(t))));
+  }
+
+  private Response mapClearFailure(Throwable t) {
+    if (t instanceof IllegalArgumentException) {
+      return PostAnonymizationDueDateStorageClearResponse.respond422WithApplicationJson(
+        ValidationHelper.createValidationErrorMessage("loanIds|all", "", t.getMessage()));
+    }
+    log.error("mapClearFailure:: clear failed", t);
+    return PostAnonymizationDueDateStorageClearResponse.respond500WithTextPlain(t.getMessage());
+  }
+
+  @Validate
+  @Override
+  public void getAnonymizationDueDateStorageDue(int limit, Map<String, String> okapiHeaders,
+    Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
+
+    new AnonymizationDueDateService(vertxContext, okapiHeaders).findDue(limit)
+      .onSuccess(loans -> asyncResultHandler.handle(succeededFuture(
+        GetAnonymizationDueDateStorageDueResponse.respond200WithApplicationJson(toLoans(loans)))))
+      .onFailure(t -> {
+        log.error("getAnonymizationDueDateStorageDue:: finder failed", t);
+        asyncResultHandler.handle(succeededFuture(
+          GetAnonymizationDueDateStorageDueResponse.respond500WithTextPlain(t.getMessage())));
+      });
+  }
+
+  @Validate
+  @Override
+  public void getAnonymizationDueDateStorageUnevaluated(int limit, Map<String, String> okapiHeaders,
+    Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
+
+    new AnonymizationDueDateService(vertxContext, okapiHeaders).findUnevaluated(limit)
+      .onSuccess(loans -> asyncResultHandler.handle(succeededFuture(
+        GetAnonymizationDueDateStorageUnevaluatedResponse.respond200WithApplicationJson(toLoans(loans)))))
+      .onFailure(t -> {
+        log.error("getAnonymizationDueDateStorageUnevaluated:: finder failed", t);
+        asyncResultHandler.handle(succeededFuture(
+          GetAnonymizationDueDateStorageUnevaluatedResponse.respond500WithTextPlain(t.getMessage())));
+      });
+  }
+
+  /**
+   * The finders return whole loans (not ids) so the scheduled job needs no
+   * follow-up fetch.
+   */
+  private Loans toLoans(JsonArray loans) {
+    return new JsonObject()
+      .put("loans", loans)
+      .put("totalRecords", loans.size())
+      .mapTo(Loans.class);
+  }
+}

--- a/src/main/java/org/folio/rest/impl/AnonymizationDueDateAPI.java
+++ b/src/main/java/org/folio/rest/impl/AnonymizationDueDateAPI.java
@@ -4,7 +4,6 @@ import static io.vertx.core.Future.succeededFuture;
 
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 import javax.ws.rs.core.Response;
 
@@ -41,7 +40,7 @@ public class AnonymizationDueDateAPI implements AnonymizationDueDateStorage {
 
     final List<StampEntry> entries = request.getEntries().stream()
       .map(e -> new StampEntry(e.getLoanId(), e.getDueAt()))
-      .collect(Collectors.toList());
+      .toList();
 
     log.info("postAnonymizationDueDateStorageStamp:: stamping {} loans", entries.size());
 

--- a/src/main/java/org/folio/rest/impl/AnonymizeStorageLoansAPI.java
+++ b/src/main/java/org/folio/rest/impl/AnonymizeStorageLoansAPI.java
@@ -118,6 +118,12 @@ public class AnonymizeStorageLoansAPI implements AnonymizeStorageLoans {
         .toString(),
       tenantId, MODULE_NAME);
 
+    // Remove the loan's due-date row. The text literals cast to the uuid
+    // loan_id column implicitly.
+    final String AnonymizeDueDateSql = String.format(
+      "DELETE FROM %s_%s.loan_anonymization_due WHERE loan_id IN %s",
+      tenantId, MODULE_NAME, loanIds);
+
     // Only anonymize the history for loans that are currently closed
     // meaning that we need to refer to loans in this query
     final String AnonymizeStorageLoansActionHistorySql = String.format(
@@ -133,6 +139,7 @@ public class AnonymizeStorageLoansAPI implements AnonymizeStorageLoans {
       tenantId, MODULE_NAME, LOAN_HISTORY_TABLE, tenantId, MODULE_NAME);
 
     // Loan action history needs to go first, as needs to be for specific loans
-    return AnonymizeStorageLoansActionHistorySql + "; " + AnonymizeStorageLoansSql;
+    return AnonymizeStorageLoansActionHistorySql + "; " + AnonymizeStorageLoansSql
+      + "; " + AnonymizeDueDateSql;
   }
 }

--- a/src/main/java/org/folio/service/anonymization/AnonymizationDueDateService.java
+++ b/src/main/java/org/folio/service/anonymization/AnonymizationDueDateService.java
@@ -48,7 +48,7 @@ public class AnonymizationDueDateService {
    */
   public Future<Integer> stamp(List<StampEntry> entries) {
     for (StampEntry entry : entries) {
-      if (!UUIDValidation.isValidUUID(entry.loanId())) {
+      if (!Boolean.TRUE.equals(UUIDValidation.isValidUUID(entry.loanId()))) {
         return Future.failedFuture(new IllegalArgumentException(
           "Invalid loan id: " + entry.loanId()));
       }
@@ -81,7 +81,7 @@ public class AnonymizationDueDateService {
   /** Return specific loans to the unevaluated state. */
   public Future<Integer> clearByLoanIds(List<String> loanIds) {
     for (String loanId : loanIds) {
-      if (!UUIDValidation.isValidUUID(loanId)) {
+      if (!Boolean.TRUE.equals(UUIDValidation.isValidUUID(loanId))) {
         return Future.failedFuture(new IllegalArgumentException("Invalid loan id: " + loanId));
       }
     }

--- a/src/main/java/org/folio/service/anonymization/AnonymizationDueDateService.java
+++ b/src/main/java/org/folio/service/anonymization/AnonymizationDueDateService.java
@@ -1,0 +1,142 @@
+package org.folio.service.anonymization;
+
+import static java.lang.String.format;
+
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+import org.folio.rest.persist.PgUtil;
+import org.folio.rest.persist.PostgresClient;
+import org.folio.rest.tools.utils.TenantTool;
+import org.folio.support.ModuleConstants;
+import org.folio.support.UUIDValidation;
+
+import io.vertx.core.Context;
+import io.vertx.core.Future;
+import io.vertx.core.json.JsonArray;
+import io.vertx.sqlclient.Row;
+import io.vertx.sqlclient.RowSet;
+
+/**
+ * Maintenance and finders for the {@code loan_anonymization_due} table. Three
+ * row states: absent = unevaluated; {@code due_at} set = due at that instant;
+ * {@code due_at} NULL = retain under the current policy. Only the scheduled job
+ * calls {@link #stamp}; other callers may only {@code clear}.
+ */
+public class AnonymizationDueDateService {
+
+  /** Accepted {@code due_at} format; validated before interpolation into SQL. */
+  private static final Pattern ISO_INSTANT =
+    Pattern.compile("\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,3})?(Z|[+-]\\d{2}:?\\d{2})");
+
+  private static final String TABLE = "loan_anonymization_due";
+
+  private final PostgresClient postgresClient;
+  private final String schemaName;
+
+  public AnonymizationDueDateService(Context vertxContext, Map<String, String> okapiHeaders) {
+    this.postgresClient = PgUtil.postgresClient(vertxContext, okapiHeaders);
+    this.schemaName = format("%s_%s", TenantTool.tenantId(okapiHeaders),
+      ModuleConstants.MODULE_NAME);
+  }
+
+  /**
+   * Upserts one due-date per loan. Only closed loans that still carry a userId
+   * are touched (the join drops the rest). A null {@code dueAt} records retain.
+   */
+  public Future<Integer> stamp(List<StampEntry> entries) {
+    for (StampEntry entry : entries) {
+      if (!UUIDValidation.isValidUUID(entry.loanId())) {
+        return Future.failedFuture(new IllegalArgumentException(
+          "Invalid loan id: " + entry.loanId()));
+      }
+      if (entry.dueAt() != null && !ISO_INSTANT.matcher(entry.dueAt()).matches()) {
+        return Future.failedFuture(new IllegalArgumentException(
+          "dueAt must be an ISO-8601 instant or null: " + entry.dueAt()));
+      }
+    }
+    if (entries.isEmpty()) {
+      return Future.succeededFuture(0);
+    }
+
+    final String values = entries.stream()
+      .map(e -> format("('%s'::uuid, %s)", e.loanId(),
+        e.dueAt() == null ? "NULL::timestamptz" : format("'%s'::timestamptz", e.dueAt())))
+      .collect(Collectors.joining(", "));
+
+    final String sql = format(
+      "INSERT INTO %1$s.%2$s (loan_id, due_at)"
+        + " SELECT v.loan_id, v.due_at FROM (VALUES %3$s) AS v(loan_id, due_at)"
+        + " JOIN %1$s.loan l ON l.id = v.loan_id"
+        // ->> so an explicit JSON null userId is treated as absent.
+        + " WHERE l.jsonb->'status'->>'name' = 'Closed' AND l.jsonb->>'userId' IS NOT NULL"
+        + " ON CONFLICT (loan_id) DO UPDATE SET due_at = EXCLUDED.due_at",
+      schemaName, TABLE, values);
+
+    return postgresClient.execute(sql).map(RowSet::rowCount);
+  }
+
+  /** Return specific loans to the unevaluated state. */
+  public Future<Integer> clearByLoanIds(List<String> loanIds) {
+    for (String loanId : loanIds) {
+      if (!UUIDValidation.isValidUUID(loanId)) {
+        return Future.failedFuture(new IllegalArgumentException("Invalid loan id: " + loanId));
+      }
+    }
+    if (loanIds.isEmpty()) {
+      return Future.succeededFuture(0);
+    }
+    final String ids = loanIds.stream()
+      .map(id -> "'" + id + "'::uuid")
+      .collect(Collectors.joining(", ", "(", ")"));
+
+    return postgresClient.execute(format(
+      "DELETE FROM %s.%s WHERE loan_id IN %s", schemaName, TABLE, ids))
+      .map(RowSet::rowCount);
+  }
+
+  /** Return every loan to the unevaluated state. TRUNCATE, so no dead tuples. */
+  public Future<Integer> clearAll() {
+    return postgresClient.execute(format("SELECT count(*) FROM %s.%s", schemaName, TABLE))
+      .map(rs -> rs.iterator().next().getInteger(0))
+      .compose(count -> postgresClient.execute(format("TRUNCATE %s.%s", schemaName, TABLE))
+        .map(x -> count));
+  }
+
+  /** Closed loans with a userId whose {@code due_at} has arrived, oldest first. */
+  public Future<JsonArray> findDue(int limit) {
+    return queryLoans(format(
+      "SELECT l.jsonb FROM %1$s.loan l"
+        + " JOIN %1$s.%2$s d ON d.loan_id = l.id"
+        + " WHERE d.due_at IS NOT NULL AND d.due_at < now()"
+        + " AND l.jsonb->'status'->>'name' = 'Closed' AND l.jsonb->>'userId' IS NOT NULL"
+        + " ORDER BY d.due_at, l.id LIMIT %3$d",
+      schemaName, TABLE, limit));
+  }
+
+  /** Closed loans with a userId that have no row here yet. */
+  public Future<JsonArray> findUnevaluated(int limit) {
+    return queryLoans(format(
+      "SELECT l.jsonb FROM %1$s.loan l"
+        + " LEFT JOIN %1$s.%2$s d ON d.loan_id = l.id"
+        + " WHERE d.loan_id IS NULL"
+        + " AND l.jsonb->'status'->>'name' = 'Closed' AND l.jsonb->>'userId' IS NOT NULL"
+        + " ORDER BY l.id LIMIT %3$d",
+      schemaName, TABLE, limit));
+  }
+
+  private Future<JsonArray> queryLoans(String sql) {
+    return postgresClient.execute(sql).map(rows -> {
+      final JsonArray loans = new JsonArray();
+      for (Row row : rows) {
+        loans.add(row.getJsonObject("jsonb"));
+      }
+      return loans;
+    });
+  }
+
+  /** One loan to stamp; a null {@code dueAt} records retain. */
+  public record StampEntry(String loanId, String dueAt) { }
+}

--- a/src/main/resources/templates/db_scripts/create_loan_anonymization_due.sql
+++ b/src/main/resources/templates/db_scripts/create_loan_anonymization_due.sql
@@ -1,0 +1,24 @@
+-- Derived anonymization due-date, kept off the audited loan record.
+-- Row states: absent = not yet evaluated; due_at set = eligible at due_at;
+-- due_at NULL = retain under the current policy.
+-- Must always run (no fromModuleVersion) so RMB creates it and keeps it.
+DO $do$
+BEGIN
+  -- No FK to loan: it would block TRUNCATE of the loan table. The stamp and
+  -- finder queries JOIN loan, so a row for a missing loan is never returned.
+  CREATE TABLE IF NOT EXISTS ${myuniversity}_${mymodule}.loan_anonymization_due (
+    loan_id uuid PRIMARY KEY,
+    due_at  timestamptz
+  );
+
+  -- Drain index (partial: NULL rows excluded).
+  CREATE INDEX IF NOT EXISTS loan_anonymization_due_due_at_idx
+    ON ${myuniversity}_${mymodule}.loan_anonymization_due (due_at)
+    WHERE due_at IS NOT NULL;
+
+  -- Sweep index: closed loans with a userId, for the anti-join.
+  PERFORM rmb_internal_index(
+    'loan', 'loan_closed_with_user_idx', 'ADD',
+    'CREATE INDEX IF NOT EXISTS loan_closed_with_user_idx ON ${myuniversity}_${mymodule}.loan '
+    || $rmb$(id) WHERE (jsonb->'status'->>'name' = 'Closed' AND jsonb->>'userId' IS NOT NULL)$rmb$);
+END $do$;

--- a/src/main/resources/templates/db_scripts/schema.json
+++ b/src/main/resources/templates/db_scripts/schema.json
@@ -622,6 +622,10 @@
     },
     {
       "run": "after",
+      "snippetPath": "create_loan_anonymization_due.sql"
+    },
+    {
+      "run": "after",
       "snippetPath": "add_staff_slips_hold_transit.sql",
       "fromModuleVersion": "12.3.0"
     },

--- a/src/test/java/org/folio/rest/api/AnonymizationDueDateApiTest.java
+++ b/src/test/java/org/folio/rest/api/AnonymizationDueDateApiTest.java
@@ -1,0 +1,214 @@
+package org.folio.rest.api;
+
+import static org.folio.rest.api.StorageTestSuite.TENANT_ID;
+import static org.folio.rest.support.ResponseHandler.json;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.core.Is.is;
+
+import java.net.MalformedURLException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeoutException;
+
+import org.folio.rest.support.ApiTests;
+import org.folio.rest.support.JsonResponse;
+import org.folio.rest.support.builders.LoanRequestBuilder;
+import org.folio.rest.support.http.AssertingRecordClient;
+import org.folio.rest.support.http.InterfaceUrls;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+
+/**
+ * Exercises the {@code loan_anonymization_due} SQL against Postgres: the stamp
+ * upsert, the clears, the due/unevaluated finders, and the strip removing both
+ * userId and the due-date row.
+ *
+ * <p>The tenant carries FOLIO sample loans, so assertions track the specific
+ * test loan ({@code hasItem}) rather than the whole finder listing.</p>
+ */
+class AnonymizationDueDateApiTest extends ApiTests {
+  private static final String PAST = "2020-01-01T00:00:00.000Z";
+  private static final String FUTURE = "2099-01-01T00:00:00.000Z";
+
+  private final AssertingRecordClient loansClient = new AssertingRecordClient(
+    client, TENANT_ID, InterfaceUrls::loanStorageUrl, "loans");
+
+  private final String loanId = UUID.randomUUID().toString();
+
+  @BeforeEach
+  void beforeEach() throws MalformedURLException, InterruptedException,
+    ExecutionException, TimeoutException {
+
+    StorageTestSuite.deleteAll(InterfaceUrls.loanStorageUrl());
+    closedLoanWithUser(loanId);
+  }
+
+  @Test
+  void unevaluatedListsClosedLoanWithNoRowYet() throws Exception {
+    assertThat(unevaluatedIds(), hasItem(loanId));
+    assertThat(dueIds(), not(hasItem(loanId)));
+  }
+
+  @Test
+  void stampPastDueAppearsInDueAndLeavesUnevaluated() throws Exception {
+    assertThat(stamp(entry(loanId, PAST)).getJson().getInteger("updated"), is(1));
+
+    assertThat(dueIds(), hasItem(loanId));
+    assertThat(unevaluatedIds(), not(hasItem(loanId)));
+  }
+
+  @Test
+  void stampFutureIsEvaluatedButNotYetDue() throws Exception {
+    stamp(entry(loanId, FUTURE));
+
+    assertThat(dueIds(), not(hasItem(loanId)));
+    assertThat(unevaluatedIds(), not(hasItem(loanId)));
+  }
+
+  @Test
+  void stampNeverIsEvaluatedAndNeverDue() throws Exception {
+    assertThat(stamp(entry(loanId, null)).getJson().getInteger("updated"), is(1));
+
+    assertThat(dueIds(), not(hasItem(loanId)));
+    assertThat(unevaluatedIds(), not(hasItem(loanId)));
+  }
+
+  @Test
+  void stampSkipsOpenLoans() throws Exception {
+    final String openId = UUID.randomUUID().toString();
+    loansClient.create(new LoanRequestBuilder().withId(UUID.fromString(openId))
+      .withItemId(UUID.randomUUID()).withUserId(UUID.randomUUID()).open().create());
+
+    assertThat(stamp(entry(openId, PAST)).getJson().getInteger("updated"), is(0));
+    assertThat(dueIds(), not(hasItem(openId)));
+  }
+
+  @Test
+  void stampRejectsMalformedDueDate() throws Exception {
+    assertThat(stamp(entry(loanId, "not-a-date")).getStatusCode(), is(422));
+  }
+
+  /**
+   * mod-circulation formats due_at with {@code yyyy-MM-dd'T'HH:mm:ss.SSS'Z'}
+   * (AnonymizationDueDateStorageRepository#formatDueAt); this endpoint must
+   * accept exactly that.
+   */
+  @Test
+  void stampAcceptsTheCanonicalWireFormatFromModCirculation() throws Exception {
+    for (String dueAt : List.of("2020-01-01T00:00:00.000Z", "2099-12-31T23:59:59.999Z",
+      "2021-05-15T08:15:43.123Z")) {
+
+      assertThat("storage must accept mod-circulation's format: " + dueAt,
+        stamp(entry(loanId, dueAt)).getStatusCode(), is(200));
+    }
+  }
+
+  @Test
+  void clearByLoanIdsReturnsToUnevaluated() throws Exception {
+    stamp(entry(loanId, PAST));
+    assertThat(unevaluatedIds(), not(hasItem(loanId)));
+
+    final JsonResponse cleared = clear(new JsonObject()
+      .put("loanIds", new JsonArray(List.of(loanId))));
+    assertThat(cleared.getStatusCode(), is(200));
+    assertThat(cleared.getJson().getInteger("updated"), is(1));
+    assertThat(unevaluatedIds(), hasItem(loanId));
+  }
+
+  @Test
+  void clearAllReturnsEveryLoanToUnevaluated() throws Exception {
+    final String otherId = UUID.randomUUID().toString();
+    closedLoanWithUser(otherId);
+    stamp(entry(loanId, PAST), entry(otherId, FUTURE));
+    assertThat(unevaluatedIds(), not(hasItem(loanId)));
+    assertThat(unevaluatedIds(), not(hasItem(otherId)));
+
+    assertThat(clear(new JsonObject().put("all", true)).getStatusCode(), is(200));
+    assertThat(unevaluatedIds(), hasItem(loanId));
+    assertThat(unevaluatedIds(), hasItem(otherId));
+  }
+
+  @Test
+  void clearRequiresExactlyOneSelector() throws Exception {
+    assertThat(clear(new JsonObject()).getStatusCode(), is(422));
+    assertThat(clear(new JsonObject()
+      .put("loanIds", new JsonArray(List.of(loanId)))
+      .put("all", true)).getStatusCode(), is(422));
+  }
+
+  @Test
+  void stripRemovesUserIdAndSideRow() throws Exception {
+    stamp(entry(loanId, PAST));
+    assertThat(dueIds(), hasItem(loanId));
+
+    final CompletableFuture<JsonResponse> completed = new CompletableFuture<>();
+    client.post(InterfaceUrls.anonymizeLoansURL(),
+      new JsonObject().put("loanIds", new JsonArray(List.of(loanId))), TENANT_ID, json(completed));
+    assertThat(get(completed).getStatusCode(), is(200));
+
+    assertThat(loansClient.getById(loanId).getJson().getString("userId"), is(nullValue()));
+    // No userId -> neither finder can return it, and the row is gone.
+    assertThat(dueIds(), not(hasItem(loanId)));
+    assertThat(unevaluatedIds(), not(hasItem(loanId)));
+  }
+
+  // ---- helpers ----
+
+  private void closedLoanWithUser(String id) throws MalformedURLException,
+    InterruptedException, ExecutionException, TimeoutException {
+
+    loansClient.create(new LoanRequestBuilder()
+      .withId(UUID.fromString(id))
+      .withItemId(UUID.randomUUID())
+      .withUserId(UUID.randomUUID())
+      .closed()
+      .create());
+  }
+
+  private static JsonObject entry(String loanId, String dueAt) {
+    final JsonObject e = new JsonObject().put("loanId", loanId);
+    if (dueAt != null) {
+      e.put("dueAt", dueAt);
+    }
+    return e;
+  }
+
+  private JsonResponse stamp(JsonObject... entries) throws MalformedURLException {
+    final JsonObject body = new JsonObject().put("entries", new JsonArray(List.of(entries)));
+    final CompletableFuture<JsonResponse> completed = new CompletableFuture<>();
+    client.post(InterfaceUrls.anonymizationDueDateStampURL(), body, TENANT_ID, json(completed));
+    return get(completed);
+  }
+
+  private JsonResponse clear(JsonObject body) throws MalformedURLException {
+    final CompletableFuture<JsonResponse> completed = new CompletableFuture<>();
+    client.post(InterfaceUrls.anonymizationDueDateClearURL(), body, TENANT_ID, json(completed));
+    return get(completed);
+  }
+
+  private List<String> dueIds() throws MalformedURLException {
+    return loanIds(InterfaceUrls.anonymizationDueDateDueURL("?limit=1000"));
+  }
+
+  private List<String> unevaluatedIds() throws MalformedURLException {
+    return loanIds(InterfaceUrls.anonymizationDueDateUnevaluatedURL("?limit=1000"));
+  }
+
+  private List<String> loanIds(java.net.URL url) {
+    final CompletableFuture<JsonResponse> completed = new CompletableFuture<>();
+    client.get(url, TENANT_ID, json(completed));
+    final JsonArray loans = get(completed).getJson().getJsonArray("loans", new JsonArray());
+    final List<String> ids = new ArrayList<>();
+    loans.forEach(o -> ids.add(((JsonObject) o).getString("id")));
+    return ids;
+  }
+}

--- a/src/test/java/org/folio/rest/api/StorageTestSuite.java
+++ b/src/test/java/org/folio/rest/api/StorageTestSuite.java
@@ -55,6 +55,7 @@ import lombok.SneakyThrows;
 @Suite
 @SelectClasses({
   AnonymizeLoansApiTest.class,
+  AnonymizationDueDateApiTest.class,
   LoansApiTest.class,
   LoansAnonymizationApiTest.class,
   CirculationRulesApiTest.class,

--- a/src/test/java/org/folio/rest/support/http/InterfaceUrls.java
+++ b/src/test/java/org/folio/rest/support/http/InterfaceUrls.java
@@ -36,6 +36,22 @@ public class InterfaceUrls {
     return storageUrl("/anonymize-storage-loans");
   }
 
+  public static URL anonymizationDueDateStampURL() throws MalformedURLException {
+    return storageUrl("/anonymization-due-date-storage/stamp");
+  }
+
+  public static URL anonymizationDueDateClearURL() throws MalformedURLException {
+    return storageUrl("/anonymization-due-date-storage/clear");
+  }
+
+  public static URL anonymizationDueDateDueURL(String query) throws MalformedURLException {
+    return storageUrl("/anonymization-due-date-storage/due" + query);
+  }
+
+  public static URL anonymizationDueDateUnevaluatedURL(String query) throws MalformedURLException {
+    return storageUrl("/anonymization-due-date-storage/unevaluated" + query);
+  }
+
   public static URL checkInsStorageUrl(String subPath) throws MalformedURLException {
     return storageUrl("/check-in-storage/check-ins" + subPath);
   }


### PR DESCRIPTION
## Purpose
The current approach to loan anonymization already can lead to wasted throughput and could sometimes lead to starvation. This would certainly be the case when user specific anonymization would be added. 

This is a prototypical implementation that resulted from a spike for [User specific loan anonymization](https://folio-org.atlassian.net/wiki/spaces/FOLIJET/pages/2129002498/User-specific+loan+anonymization#Open-Questions). It is intended to stay a draft.

## Approach
Add the loan_anonymization_due table (loan_id, due_at) with drain and sweep indexes, and the anonymization-due-date-storage interface: stamp and clear maintainers plus due/unevaluated join-finders. The anonymize-storage-loans strip also deletes the loan's due-date row. Includes API tests against Postgres.